### PR TITLE
fix: Make runtime resilient for dev/CI environments

### DIFF
--- a/dev/fake-camera/mediamtx.yml
+++ b/dev/fake-camera/mediamtx.yml
@@ -1,6 +1,9 @@
 rtspAddress: :8099
 rtpAddress: :8100
 rtcpAddress: :8101
+readTimeout: 20s
+writeTimeout: 20s
+writeQueueSize: 2048
 authMethod: internal
 authInternalUsers:
   - user: admin
@@ -15,3 +18,4 @@ authInternalUsers:
 
 paths:
   live:
+    maxReaders: 10

--- a/src/homesec/models/enums.py
+++ b/src/homesec/models/enums.py
@@ -74,6 +74,13 @@ class VLMRunMode(StrEnum):
     NEVER = "never"
 
 
+class VLMSkipReason(StrEnum):
+    """Reason why VLM analysis was skipped for a clip."""
+
+    RUN_MODE_NEVER = "run_mode_never"
+    NO_TRIGGER_CLASSES = "no_trigger_classes"
+
+
 class RiskLevel(IntEnum):
     """VLM risk assessment levels.
 

--- a/src/homesec/models/events.py
+++ b/src/homesec/models/events.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
-from homesec.models.enums import EventType, RiskLevelField
+from homesec.models.enums import EventType, RiskLevelField, VLMSkipReason
 from homesec.models.filter import FilterResult
 
 
@@ -145,7 +145,7 @@ class VLMSkippedEvent(ClipEvent):
     """VLM analysis skipped by runtime policy."""
 
     event_type: Literal[EventType.VLM_SKIPPED] = EventType.VLM_SKIPPED
-    reason: str
+    reason: VLMSkipReason
 
 
 class AlertDecisionMadeEvent(ClipEvent):

--- a/src/homesec/models/events.py
+++ b/src/homesec/models/events.py
@@ -142,7 +142,7 @@ class VLMFailedEvent(ClipEvent):
 
 
 class VLMSkippedEvent(ClipEvent):
-    """VLM analysis skipped (no trigger classes detected)."""
+    """VLM analysis skipped by runtime policy."""
 
     event_type: Literal[EventType.VLM_SKIPPED] = EventType.VLM_SKIPPED
     reason: str

--- a/src/homesec/pipeline/core.py
+++ b/src/homesec/pipeline/core.py
@@ -15,7 +15,7 @@ from homesec.errors import FilterError, NotifyError, UploadError, VLMError
 from homesec.models.alert import Alert, AlertDecision
 from homesec.models.clip import Clip
 from homesec.models.config import Config
-from homesec.models.enums import VLMRunMode
+from homesec.models.enums import VLMRunMode, VLMSkipReason
 from homesec.models.filter import FilterResult
 from homesec.models.vlm import AnalysisResult
 from homesec.notifiers.multiplex import NotifierEntry
@@ -643,11 +643,11 @@ class ClipPipeline:
                 return type(exc.cause).__name__
         return type(exc).__name__
 
-    def _vlm_skip_reason(self, filter_result: FilterResult) -> str | None:
+    def _vlm_skip_reason(self, filter_result: FilterResult) -> VLMSkipReason | None:
         """Return skip reason when VLM should not run, otherwise None."""
         run_mode = self._config.vlm.run_mode
         if run_mode == VLMRunMode.NEVER:
-            return "run_mode_never"
+            return VLMSkipReason.RUN_MODE_NEVER
         if run_mode == VLMRunMode.ALWAYS:
             return None
 
@@ -655,7 +655,7 @@ class ClipPipeline:
         trigger = set(self._config.vlm.trigger_classes)
         if detected & trigger:
             return None
-        return "no_trigger_classes"
+        return VLMSkipReason.NO_TRIGGER_CLASSES
 
     async def _apply_upload_result(
         self,

--- a/src/homesec/pipeline/core.py
+++ b/src/homesec/pipeline/core.py
@@ -15,6 +15,7 @@ from homesec.errors import FilterError, NotifyError, UploadError, VLMError
 from homesec.models.alert import Alert, AlertDecision
 from homesec.models.clip import Clip
 from homesec.models.config import Config
+from homesec.models.enums import VLMRunMode
 from homesec.models.filter import FilterResult
 from homesec.models.vlm import AnalysisResult
 from homesec.notifiers.multiplex import NotifierEntry
@@ -262,7 +263,8 @@ class ClipPipeline:
             # Stage 3: VLM (conditional)
             analysis_result: AnalysisResult | None = None
             vlm_failed = False
-            if self._should_run_vlm(filter_res):
+            vlm_skip_reason = self._vlm_skip_reason(filter_res)
+            if vlm_skip_reason is None:
                 vlm_result = await self._vlm_stage(clip, filter_res)
                 match vlm_result:
                     case VLMError() as vlm_err:
@@ -284,9 +286,9 @@ class ClipPipeline:
             else:
                 await self._repository.record_vlm_skipped(
                     clip.clip_id,
-                    reason="no_trigger_classes",
+                    reason=vlm_skip_reason,
                 )
-                logger.info("VLM skipped for %s: no trigger classes", clip.clip_id)
+                logger.info("VLM skipped for %s: %s", clip.clip_id, vlm_skip_reason)
 
             # Await upload after filter/VLM to maximize overlap
             upload_result = await upload_task
@@ -641,17 +643,19 @@ class ClipPipeline:
                 return type(exc.cause).__name__
         return type(exc).__name__
 
-    def _should_run_vlm(self, filter_result: FilterResult) -> bool:
-        """Check if VLM should run based on detected classes and config."""
+    def _vlm_skip_reason(self, filter_result: FilterResult) -> str | None:
+        """Return skip reason when VLM should not run, otherwise None."""
         run_mode = self._config.vlm.run_mode
-        if run_mode == "never":
-            return False
-        if run_mode == "always":
-            return True
+        if run_mode == VLMRunMode.NEVER:
+            return "run_mode_never"
+        if run_mode == VLMRunMode.ALWAYS:
+            return None
 
         detected = set(filter_result.detected_classes)
         trigger = set(self._config.vlm.trigger_classes)
-        return bool(detected & trigger)
+        if detected & trigger:
+            return None
+        return "no_trigger_classes"
 
     async def _apply_upload_result(
         self,

--- a/src/homesec/plugins/analyzers/__init__.py
+++ b/src/homesec/plugins/analyzers/__init__.py
@@ -3,13 +3,35 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import cast
 
 from homesec.interfaces import VLMAnalyzer
-from homesec.models.vlm import VLMConfig
+from homesec.models.enums import RiskLevel, VLMRunMode
+from homesec.models.filter import FilterResult
+from homesec.models.vlm import AnalysisResult, VLMConfig
 from homesec.plugins.registry import PluginType, load_plugin
 
 logger = logging.getLogger(__name__)
+
+
+class _NoopVLM(VLMAnalyzer):
+    """Placeholder VLM that returns a safe default when run_mode is 'never'."""
+
+    async def analyze(
+        self, video_path: Path, filter_result: FilterResult, config: VLMConfig
+    ) -> AnalysisResult:
+        return AnalysisResult(
+            risk_level=RiskLevel.LOW,
+            activity_type="skipped",
+            summary="VLM analysis disabled (run_mode=never)",
+        )
+
+    async def ping(self) -> bool:
+        return True
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        pass
 
 
 def load_analyzer(config: VLMConfig) -> VLMAnalyzer:
@@ -25,6 +47,10 @@ def load_analyzer(config: VLMConfig) -> VLMAnalyzer:
         ValueError: If backend not found in registry
         ValidationError: If config validation fails
     """
