### PR TITLE
refactor: add setup probe registry for setup flow

### DIFF
--- a/src/homesec/services/setup.py
+++ b/src/homesec/services/setup.py
@@ -50,6 +50,7 @@ from homesec.services.setup_probes import (
     SetupProbeTarget,
     get_setup_probe,
     get_setup_probe_backends,
+    get_setup_probe_timeout,
     setup_probe,
 )
 from homesec.sources.ftp import FtpSourceConfig
@@ -260,7 +261,7 @@ async def _test_analyzer_connection(
     )
 
 
-@setup_probe("camera", "rtsp")
+@setup_probe("camera", "rtsp", timeout_s=_RTSP_TEST_CONNECTION_TIMEOUT_S + 1.0)
 async def _test_rtsp_camera_connection(
     *,
     config: dict[str, object],
@@ -354,7 +355,7 @@ async def _test_rtsp_camera_connection(
     )
 
 
-@setup_probe("camera", "ftp")
+@setup_probe("camera", "ftp", timeout_s=_FTP_TEST_CONNECTION_TIMEOUT_S + 1.0)
 async def _test_ftp_camera_connection(
     *,
     config: dict[str, object],
@@ -465,7 +466,7 @@ async def _test_local_folder_camera_connection(
     )
 
 
-@setup_probe("camera", "onvif")
+@setup_probe("camera", "onvif", timeout_s=_ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S + 1.0)
 async def _test_onvif_camera_connection(
     *,
     config: dict[str, object],
@@ -718,11 +719,11 @@ async def _run_registered_setup_probe(
     probe = get_setup_probe(target, backend)
     if probe is None:
         return None
+    timeout_s = get_setup_probe_timeout(target, backend)
     try:
-        return await asyncio.wait_for(
-            probe(config=config),
-            timeout=_PLUGIN_TEST_CONNECTION_TIMEOUT_S,
-        )
+        if timeout_s is None:
+            return await probe(config=config)
+        return await asyncio.wait_for(probe(config=config), timeout=timeout_s)
     except SetupTestConnectionRequestError:
         raise
     except ValidationError as exc:
@@ -740,7 +741,7 @@ async def _run_registered_setup_probe(
         )
         return _result(
             success=False,
-            message=(f"{target} probe timed out after {_PLUGIN_TEST_CONNECTION_TIMEOUT_S:.1f}s."),
+            message=f"{target} probe timed out after {timeout_s:.1f}s.",
             start=start,
         )
     except Exception:

--- a/src/homesec/services/setup.py
+++ b/src/homesec/services/setup.py
@@ -46,17 +46,17 @@ from homesec.onvif.service import (
 )
 from homesec.plugins.registry import PluginType, get_plugin_names, load_plugin, validate_plugin
 from homesec.plugins.storage.local import LocalStorageConfig
-from homesec.sources.ftp import FtpSourceConfig
-from homesec.sources.local_folder import LocalFolderSourceConfig
-from homesec.sources.rtsp.core import RTSPSourceConfig
-from homesec.sources.rtsp.preflight import PreflightError, RTSPStartupPreflight
-from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 from homesec.services.setup_probes import (
     SetupProbeTarget,
     get_setup_probe,
     get_setup_probe_backends,
     setup_probe,
 )
+from homesec.sources.ftp import FtpSourceConfig
+from homesec.sources.local_folder import LocalFolderSourceConfig
+from homesec.sources.rtsp.core import RTSPSourceConfig
+from homesec.sources.rtsp.preflight import PreflightError, RTSPStartupPreflight
+from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 from homesec.state.postgres import PostgresStateStore
 
 if TYPE_CHECKING:

--- a/src/homesec/services/setup.py
+++ b/src/homesec/services/setup.py
@@ -51,6 +51,12 @@ from homesec.sources.local_folder import LocalFolderSourceConfig
 from homesec.sources.rtsp.core import RTSPSourceConfig
 from homesec.sources.rtsp.preflight import PreflightError, RTSPStartupPreflight
 from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
+from homesec.services.setup_probes import (
+    SetupProbeTarget,
+    get_setup_probe,
+    get_setup_probe_backends,
+    setup_probe,
+)
 from homesec.state.postgres import PostgresStateStore
 
 if TYPE_CHECKING:
@@ -176,6 +182,10 @@ async def _test_camera_connection(
     backend: str,
     config: dict[str, object],
 ) -> TestConnectionResponse:
+    probe_result = await _run_registered_setup_probe("camera", backend, config)
+    if probe_result is not None:
+        return probe_result
+
     available_backends = _camera_backend_names()
     if backend not in available_backends:
         raise SetupTestConnectionRequestError(
@@ -208,8 +218,9 @@ async def _test_storage_connection(
     backend: str,
     config: dict[str, object],
 ) -> TestConnectionResponse:
-    if backend == "local":
-        return await _test_local_storage_connection(config=config)
+    probe_result = await _run_registered_setup_probe("storage", backend, config)
+    if probe_result is not None:
+        return probe_result
     return await _test_plugin_ping_connection(
         plugin_type=PluginType.STORAGE,
         backend=backend,
@@ -222,6 +233,10 @@ async def _test_notifier_connection(
     backend: str,
     config: dict[str, object],
 ) -> TestConnectionResponse:
+    probe_result = await _run_registered_setup_probe("notifier", backend, config)
+    if probe_result is not None:
+        return probe_result
+
     return await _test_plugin_ping_connection(
         plugin_type=PluginType.NOTIFIER,
         backend=backend,
@@ -234,6 +249,10 @@ async def _test_analyzer_connection(
     backend: str,
     config: dict[str, object],
 ) -> TestConnectionResponse:
+    probe_result = await _run_registered_setup_probe("analyzer", backend, config)
+    if probe_result is not None:
+        return probe_result
+
     return await _test_plugin_ping_connection(
         plugin_type=PluginType.ANALYZER,
         backend=backend,
@@ -241,6 +260,7 @@ async def _test_analyzer_connection(
     )
 
 
+@setup_probe("camera", "rtsp")
 async def _test_rtsp_camera_connection(
     *,
     config: dict[str, object],
@@ -334,6 +354,7 @@ async def _test_rtsp_camera_connection(
     )
 
 
+@setup_probe("camera", "ftp")
 async def _test_ftp_camera_connection(
     *,
     config: dict[str, object],
@@ -387,6 +408,7 @@ async def _test_ftp_camera_connection(
     )
 
 
+@setup_probe("camera", "local_folder")
 async def _test_local_folder_camera_connection(
     *,
     config: dict[str, object],
@@ -443,6 +465,7 @@ async def _test_local_folder_camera_connection(
     )
 
 
+@setup_probe("camera", "onvif")
 async def _test_onvif_camera_connection(
     *,
     config: dict[str, object],
@@ -497,6 +520,7 @@ async def _test_onvif_camera_connection(
     )
 
 
+@setup_probe("storage", "local")
 async def _test_local_storage_connection(*, config: dict[str, object]) -> TestConnectionResponse:
     start = time.perf_counter()
     _ensure_known_backend(PluginType.STORAGE, "local")
@@ -681,8 +705,19 @@ def _ensure_known_backend(plugin_type: PluginType, backend: str) -> None:
 
 def _camera_backend_names() -> list[str]:
     available = set(get_plugin_names(PluginType.SOURCE))
-    available.add("onvif")
+    available.update(get_setup_probe_backends("camera"))
     return sorted(available)
+
+
+async def _run_registered_setup_probe(
+    target: SetupProbeTarget,
+    backend: str,
+    config: dict[str, object],
+) -> TestConnectionResponse | None:
+    probe = get_setup_probe(target, backend)
+    if probe is None:
+        return None
+    return await probe(config=config)
 
 
 def _resolve_rtsp_primary_url(config: RTSPSourceConfig) -> str | None:

--- a/src/homesec/services/setup.py
+++ b/src/homesec/services/setup.py
@@ -714,10 +714,50 @@ async def _run_registered_setup_probe(
     backend: str,
     config: dict[str, object],
 ) -> TestConnectionResponse | None:
+    start = time.perf_counter()
     probe = get_setup_probe(target, backend)
     if probe is None:
         return None
-    return await probe(config=config)
+    try:
+        return await asyncio.wait_for(
+            probe(config=config),
+            timeout=_PLUGIN_TEST_CONNECTION_TIMEOUT_S,
+        )
+    except SetupTestConnectionRequestError:
+        raise
+    except ValidationError as exc:
+        return _result(
+            success=False,
+            message=_format_validation_error(exc),
+            start=start,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Setup registered probe timed out for %s backend=%s",
+            target,
+            backend,
+            exc_info=True,
+        )
+        return _result(
+            success=False,
+            message=(f"{target} probe timed out after {_PLUGIN_TEST_CONNECTION_TIMEOUT_S:.1f}s."),
+            start=start,
+        )
+    except Exception:
+        logger.warning(
+            "Setup registered probe failed for %s backend=%s",
+            target,
+            backend,
+            exc_info=True,
+        )
+        return _result(
+            success=False,
+            message=(
+                f"{target} probe failed during connectivity test. "
+                "Check backend configuration and connectivity."
+            ),
+            start=start,
+        )
 
 
 def _resolve_rtsp_primary_url(config: RTSPSourceConfig) -> str | None:

--- a/src/homesec/services/setup_probes.py
+++ b/src/homesec/services/setup_probes.py
@@ -1,0 +1,85 @@
+"""Setup-only probe registry for onboarding test-connection flows."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from homesec.models.setup import TestConnectionResponse
+
+SetupProbeTarget = Literal["camera", "storage", "notifier", "analyzer"]
+SetupProbeFn = Callable[..., Awaitable[TestConnectionResponse]]
+
+
+@dataclass(frozen=True)
+class _RegisteredSetupProbe:
+    target: SetupProbeTarget
+    backend: str
+    probe: SetupProbeFn
+
+
+class SetupProbeRegistry:
+    """Registry for setup-only probe handlers keyed by target/backend."""
+
+    def __init__(self) -> None:
+        self._probes: dict[tuple[SetupProbeTarget, str], _RegisteredSetupProbe] = {}
+
+    def register(
+        self,
+        target: SetupProbeTarget,
+        backend: str,
+    ) -> Callable[[SetupProbeFn], SetupProbeFn]:
+        """Register a setup probe for a target/backend pair."""
+
+        normalized_backend = backend.strip().lower()
+        key = (target, normalized_backend)
+
+        def decorator(probe: SetupProbeFn) -> SetupProbeFn:
+            if key in self._probes:
+                raise ValueError(
+                    f"Setup probe for {target} backend {normalized_backend!r} is already registered."
+                )
+            self._probes[key] = _RegisteredSetupProbe(
+                target=target,
+                backend=normalized_backend,
+                probe=probe,
+            )
+            return probe
+
+        return decorator
+
+    def get(self, target: SetupProbeTarget, backend: str) -> SetupProbeFn | None:
+        """Return a registered probe for the target/backend pair, if present."""
+        entry = self._probes.get((target, backend.strip().lower()))
+        if entry is None:
+            return None
+        return entry.probe
+
+    def get_backends(self, target: SetupProbeTarget) -> list[str]:
+        """Return known special-case backends for a target."""
+        return sorted(
+            {
+                entry.backend
+                for entry in self._probes.values()
+                if entry.target == target
+            }
+        )
+
+
+_SETUP_PROBE_REGISTRY = SetupProbeRegistry()
+
+
+def setup_probe(target: SetupProbeTarget, backend: str) -> Callable[[SetupProbeFn], SetupProbeFn]:
+    """Decorator for registering a setup-only probe handler."""
+    return _SETUP_PROBE_REGISTRY.register(target, backend)
+
+
+def get_setup_probe(target: SetupProbeTarget, backend: str) -> SetupProbeFn | None:
+    """Look up a setup-only probe handler."""
+    return _SETUP_PROBE_REGISTRY.get(target, backend)
+
+
+def get_setup_probe_backends(target: SetupProbeTarget) -> list[str]:
+    """List special-case backends registered for a setup target."""
+    return _SETUP_PROBE_REGISTRY.get_backends(target)

--- a/src/homesec/services/setup_probes.py
+++ b/src/homesec/services/setup_probes.py
@@ -10,6 +10,7 @@ from homesec.models.setup import TestConnectionResponse
 
 SetupProbeTarget = Literal["camera", "storage", "notifier", "analyzer"]
 SetupProbeFn = Callable[..., Awaitable[TestConnectionResponse]]
+_DEFAULT_SETUP_PROBE_TIMEOUT_S = 5.0
 
 
 @dataclass(frozen=True)
@@ -17,6 +18,7 @@ class _RegisteredSetupProbe:
     target: SetupProbeTarget
     backend: str
     probe: SetupProbeFn
+    timeout_s: float | None
 
 
 class SetupProbeRegistry:
@@ -29,11 +31,15 @@ class SetupProbeRegistry:
         self,
         target: SetupProbeTarget,
         backend: str,
+        *,
+        timeout_s: float | None = _DEFAULT_SETUP_PROBE_TIMEOUT_S,
     ) -> Callable[[SetupProbeFn], SetupProbeFn]:
         """Register a setup probe for a target/backend pair."""
 
         normalized_backend = backend.strip().lower()
         key = (target, normalized_backend)
+        if timeout_s is not None and timeout_s <= 0:
+            raise ValueError("Setup probe timeout must be positive when provided.")
 
         def decorator(probe: SetupProbeFn) -> SetupProbeFn:
             if key in self._probes:
@@ -44,6 +50,7 @@ class SetupProbeRegistry:
                 target=target,
                 backend=normalized_backend,
                 probe=probe,
+                timeout_s=timeout_s,
             )
             return probe
 
@@ -60,18 +67,35 @@ class SetupProbeRegistry:
         """Return known special-case backends for a target."""
         return sorted({entry.backend for entry in self._probes.values() if entry.target == target})
 
+    def get_timeout(self, target: SetupProbeTarget, backend: str) -> float | None:
+        """Return the registered timeout budget for the target/backend pair, if present."""
+        entry = self._probes.get((target, backend.strip().lower()))
+        if entry is None:
+            return None
+        return entry.timeout_s
+
 
 _SETUP_PROBE_REGISTRY = SetupProbeRegistry()
 
 
-def setup_probe(target: SetupProbeTarget, backend: str) -> Callable[[SetupProbeFn], SetupProbeFn]:
+def setup_probe(
+    target: SetupProbeTarget,
+    backend: str,
+    *,
+    timeout_s: float | None = _DEFAULT_SETUP_PROBE_TIMEOUT_S,
+) -> Callable[[SetupProbeFn], SetupProbeFn]:
     """Decorator for registering a setup-only probe handler."""
-    return _SETUP_PROBE_REGISTRY.register(target, backend)
+    return _SETUP_PROBE_REGISTRY.register(target, backend, timeout_s=timeout_s)
 
 
 def get_setup_probe(target: SetupProbeTarget, backend: str) -> SetupProbeFn | None:
     """Look up a setup-only probe handler."""
     return _SETUP_PROBE_REGISTRY.get(target, backend)
+
+
+def get_setup_probe_timeout(target: SetupProbeTarget, backend: str) -> float | None:
+    """Look up the registered timeout budget for a setup-only probe handler."""
+    return _SETUP_PROBE_REGISTRY.get_timeout(target, backend)
 
 
 def get_setup_probe_backends(target: SetupProbeTarget) -> list[str]:

--- a/src/homesec/services/setup_probes.py
+++ b/src/homesec/services/setup_probes.py
@@ -58,13 +58,7 @@ class SetupProbeRegistry:
 
     def get_backends(self, target: SetupProbeTarget) -> list[str]:
         """Return known special-case backends for a target."""
-        return sorted(
-            {
-                entry.backend
-                for entry in self._probes.values()
-                if entry.target == target
-            }
-        )
+        return sorted({entry.backend for entry in self._probes.values() if entry.target == target})
 
 
 _SETUP_PROBE_REGISTRY = SetupProbeRegistry()

--- a/tests/homesec/test_setup_probes.py
+++ b/tests/homesec/test_setup_probes.py
@@ -45,3 +45,19 @@ def test_setup_probe_registry_rejects_duplicate_registration() -> None:
     # When / Then: Registering the same target/backend again raises a clear error
     with pytest.raises(ValueError, match="already registered"):
         registry.register("storage", "local")(_probe_two)
+
+
+def test_setup_probe_registry_tracks_custom_timeout_budget() -> None:
+    """Registry should preserve explicit timeout metadata for registered probes."""
+    # Given: A probe registered with a non-default timeout budget
+    registry = SetupProbeRegistry()
+
+    async def _probe(*, config: dict[str, object]) -> SetupTestConnectionResponse:
+        _ = config
+        return SetupTestConnectionResponse(success=True, message="ok")
+
+    registry.register("camera", "rtsp", timeout_s=11.0)(_probe)
+
+    # When / Then: Lookup returns the probe and its configured timeout budget
+    assert registry.get("camera", "rtsp") is _probe
+    assert registry.get_timeout("camera", "rtsp") == 11.0

--- a/tests/homesec/test_setup_probes.py
+++ b/tests/homesec/test_setup_probes.py
@@ -1,0 +1,47 @@
+"""Tests for setup-only probe registry helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from homesec.models.setup import TestConnectionResponse as SetupTestConnectionResponse
+from homesec.services.setup_probes import SetupProbeRegistry
+
+
+def test_setup_probe_registry_registers_and_looks_up_probe() -> None:
+    """Registry should register probes by target/backend and normalize lookup keys."""
+    # Given: A fresh setup probe registry and a probe handler for one backend
+    registry = SetupProbeRegistry()
+
+    async def _probe(*, config: dict[str, object]) -> SetupTestConnectionResponse:
+        _ = config
+        return SetupTestConnectionResponse(success=True, message="ok")
+
+    registry.register("camera", "onvif")(_probe)
+
+    # When: Looking up the probe with mixed-case backend input
+    probe = registry.get("camera", " ONVIF ")
+
+    # Then: Registry returns the registered probe and backend listing is normalized
+    assert probe is _probe
+    assert registry.get_backends("camera") == ["onvif"]
+
+
+def test_setup_probe_registry_rejects_duplicate_registration() -> None:
+    """Registry should reject duplicate target/backend registrations."""
+    # Given: A registry with one already-registered probe
+    registry = SetupProbeRegistry()
+
+    async def _probe_one(*, config: dict[str, object]) -> SetupTestConnectionResponse:
+        _ = config
+        return SetupTestConnectionResponse(success=True, message="one")
+
+    async def _probe_two(*, config: dict[str, object]) -> SetupTestConnectionResponse:
+        _ = config
+        return SetupTestConnectionResponse(success=True, message="two")
+
+    registry.register("storage", "local")(_probe_one)
+
+    # When / Then: Registering the same target/backend again raises a clear error
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("storage", "local")(_probe_two)

--- a/tests/homesec/test_setup_test_connection_service.py
+++ b/tests/homesec/test_setup_test_connection_service.py
@@ -734,6 +734,43 @@ async def test_test_connection_camera_onvif_success(
 
 
 @pytest.mark.asyncio
+async def test_test_connection_camera_onvif_uses_requested_timeout_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Camera onvif test should not inherit the shorter generic plugin timeout."""
+
+    # Given: An ONVIF probe that outlives the generic plugin timeout but stays within request budget
+    class _SlowSuccessfulOnvifService:
+        def __init__(self, *, discover_fn: object, client_factory: object) -> None:
+            _ = (discover_fn, client_factory)
+
+        async def probe(self, options: setup_service.OnvifProbeOptions) -> object:
+            assert options.timeout_s == 0.05
+            await asyncio.sleep(0.02)
+            return SimpleNamespace(profiles=[object()], streams=[object()])
+
+    monkeypatch.setattr(setup_service, "_PLUGIN_TEST_CONNECTION_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(setup_service, "OnvifService", _SlowSuccessfulOnvifService)
+    request = SetupTestConnectionRequest(
+        type="camera",
+        backend="onvif",
+        config={
+            "host": "192.168.1.10",
+            "username": "admin",
+            "password": "secret",
+            "timeout_s": 0.05,
+        },
+    )
+
+    # When: Running the setup test-connection service
+    response = await setup_service.test_connection(request, _StubApp())
+
+    # Then: The setup-specific ONVIF timeout governs the registered probe
+    assert response.success is True
+    assert response.message == "ONVIF probe succeeded."
+
+
+@pytest.mark.asyncio
 async def test_test_connection_camera_onvif_validation_failure() -> None:
     """Camera onvif test should fail when required config fields are missing."""
     # Given: An ONVIF request missing required host/username/password fields

--- a/tests/homesec/test_setup_test_connection_service.py
+++ b/tests/homesec/test_setup_test_connection_service.py
@@ -285,9 +285,7 @@ async def test_test_connection_camera_uses_registered_setup_probe(
     monkeypatch.setattr(
         setup_service,
         "get_setup_probe",
-        lambda target, backend: _fake_probe
-        if target == "camera" and backend == "custom"
-        else None,
+        lambda target, backend: _fake_probe if target == "camera" and backend == "custom" else None,
     )
     monkeypatch.setattr(
         setup_service,

--- a/tests/homesec/test_setup_test_connection_service.py
+++ b/tests/homesec/test_setup_test_connection_service.py
@@ -308,6 +308,38 @@ async def test_test_connection_camera_uses_registered_setup_probe(
 
 
 @pytest.mark.asyncio
+async def test_test_connection_camera_registered_probe_failure_returns_failed_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registered setup probe failures should return a failed probe response."""
+
+    # Given: A registered camera probe that raises during connectivity testing
+    async def _failing_probe(*, config: dict[str, object]) -> setup_service.TestConnectionResponse:
+        _ = config
+        raise RuntimeError("socket connect failed")
+
+    monkeypatch.setattr(
+        setup_service,
+        "get_setup_probe",
+        lambda target, backend: _failing_probe
+        if target == "camera" and backend == "custom"
+        else None,
+    )
+    request = SetupTestConnectionRequest(
+        type="camera",
+        backend="custom",
+        config={"host": "192.168.1.10"},
+    )
+
+    # When: Running the setup test-connection service
+    response = await setup_service.test_connection(request, _StubApp())
+
+    # Then: The API returns a failed probe response instead of raising
+    assert response.success is False
+    assert "failed during connectivity test" in response.message
+
+
+@pytest.mark.asyncio
 async def test_test_connection_camera_rtsp_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/homesec/test_setup_test_connection_service.py
+++ b/tests/homesec/test_setup_test_connection_service.py
@@ -268,6 +268,48 @@ async def test_test_connection_notifier_normalizes_backend_name(
 
 
 @pytest.mark.asyncio
+async def test_test_connection_camera_uses_registered_setup_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Camera test-connection should prefer registered setup probes over generic ping."""
+
+    # Given: A registry-backed camera probe for a backend without generic plugin wiring
+    async def _fake_probe(*, config: dict[str, object]) -> setup_service.TestConnectionResponse:
+        assert config == {"host": "192.168.1.10"}
+        return setup_service.TestConnectionResponse(
+            success=True,
+            message="camera probe ok",
+            details={"backend": "custom"},
+        )
+
+    monkeypatch.setattr(
+        setup_service,
+        "get_setup_probe",
+        lambda target, backend: _fake_probe
+        if target == "camera" and backend == "custom"
+        else None,
+    )
+    monkeypatch.setattr(
+        setup_service,
+        "_test_plugin_ping_connection",
+        lambda *_args, **_kwargs: pytest.fail("generic ping fallback should not be used"),
+    )
+    request = SetupTestConnectionRequest(
+        type="camera",
+        backend="custom",
+        config={"host": "192.168.1.10"},
+    )
+
+    # When: Running the setup test-connection service
+    response = await setup_service.test_connection(request, _StubApp())
+
+    # Then: The registered probe handles the request without falling back to plugin ping
+    assert response.success is True
+    assert response.message == "camera probe ok"
+    assert response.details == {"backend": "custom"}
+
+
+@pytest.mark.asyncio
 async def test_test_connection_camera_rtsp_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1134,7 +1176,7 @@ async def test_test_connection_camera_unknown_backend_includes_onvif_hint(
         await setup_service.test_connection(request, _StubApp())
 
     assert "Unknown camera backend" in str(exc_info.value)
-    assert exc_info.value.available_backends == ["ftp", "onvif", "rtsp"]
+    assert exc_info.value.available_backends == ["ftp", "local_folder", "onvif", "rtsp"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- add a setup-only probe registry for onboarding test-connection flows
- refactor setup test-connection dispatch to consult registered probes before generic plugin ping
- register setup-specific probes for camera backends and local storage
- add focused registry and setup-service coverage

## Why
`services/setup.py` had hardcoded backend-specific probe branching that bypassed the plugin boundary at onboarding time. This change keeps setup-specific probing in setup code without polluting runtime plugin interfaces.

## Impact
- setup/test-connection flow is easier to extend
- ONVIF remains setup-domain specific
- notifier and analyzer flows still use the existing generic plugin ping path

## Validation
- `uv run pytest tests/homesec/test_setup_probes.py tests/homesec/test_setup_test_connection_service.py tests/homesec/test_api_setup_routes.py -q`
- `uv run mypy src/homesec/services/setup.py src/homesec/services/setup_probes.py`

## Notes
- camera backend hints now include `local_folder` because it is registered as a setup-only probe; this is intentional and covered by tests