+    if config.run_mode == VLMRunMode.NEVER:
+        logger.info("VLM run_mode is 'never'; using no-op analyzer")
+        return _NoopVLM()
+
     return cast(
         VLMAnalyzer,
         load_plugin(

--- a/src/homesec/plugins/analyzers/__init__.py
+++ b/src/homesec/plugins/analyzers/__init__.py
@@ -2,36 +2,11 @@
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
 from typing import cast
 
 from homesec.interfaces import VLMAnalyzer
-from homesec.models.enums import RiskLevel, VLMRunMode
-from homesec.models.filter import FilterResult
-from homesec.models.vlm import AnalysisResult, VLMConfig
+from homesec.models.vlm import VLMConfig
 from homesec.plugins.registry import PluginType, load_plugin
-
-logger = logging.getLogger(__name__)
-
-
-class _NoopVLM(VLMAnalyzer):
-    """Placeholder VLM that returns a safe default when run_mode is 'never'."""
-
-    async def analyze(
-        self, video_path: Path, filter_result: FilterResult, config: VLMConfig
-    ) -> AnalysisResult:
-        return AnalysisResult(
-            risk_level=RiskLevel.LOW,
-            activity_type="skipped",
-            summary="VLM analysis disabled (run_mode=never)",
-        )
-
-    async def ping(self) -> bool:
-        return True
-
-    async def shutdown(self, timeout: float | None = None) -> None:
-        pass
 
 
 def load_analyzer(config: VLMConfig) -> VLMAnalyzer:
@@ -47,10 +22,6 @@ def load_analyzer(config: VLMConfig) -> VLMAnalyzer:
         ValueError: If backend not found in registry
         ValidationError: If config validation fails
     """
-    if config.run_mode == VLMRunMode.NEVER:
-        logger.info("VLM run_mode is 'never'; using no-op analyzer")
-        return _NoopVLM()
-
     return cast(
         VLMAnalyzer,
         load_plugin(

--- a/src/homesec/repository/clip_repository.py
+++ b/src/homesec/repository/clip_repository.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from homesec.models.clip import Clip, ClipListCursor, ClipListPage, ClipStateData
 from homesec.models.config import RetryConfig
-from homesec.models.enums import ClipStatus, RiskLevelField
+from homesec.models.enums import ClipStatus, RiskLevelField, VLMSkipReason
 from homesec.models.events import (
     AlertDecisionMadeEvent,
     ClipDeletedEvent,
@@ -285,7 +285,7 @@ class ClipRepository:
             )
         )
 
-    async def record_vlm_skipped(self, clip_id: str, reason: str) -> None:
+    async def record_vlm_skipped(self, clip_id: str, reason: VLMSkipReason) -> None:
         """Record VLM skipped event."""
         await self._safe_append(
             VLMSkippedEvent(

--- a/src/homesec/runtime/assembly.py
+++ b/src/homesec/runtime/assembly.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
+from homesec.interfaces import VLMAnalyzer
+from homesec.models.enums import RiskLevel, VLMRunMode
+from homesec.models.filter import FilterResult
+from homesec.models.vlm import AnalysisResult, VLMConfig
 from homesec.notifiers.multiplex import NotifierEntry
 from homesec.pipeline import ClipPipeline
 from homesec.plugins.analyzers import load_analyzer
@@ -22,7 +27,6 @@ if TYPE_CHECKING:
         Notifier,
         ObjectFilter,
         StorageBackend,
-        VLMAnalyzer,
     )
     from homesec.models.config import Config
 
@@ -32,6 +36,28 @@ logger = logging.getLogger(__name__)
 class _AsyncShutdown(Protocol):
     async def shutdown(self, timeout: float = 30.0) -> None:
         """Release resources."""
+
+
+class _DisabledVLMAnalyzer(VLMAnalyzer):
+    """Runtime-only analyzer used when VLM run_mode is disabled."""
+
+    async def analyze(
+        self, video_path: Path, filter_result: FilterResult, config: VLMConfig
+    ) -> AnalysisResult:
+        _ = video_path
+        _ = filter_result
+        _ = config
+        return AnalysisResult(
+            risk_level=RiskLevel.LOW,
+            activity_type="skipped",
+            summary="VLM analysis disabled (run_mode=never)",
+        )
+
+    async def ping(self) -> bool:
+        return True
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        _ = timeout
 
 
 class RuntimeAssembler:
@@ -76,7 +102,11 @@ class RuntimeAssembler:
             await self._notifier_health_logger(notifier_entries)
 
             filter_plugin = load_filter(config.filter)
-            vlm_plugin = load_analyzer(config.vlm)
+            if config.vlm.run_mode == VLMRunMode.NEVER:
+                logger.info("VLM run_mode=never; runtime will use disabled analyzer")
+                vlm_plugin = _DisabledVLMAnalyzer()
+            else:
+                vlm_plugin = load_analyzer(config.vlm)
             alert_policy = self._alert_policy_factory(config)
 
             sources, sources_by_camera = self._source_factory(config)

--- a/src/homesec/runtime/assembly.py
+++ b/src/homesec/runtime/assembly.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
-from homesec.interfaces import VLMAnalyzer
-from homesec.models.enums import RiskLevel, VLMRunMode
-from homesec.models.filter import FilterResult
-from homesec.models.vlm import AnalysisResult, VLMConfig
+from homesec.models.enums import VLMRunMode
 from homesec.notifiers.multiplex import NotifierEntry
 from homesec.pipeline import ClipPipeline
 from homesec.plugins.analyzers import load_analyzer
 from homesec.plugins.filters import load_filter
 from homesec.repository import ClipRepository
 from homesec.retention import build_local_retention_pruner
+from homesec.runtime.disabled_vlm import DisabledVLMAnalyzer
 from homesec.runtime.models import RuntimeBundle, config_signature
 
 if TYPE_CHECKING:
@@ -27,6 +24,7 @@ if TYPE_CHECKING:
         Notifier,
         ObjectFilter,
         StorageBackend,
+        VLMAnalyzer,
     )
     from homesec.models.config import Config
 
@@ -36,28 +34,6 @@ logger = logging.getLogger(__name__)
 class _AsyncShutdown(Protocol):
     async def shutdown(self, timeout: float = 30.0) -> None:
         """Release resources."""
-
-
-class _DisabledVLMAnalyzer(VLMAnalyzer):
-    """Runtime-only analyzer used when VLM run_mode is disabled."""
-
-    async def analyze(
-        self, video_path: Path, filter_result: FilterResult, config: VLMConfig
-    ) -> AnalysisResult:
-        _ = video_path
-        _ = filter_result
-        _ = config
-        return AnalysisResult(
-            risk_level=RiskLevel.LOW,
-            activity_type="skipped",
-            summary="VLM analysis disabled (run_mode=never)",
-        )
-
-    async def ping(self) -> bool:
-        return True
-
-    async def shutdown(self, timeout: float | None = None) -> None:
-        _ = timeout
 
 
 class RuntimeAssembler:
@@ -104,7 +80,7 @@ class RuntimeAssembler:
             filter_plugin = load_filter(config.filter)
             if config.vlm.run_mode == VLMRunMode.NEVER:
                 logger.info("VLM run_mode=never; runtime will use disabled analyzer")
-                vlm_plugin = _DisabledVLMAnalyzer()
+                vlm_plugin = DisabledVLMAnalyzer()
             else:
                 vlm_plugin = load_analyzer(config.vlm)
             alert_policy = self._alert_policy_factory(config)

--- a/src/homesec/runtime/disabled_vlm.py
+++ b/src/homesec/runtime/disabled_vlm.py
@@ -1,0 +1,32 @@
+"""Disabled VLM analyzer implementation for run_mode=never."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from homesec.interfaces import VLMAnalyzer
+from homesec.models.enums import RiskLevel
+from homesec.models.filter import FilterResult
+from homesec.models.vlm import AnalysisResult, VLMConfig
+
+
+class DisabledVLMAnalyzer(VLMAnalyzer):
+    """Runtime-only analyzer used when VLM is disabled."""
+
+    async def analyze(
+        self, video_path: Path, filter_result: FilterResult, config: VLMConfig
+    ) -> AnalysisResult:
+        _ = video_path
+        _ = filter_result
+        _ = config
+        return AnalysisResult(
+            risk_level=RiskLevel.LOW,
+            activity_type="skipped",
+            summary="VLM analysis disabled (run_mode=never)",
+        )
+
+    async def ping(self) -> bool:
+        return True
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        _ = timeout

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -36,7 +36,7 @@ from homesec.sources.rtsp.preflight import (
     RTSPStartupPreflight,
 )
 from homesec.sources.rtsp.recorder import FfmpegRecorder, Recorder
-from homesec.sources.rtsp.recording_profile import MotionProfile, RecordingProfile
+from homesec.sources.rtsp.recording_profile import MotionProfile, build_default_recording_profile
 from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
@@ -434,14 +434,7 @@ class RTSPSource(ThreadedClipSource):
 
     def _build_fallback_preflight_outcome(self, camera_key: str) -> CameraPreflightOutcome:
         motion_profile = MotionProfile(input_url=self.rtsp_url, ffmpeg_input_args=[])
-        recording_profile = RecordingProfile(
-            input_url=self.rtsp_url,
-            ffmpeg_input_args=[],
-            container="mp4",
-            video_mode="copy",
-            audio_mode="copy",
-            ffmpeg_output_args=["-movflags", "+frag_keyframe+empty_moov+faststart"],
-        )
+        recording_profile = build_default_recording_profile(self.rtsp_url)
         diagnostics = CameraPreflightDiagnostics(
             attempted_urls=[self.rtsp_url],
             probes=[],

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -30,12 +30,13 @@ from homesec.sources.rtsp.frame_pipeline import FfmpegFramePipeline, FramePipeli
 from homesec.sources.rtsp.hardware import HardwareAccelConfig, HardwareAccelDetector
 from homesec.sources.rtsp.motion import MotionDetector
 from homesec.sources.rtsp.preflight import (
+    CameraPreflightDiagnostics,
     CameraPreflightOutcome,
     PreflightError,
     RTSPStartupPreflight,
 )
 from homesec.sources.rtsp.recorder import FfmpegRecorder, Recorder
-from homesec.sources.rtsp.recording_profile import MotionProfile
+from homesec.sources.rtsp.recording_profile import MotionProfile, RecordingProfile
 from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
@@ -407,21 +408,55 @@ class RTSPSource(ThreadedClipSource):
             case CameraPreflightOutcome() as outcome:
                 self._apply_preflight_outcome(outcome)
             case PreflightError() as err:
-                logger.error(
-                    "RTSP startup preflight failed: camera=%s key=%s stage=%s reason=%s",
-                    self.camera_name,
-                    err.camera_key,
-                    err.stage,
-                    err.message,
-                )
-                raise RuntimeError(
-                    f"RTSP preflight failed for {self.camera_name} at {err.stage}: {err.message}"
-                ) from err
+                if err.stage == "session_limit":
+                    logger.warning(
+                        "RTSP session-limit preflight failed for %s; falling back to single-stream defaults",
+                        self.camera_name,
+                    )
+                    fallback = self._build_fallback_preflight_outcome(err.camera_key)
+                    self._apply_preflight_outcome(fallback)
+                else:
+                    logger.error(
+                        "RTSP startup preflight failed: camera=%s key=%s stage=%s reason=%s",
+                        self.camera_name,
+                        err.camera_key,
+                        err.stage,
+                        err.message,
+                    )
+                    raise RuntimeError(
+                        f"RTSP preflight failed for {self.camera_name} at {err.stage}: {err.message}"
+                    ) from err
             case _:
                 raise RuntimeError(
                     "RTSP startup preflight returned unexpected result type: "
                     f"{type(result).__name__}"
                 )
+
+    def _build_fallback_preflight_outcome(self, camera_key: str) -> CameraPreflightOutcome:
+        motion_profile = MotionProfile(input_url=self.rtsp_url, ffmpeg_input_args=[])
+        recording_profile = RecordingProfile(
+            input_url=self.rtsp_url,
+            ffmpeg_input_args=[],
+            container="mp4",
+            video_mode="copy",
+            audio_mode="copy",
+            ffmpeg_output_args=["-movflags", "+frag_keyframe+empty_moov+faststart"],
+        )
+        diagnostics = CameraPreflightDiagnostics(
+            attempted_urls=[self.rtsp_url],
+            probes=[],
+            selected_motion_url=self.rtsp_url,
+            selected_recording_url=self.rtsp_url,
+            selected_recording_profile=recording_profile.profile_id(),
+            session_mode="single_stream",
+            notes=["Session-limit preflight failed; using single-stream fallback defaults"],
+        )
+        return CameraPreflightOutcome(
+            camera_key=camera_key,
+            motion_profile=motion_profile,
+            recording_profile=recording_profile,
+            diagnostics=diagnostics,
+        )
 
     def _apply_preflight_outcome(self, outcome: CameraPreflightOutcome) -> None:
         self._preflight_outcome = outcome

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -15,7 +15,7 @@ from homesec.sources.rtsp.core import RTSPRunState, RTSPSource, RTSPSourceConfig
 from homesec.sources.rtsp.frame_pipeline import FfmpegFramePipeline
 from homesec.sources.rtsp.hardware import HardwareAccelConfig
 from homesec.sources.rtsp.recorder import FfmpegRecorder
-from homesec.sources.rtsp.recording_profile import MotionProfile
+from homesec.sources.rtsp.recording_profile import MotionProfile, build_default_recording_profile
 
 
 class FakeClock:
@@ -294,6 +294,21 @@ def test_detect_stream_defaults_to_main(tmp_path: Path) -> None:
     assert source.detect_rtsp_url == source.rtsp_url
     assert source._detect_rtsp_url_source == "same_as_rtsp_url"
     assert not source._detect_stream_available
+
+
+def test_session_limit_fallback_uses_default_recording_profile(tmp_path: Path) -> None:
+    """Session-limit fallback should reuse shared default recording profile builder."""
+    # Given: an RTSP source with default startup configuration
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(config, camera_name="cam")
+
+    # When: constructing the startup session-limit fallback outcome
+    outcome = source._build_fallback_preflight_outcome("cam-key")
+
+    # Then: fallback uses the canonical default recording profile
+    expected_profile = build_default_recording_profile(source.rtsp_url)
+    assert outcome.recording_profile == expected_profile
+    assert outcome.diagnostics.selected_recording_profile == expected_profile.profile_id()
 
 
 def test_reconnect_retries_until_success(tmp_path: Path) -> None:

--- a/tests/homesec/test_pipeline.py
+++ b/tests/homesec/test_pipeline.py
@@ -283,6 +283,53 @@ class TestClipPipelineHappyPath:
         assert state is not None
         assert state.analysis_result is not None
 
+    @pytest.mark.asyncio
+    async def test_run_mode_never_skips_vlm_with_explicit_reason(
+        self, base_config: Config, sample_clip: Clip, mocks: PipelineMocks
+    ) -> None:
+        """When run_mode=never, VLM is skipped even for trigger detections."""
+        # Given run_mode=never and a trigger-class filter result
+        base_config = Config(
+            cameras=base_config.cameras,
+            storage=base_config.storage,
+            state_store=base_config.state_store,
+            notifiers=base_config.notifiers,
+            filter=base_config.filter,
+            vlm=base_config.vlm.model_copy(update={"run_mode": "never"}),
+            alert_policy=base_config.alert_policy,
+        )
+        person_result = FilterResult(
+            detected_classes=["person"],
+            confidence=0.95,
+            model="mock",
+            sampled_frames=30,
+        )
+        filter_mock = MockFilter(result=person_result)
+        mocks.filter = filter_mock
+
+        pipeline = ClipPipeline(
+            config=base_config,
+            storage=mocks.storage,
+            repository=make_repository(base_config, mocks),
+            filter_plugin=filter_mock,
+            vlm_plugin=mocks.vlm,
+            notifier=mocks.notifier,
+            alert_policy=make_alert_policy(base_config),
+            retention_pruner=MockRetentionPruner(),
+        )
+
+        # When a clip is processed
+        pipeline.on_new_clip(sample_clip)
+        await pipeline.shutdown()
+
+        # Then VLM is skipped with a run_mode-specific reason
+        events = await mocks.event_store.get_events(sample_clip.clip_id)
+        skipped_events = [event for event in events if event.event_type == "vlm_skipped"]
+        assert len(skipped_events) == 1
+        assert skipped_events[0].reason == "run_mode_never"
+        assert all(event.event_type != "vlm_started" for event in events)
+        assert all(event.event_type != "vlm_completed" for event in events)
+
 
 class TestClipPipelineErrorHandling:
     """Test error handling and partial failures."""

--- a/tests/homesec/test_pipeline.py
+++ b/tests/homesec/test_pipeline.py
@@ -21,7 +21,7 @@ from homesec.models.config import (
     StateStoreConfig,
     StorageConfig,
 )
-from homesec.models.enums import RiskLevel
+from homesec.models.enums import RiskLevel, VLMSkipReason
 from homesec.models.filter import FilterConfig, FilterOverrides, FilterResult
 from homesec.models.vlm import AnalysisResult, VLMConfig
 from homesec.pipeline import ClipPipeline
@@ -326,7 +326,7 @@ class TestClipPipelineHappyPath:
         events = await mocks.event_store.get_events(sample_clip.clip_id)
         skipped_events = [event for event in events if event.event_type == "vlm_skipped"]
         assert len(skipped_events) == 1
-        assert skipped_events[0].reason == "run_mode_never"
+        assert skipped_events[0].reason == VLMSkipReason.RUN_MODE_NEVER
         assert all(event.event_type != "vlm_started" for event in events)
         assert all(event.event_type != "vlm_completed" for event in events)
 

--- a/tests/homesec/test_pipeline_events.py
+++ b/tests/homesec/test_pipeline_events.py
@@ -37,7 +37,12 @@ from tests.homesec.mocks import (
 )
 
 
-def build_config(*, notify_on_motion: bool = False, notifier_count: int = 1) -> Config:
+def build_config(
+    *,
+    notify_on_motion: bool = False,
+    notifier_count: int = 1,
+    run_mode: str = "trigger_only",
+) -> Config:
     """Build a minimal config for pipeline tests."""
     cameras = [
         CameraConfig(
@@ -68,6 +73,7 @@ def build_config(*, notify_on_motion: bool = False, notifier_count: int = 1) -> 
         ),
         vlm=VLMConfig(
             backend="openai",
+            run_mode=run_mode,
             trigger_classes=["person", "car"],
             config=OpenAIConfig(api_key_env="OPENAI_API_KEY", model="gpt-4o"),
         ),
@@ -314,6 +320,52 @@ async def test_pipeline_emits_vlm_skipped_event(
     assert "vlm_completed" not in event_types
     skipped_event = next(event for event in events if event.event_type == "vlm_skipped")
     assert skipped_event.reason == "no_trigger_classes"
+
+    await state_store.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_emits_vlm_skipped_event_for_run_mode_never(
+    postgres_dsn: str, tmp_path: Path, clean_test_db: None
+) -> None:
+    # Given: A clip with trigger classes but run_mode forcing VLM disabled
+    state_store = PostgresStateStore(postgres_dsn)
+    await state_store.initialize()
+    event_store = state_store.create_event_store()
+    assert isinstance(event_store, PostgresEventStore)
+    config = build_config(run_mode="never")
+    repository = ClipRepository(state_store, event_store, retry=config.retry)
+
+    filter_result = FilterResult(
+        detected_classes=["person"],
+        confidence=0.9,
+        model="mock",
+        sampled_frames=30,
+    )
+    pipeline = ClipPipeline(
+        config=config,
+        storage=MockStorage(),
+        repository=repository,
+        filter_plugin=MockFilter(result=filter_result),
+        vlm_plugin=MockVLM(),
+        notifier=MockNotifier(),
+        alert_policy=make_alert_policy(config),
+        retention_pruner=MockRetentionPruner(),
+    )
+    clip = make_clip(tmp_path, "test-clip-events-006")
+
+    # When: A clip is processed
+    pipeline.on_new_clip(clip)
+    await pipeline.shutdown()
+
+    # Then: VLM is skipped because run mode is disabled
+    events = await event_store.get_events(clip.clip_id)
+    event_types = {event.event_type for event in events}
+    assert "vlm_skipped" in event_types
+    assert "vlm_started" not in event_types
+    assert "vlm_completed" not in event_types
+    skipped_event = next(event for event in events if event.event_type == "vlm_skipped")
+    assert skipped_event.reason == "run_mode_never"
 
     await state_store.shutdown()
 

--- a/tests/homesec/test_pipeline_events.py
+++ b/tests/homesec/test_pipeline_events.py
@@ -18,6 +18,7 @@ from homesec.models.config import (
     StateStoreConfig,
     StorageConfig,
 )
+from homesec.models.enums import VLMSkipReason
 from homesec.models.filter import FilterConfig, FilterResult
 from homesec.models.vlm import AnalysisResult, VLMConfig
 from homesec.notifiers.multiplex import NotifierEntry
@@ -319,7 +320,7 @@ async def test_pipeline_emits_vlm_skipped_event(
     assert "vlm_started" not in event_types
     assert "vlm_completed" not in event_types
     skipped_event = next(event for event in events if event.event_type == "vlm_skipped")
-    assert skipped_event.reason == "no_trigger_classes"
+    assert skipped_event.reason == VLMSkipReason.NO_TRIGGER_CLASSES
 
     await state_store.shutdown()
 
@@ -365,7 +366,7 @@ async def test_pipeline_emits_vlm_skipped_event_for_run_mode_never(
     assert "vlm_started" not in event_types
     assert "vlm_completed" not in event_types
     skipped_event = next(event for event in events if event.event_type == "vlm_skipped")
-    assert skipped_event.reason == "run_mode_never"
+    assert skipped_event.reason == VLMSkipReason.RUN_MODE_NEVER
 
     await state_store.shutdown()
 

--- a/tests/homesec/test_runtime_assembly.py
+++ b/tests/homesec/test_runtime_assembly.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -143,7 +144,7 @@ class _FailOnRetentionPipeline:
         _ = timeout
 
 
-def _make_config() -> Config:
+def _make_config(*, run_mode: str = "trigger_only") -> Config:
     return Config(
         cameras=[
             CameraConfig(
@@ -166,6 +167,7 @@ def _make_config() -> Config:
         ),
         vlm=VLMConfig(
             backend="openai",
+            run_mode=run_mode,
             config=OpenAIConfig(api_key_env="OPENAI_API_KEY", model="gpt-4o"),
             trigger_classes=["person"],
         ),
@@ -238,6 +240,48 @@ async def test_runtime_assembly_cleans_filter_and_notifier_when_analyzer_build_f
         await assembler.build_bundle(config, generation=1)
 
     # Then: Created components are shut down during partial-build cleanup
+    assert notifier.shutdown_called is True
+    assert filter_plugin.shutdown_called is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_assembly_skips_analyzer_load_when_run_mode_never(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_mode=never should avoid analyzer plugin instantiation at startup."""
+    # Given: Runtime assembly with VLM disabled and filter creation stubbed
+    notifier = _StubNotifier()
+    filter_plugin = _StubFilter()
+    assembler = _make_assembler(notifier)
+    config = _make_config(run_mode="never")
+
+    monkeypatch.setattr("homesec.runtime.assembly.load_filter", lambda _cfg: filter_plugin)
+
+    def _fail_if_called(_: object) -> object:
+        raise AssertionError("load_analyzer should not run when run_mode=never")
+
+    monkeypatch.setattr("homesec.runtime.assembly.load_analyzer", _fail_if_called)
+
+    # When: Building a runtime bundle
+    runtime = await assembler.build_bundle(config, generation=1)
+
+    # Then: Runtime uses disabled analyzer semantics and bundle remains healthy
+    try:
+        assert await runtime.vlm_plugin.ping() is True
+        analysis = await runtime.vlm_plugin.analyze(
+            video_path=Path("/tmp/disabled-vlm-test.mp4"),
+            filter_result=FilterResult(
+                detected_classes=["person"],
+                confidence=0.9,
+                model="stub",
+                sampled_frames=1,
+            ),
+            config=config.vlm,
+        )
+        assert analysis.activity_type == "skipped"
+        assert analysis.summary == "VLM analysis disabled (run_mode=never)"
+    finally:
+        await assembler.shutdown_bundle(runtime)
     assert notifier.shutdown_called is True
     assert filter_plugin.shutdown_called is True
 

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from argparse import Namespace
 from typing import Any, cast
+
+import pytest
 
 import homesec.runtime.worker as worker_module
 from homesec.models.config import (
@@ -27,7 +30,7 @@ class _StubEmitter:
         return None
 
 
-def _make_config(*, notifiers: list[NotifierConfig]) -> Config:
+def _make_config(*, notifiers: list[NotifierConfig], run_mode: str = "trigger_only") -> Config:
     return Config(
         cameras=[
             CameraConfig(
@@ -39,7 +42,7 @@ def _make_config(*, notifiers: list[NotifierConfig]) -> Config:
         state_store=StateStoreConfig(dsn="postgresql://user:pass@localhost/homesec"),
         notifiers=notifiers,
         filter=FilterConfig(backend="yolo", config={}),
-        vlm=VLMConfig(backend="openai", config={}),
+        vlm=VLMConfig(backend="openai", run_mode=run_mode, config={}),
         alert_policy=AlertPolicyConfig(backend="default", config={}),
     )
 
@@ -122,3 +125,53 @@ def test_runtime_worker_create_notifier_skips_disabled_entries(
     # Then: Worker keeps notifications disabled and does not load plugins
     assert isinstance(notifier, worker_module._NoopNotifier)
     assert entries == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_worker_run_runtime_skips_analyzer_load_when_run_mode_never(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run_mode=never should avoid analyzer plugin loading in worker startup."""
+    # Given: Runtime worker with VLM disabled and analyzer loader guarded
+    config = _make_config(notifiers=[], run_mode="never")
+    service = _make_service(config)
+    stop_event = asyncio.Event()
+    stop_event.set()
+
+    class _StubStorage:
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+    class _StubStateStore:
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+    class _StubEventStore:
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+    class _StubFilter:
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+    async def _fake_create_state_store(_config: Config) -> _StubStateStore:
+        return _StubStateStore()
+
+    monkeypatch.setattr(worker_module, "discover_all_plugins", lambda: None)
+    monkeypatch.setattr(worker_module, "load_storage_plugin", lambda _cfg: _StubStorage())
+    monkeypatch.setattr(service, "_create_state_store", _fake_create_state_store)
+    monkeypatch.setattr(service, "_create_event_store", lambda _state: _StubEventStore())
+    monkeypatch.setattr(service, "_create_alert_policy", lambda _cfg: cast(Any, object()))
+    monkeypatch.setattr(service, "_create_sources", lambda _cfg: ([], {}))
+    monkeypatch.setattr("homesec.runtime.assembly.load_filter", lambda _cfg: _StubFilter())
+
+    def _fail_if_called(_: object) -> object:
+        raise AssertionError("load_analyzer should not be called for run_mode=never")
+
+    monkeypatch.setattr("homesec.runtime.assembly.load_analyzer", _fail_if_called)
+
+    # When: Running runtime worker startup/shutdown cycle
+    await service.run_runtime(stop_event)
+
+    # Then: Worker completes lifecycle without invoking analyzer loader
+    assert service._runtime_bundle is None


### PR DESCRIPTION
## Summary

Make runtime startup resilient in dev/CI while keeping cleaner abstraction boundaries and stronger typed telemetry.

## Changes

### 1. VLM `run_mode: never` is handled in runtime assembly (not plugin loader)
- **Files**:
  - `src/homesec/runtime/assembly.py`
  - `src/homesec/runtime/disabled_vlm.py`
  - `src/homesec/plugins/analyzers/__init__.py`
- `load_analyzer()` is now a pure plugin loader again.
- Runtime assembly now decides activation:
  - if `vlm.run_mode == never`, it injects `DisabledVLMAnalyzer`
  - otherwise, it loads the configured analyzer plugin.
- Net effect: when disabled, startup no longer initializes OpenAI analyzer/env checks.

### 2. Typed VLM skip reasons (no magic strings)
- **Files**:
  - `src/homesec/models/enums.py`
  - `src/homesec/models/events.py`
  - `src/homesec/repository/clip_repository.py`
  - `src/homesec/pipeline/core.py`
- Added `VLMSkipReason` enum.
- `VLMSkippedEvent.reason` now uses typed enum values.
- Pipeline skip logic now emits explicit reasons:
  - `run_mode_never`
  - `no_trigger_classes`

### 3. Worker-level coverage for disabled VLM startup
- **File**: `tests/homesec/test_runtime_worker.py`
- Added a worker lifecycle test that guards `load_analyzer` from being called when `run_mode=never`.

### 4. RTSP session-limit fallback profile cleanup
- **Files**:
  - `src/homesec/sources/rtsp/core.py`
  - `tests/homesec/rtsp/test_runtime.py`
- Session-limit fallback now reuses `build_default_recording_profile()` instead of hand-building a profile in `RTSPSource`.
- Added regression test to lock this behavior.

### 5. Existing RTSP/dev resiliency changes retained in this PR
- **Files**:
  - `src/homesec/sources/rtsp/core.py`
  - `dev/fake-camera/mediamtx.yml`
- Keeps the session-limit startup fallback path and MediaMTX stability tuning (`readTimeout`, `writeTimeout`, `writeQueueSize`, `maxReaders`).

## Tests

Added/updated tests:
- `tests/homesec/test_runtime_assembly.py`
- `tests/homesec/test_runtime_worker.py`
- `tests/homesec/test_pipeline.py`
- `tests/homesec/test_pipeline_events.py`
- `tests/homesec/rtsp/test_runtime.py`

## Validation run locally

- `make typecheck` ✅
- `uv run ruff check` on touched files ✅
- `uv run pytest tests/homesec/test_pipeline.py tests/homesec/test_runtime_assembly.py tests/homesec/test_runtime_worker.py tests/homesec/rtsp/test_runtime.py` ✅
- `tests/homesec/test_pipeline_events.py` requires valid local Postgres auth; in this environment DB-backed event tests fail with `InvalidPasswordError` for `homesec@localhost:5432`.
