### PR TITLE
refactor: share runtime persistence bootstrap wiring

### DIFF
--- a/src/homesec/app.py
+++ b/src/homesec/app.py
@@ -19,6 +19,10 @@ from homesec.models.config import FastAPIServerConfig
 from homesec.plugins.registry import PluginType, get_plugin_names
 from homesec.plugins.storage import load_storage_plugin
 from homesec.repository import ClipRepository
+from homesec.runtime.bootstrap import (
+    RuntimePersistenceStack,
+    build_runtime_persistence_stack,
+)
 from homesec.runtime.controller import RuntimeController
 from homesec.runtime.errors import RuntimeReloadConfigError
 from homesec.runtime.manager import RuntimeManager
@@ -193,14 +197,7 @@ class Application:
         self._validate_config(config)
 
         # Build components locally first so partial failures do not leak mutable app state.
-        storage = self._create_storage(config)
-        state_store = await self._create_state_store(config)
-        event_store = self._create_event_store(state_store)
-        repository = ClipRepository(
-            state_store,
-            event_store,
-            retry=config.retry,
-        )
+        persistence = await self._build_runtime_persistence_stack(config)
         runtime_manager = RuntimeManager(
             self._create_runtime_controller(),
             on_runtime_activated=self._bind_active_runtime,
@@ -209,8 +206,8 @@ class Application:
             await runtime_manager.start_initial_runtime(config)
         except Exception:
             await runtime_manager.shutdown()
-            await state_store.shutdown()
-            await storage.shutdown()
+            await persistence.state_store.shutdown()
+            await persistence.storage.shutdown()
             raise
 
         api_server = self._api_server
@@ -226,10 +223,10 @@ class Application:
             else:
                 api_server = None
 
-        self._storage = storage
-        self._state_store = state_store
-        self._event_store = event_store
-        self._repository = repository
+        self._storage = persistence.storage
+        self._state_store = persistence.state_store
+        self._event_store = persistence.event_store
+        self._repository = persistence.repository
         self._runtime_manager = runtime_manager
         self._api_server = api_server
 
@@ -250,30 +247,18 @@ class Application:
         self._bootstrap = False
         logger.info("Setup finalized; runtime activated in-process without API restart")
 
-    def _create_storage(self, config: Config) -> StorageBackend:
-        """Create storage backend based on config."""
-        return load_storage_plugin(config.storage)
-
-    async def _create_state_store(self, config: Config) -> StateStore:
-        """Create state store based on config."""
-        state_cfg = config.state_store
-        dsn = state_cfg.dsn
-        if state_cfg.dsn_env:
-            dsn = resolve_env_var(state_cfg.dsn_env)
-        if not dsn:
-            raise RuntimeError("Postgres DSN is required for state_store backend")
-        store = PostgresStateStore(dsn)
-        await store.initialize()
-        return store
-
-    def _create_event_store(self, state_store: StateStore) -> EventStore:
-        """Create event store based on state store backend."""
-        event_store = state_store.create_event_store()
-        if isinstance(event_store, NoopEventStore):
-            logger.warning(
+    async def _build_runtime_persistence_stack(self, config: Config) -> RuntimePersistenceStack:
+        """Build shared storage and persistence components for the app runtime."""
+        return await build_runtime_persistence_stack(
+            config,
+            resolve_env=resolve_env_var,
+            missing_dsn_message="Postgres DSN is required for state_store backend",
+            event_store_unavailable_warning=(
                 "Event store unavailable (NoopEventStore returned); events will be dropped"
-            )
-        return event_store
+            ),
+            storage_loader=load_storage_plugin,
+            state_store_factory=PostgresStateStore,
+        )
 
     def _create_runtime_controller(self) -> RuntimeController:
         controller = SubprocessRuntimeController()

--- a/src/homesec/app.py
+++ b/src/homesec/app.py
@@ -14,11 +14,8 @@ from homesec.api import APIServer, create_app
 from homesec.config import load_config, resolve_env_var, validate_config, validate_plugin_names
 from homesec.config.loader import ConfigError, ConfigErrorCode
 from homesec.config.manager import ConfigManager
-from homesec.interfaces import EventStore
 from homesec.models.config import FastAPIServerConfig
 from homesec.plugins.registry import PluginType, get_plugin_names
-from homesec.plugins.storage import load_storage_plugin
-from homesec.repository import ClipRepository
 from homesec.runtime.bootstrap import (
     RuntimePersistenceStack,
     build_runtime_persistence_stack,
@@ -38,14 +35,12 @@ from homesec.runtime.subprocess_controller import (
     SubprocessRuntimeController,
     SubprocessRuntimeHandle,
 )
-from homesec.state import NoopEventStore, NoopStateStore, PostgresStateStore
+from homesec.state import NoopEventStore, NoopStateStore
 
 if TYPE_CHECKING:
-    from homesec.interfaces import (
-        StateStore,
-        StorageBackend,
-    )
+    from homesec.interfaces import EventStore, StateStore, StorageBackend
     from homesec.models.config import Config
+    from homesec.repository import ClipRepository
 
 logger = logging.getLogger(__name__)
 RESTART_EXIT_CODE = 42
@@ -256,8 +251,6 @@ class Application:
             event_store_unavailable_warning=(
                 "Event store unavailable (NoopEventStore returned); events will be dropped"
             ),
-            storage_loader=load_storage_plugin,
-            state_store_factory=PostgresStateStore,
         )
 
     def _create_runtime_controller(self) -> RuntimeController:

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -104,24 +104,31 @@ async def build_runtime_persistence_stack(
 ) -> RuntimePersistenceStack:
     """Build shared storage and persistence components for a runtime."""
     storage = create_storage_backend(config, loader=storage_loader)
-    state_store = await create_state_store(
-        config.state_store,
-        resolve_env=resolve_env,
-        state_store_factory=state_store_factory,
-        missing_dsn_message=missing_dsn_message,
-    )
-    event_store = create_event_store(
-        state_store,
-        unavailable_warning=event_store_unavailable_warning,
-    )
-    repository = create_repository(
-        state_store=state_store,
-        event_store=event_store,
-        config=config,
-    )
-    return RuntimePersistenceStack(
-        storage=storage,
-        state_store=state_store,
-        event_store=event_store,
-        repository=repository,
-    )
+    state_store: StateStore | None = None
+    try:
+        state_store = await create_state_store(
+            config.state_store,
+            resolve_env=resolve_env,
+            state_store_factory=state_store_factory,
+            missing_dsn_message=missing_dsn_message,
+        )
+        event_store = create_event_store(
+            state_store,
+            unavailable_warning=event_store_unavailable_warning,
+        )
+        repository = create_repository(
+            state_store=state_store,
+            event_store=event_store,
+            config=config,
+        )
+        return RuntimePersistenceStack(
+            storage=storage,
+            state_store=state_store,
+            event_store=event_store,
+            repository=repository,
+        )
+    except Exception:
+        if state_store is not None:
+            await state_store.shutdown()
+        await storage.shutdown()
+        raise

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -1,0 +1,127 @@
+"""Shared runtime bootstrap helpers for storage and persistence wiring."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
+
+from homesec.interfaces import EventStore
+from homesec.plugins.storage import load_storage_plugin
+from homesec.repository import ClipRepository
+from homesec.state import NoopEventStore, PostgresStateStore
+
+if TYPE_CHECKING:
+    from homesec.interfaces import StateStore, StorageBackend
+    from homesec.models.config import Config, StateStoreConfig, StorageConfig
+
+logger = logging.getLogger(__name__)
+
+
+class _InitializableStateStore(Protocol):
+    """State store contract needed during runtime bootstrap."""
+
+    async def initialize(self) -> bool:
+        """Initialize backing resources."""
+
+    def create_event_store(self) -> EventStore:
+        """Create associated event store."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimePersistenceStack:
+    """Shared storage and persistence components for runtime wiring."""
+
+    storage: StorageBackend
+    state_store: StateStore
+    event_store: EventStore
+    repository: ClipRepository
+
+
+def create_storage_backend(
+    config: Config,
+    *,
+    loader: Callable[[StorageConfig], StorageBackend] = load_storage_plugin,
+) -> StorageBackend:
+    """Create the configured storage backend."""
+    return loader(config.storage)
+
+
+async def create_state_store(
+    config: StateStoreConfig,
+    *,
+    resolve_env: Callable[[str], str | None],
+    state_store_factory: Callable[[str], _InitializableStateStore] = PostgresStateStore,
+    missing_dsn_message: str,
+) -> StateStore:
+    """Create and initialize the configured state store."""
+    dsn = config.dsn
+    if config.dsn_env:
+        dsn = resolve_env(config.dsn_env)
+    if not dsn:
+        raise RuntimeError(missing_dsn_message)
+
+    store = state_store_factory(dsn)
+    await store.initialize()
+    return cast("StateStore", store)
+
+
+def create_event_store(
+    state_store: StateStore,
+    *,
+    unavailable_warning: str,
+) -> EventStore:
+    """Create event store from state store and warn when events are unavailable."""
+    event_store = state_store.create_event_store()
+    if isinstance(event_store, NoopEventStore):
+        logger.warning(unavailable_warning)
+    return event_store
+
+
+def create_repository(
+    *,
+    state_store: StateStore,
+    event_store: EventStore,
+    config: Config,
+) -> ClipRepository:
+    """Create repository over the configured state and event stores."""
+    return ClipRepository(
+        state_store,
+        event_store,
+        retry=config.retry,
+    )
+
+
+async def build_runtime_persistence_stack(
+    config: Config,
+    *,
+    resolve_env: Callable[[str], str | None],
+    missing_dsn_message: str,
+    event_store_unavailable_warning: str,
+    storage_loader: Callable[[StorageConfig], StorageBackend] = load_storage_plugin,
+    state_store_factory: Callable[[str], _InitializableStateStore] = PostgresStateStore,
+) -> RuntimePersistenceStack:
+    """Build shared storage and persistence components for a runtime."""
+    storage = create_storage_backend(config, loader=storage_loader)
+    state_store = await create_state_store(
+        config.state_store,
+        resolve_env=resolve_env,
+        state_store_factory=state_store_factory,
+        missing_dsn_message=missing_dsn_message,
+    )
+    event_store = create_event_store(
+        state_store,
+        unavailable_warning=event_store_unavailable_warning,
+    )
+    repository = create_repository(
+        state_store=state_store,
+        event_store=event_store,
+        config=config,
+    )
+    return RuntimePersistenceStack(
+        storage=storage,
+        state_store=state_store,
+        event_store=event_store,
+        repository=repository,
+    )

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -39,7 +39,7 @@ class RuntimePersistenceStack:
     repository: ClipRepository
 
 
-def create_storage_backend(
+def _create_storage_backend(
     config: Config,
     *,
     loader: Callable[[StorageConfig], StorageBackend] = load_storage_plugin,
@@ -48,7 +48,7 @@ def create_storage_backend(
     return loader(config.storage)
 
 
-async def create_state_store(
+async def _create_state_store(
     config: StateStoreConfig,
     *,
     resolve_env: Callable[[str], str | None],
@@ -67,7 +67,7 @@ async def create_state_store(
     return cast("StateStore", store)
 
 
-def create_event_store(
+def _create_event_store(
     state_store: StateStore,
     *,
     unavailable_warning: str,
@@ -79,7 +79,7 @@ def create_event_store(
     return event_store
 
 
-def create_repository(
+def _create_repository(
     *,
     state_store: StateStore,
     event_store: EventStore,
@@ -99,24 +99,27 @@ async def build_runtime_persistence_stack(
     resolve_env: Callable[[str], str | None],
     missing_dsn_message: str,
     event_store_unavailable_warning: str,
-    storage_loader: Callable[[StorageConfig], StorageBackend] = load_storage_plugin,
-    state_store_factory: Callable[[str], _InitializableStateStore] = PostgresStateStore,
+    storage_loader: Callable[[StorageConfig], StorageBackend] | None = None,
+    state_store_factory: Callable[[str], _InitializableStateStore] | None = None,
 ) -> RuntimePersistenceStack:
     """Build shared storage and persistence components for a runtime."""
-    storage = create_storage_backend(config, loader=storage_loader)
+    loader = load_storage_plugin if storage_loader is None else storage_loader
+    factory = PostgresStateStore if state_store_factory is None else state_store_factory
+
+    storage = _create_storage_backend(config, loader=loader)
     state_store: StateStore | None = None
     try:
-        state_store = await create_state_store(
+        state_store = await _create_state_store(
             config.state_store,
             resolve_env=resolve_env,
-            state_store_factory=state_store_factory,
+            state_store_factory=factory,
             missing_dsn_message=missing_dsn_message,
         )
-        event_store = create_event_store(
+        event_store = _create_event_store(
             state_store,
             unavailable_warning=event_store_unavailable_warning,
         )
-        repository = create_repository(
+        repository = _create_repository(
             state_store=state_store,
             event_store=event_store,
             config=config,

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -129,6 +129,17 @@ async def build_runtime_persistence_stack(
         )
     except Exception:
         if state_store is not None:
-            await state_store.shutdown()
-        await storage.shutdown()
+            await _safe_shutdown(state_store, label="state store")
+        await _safe_shutdown(storage, label="storage backend")
         raise
+
+
+async def _safe_shutdown(component: object, *, label: str) -> None:
+    """Best-effort shutdown for partially built bootstrap components."""
+    shutdown = getattr(component, "shutdown", None)
+    if shutdown is None:
+        return
+    try:
+        await shutdown()
+    except Exception as exc:
+        logger.warning("Failed to shut down partial %s during bootstrap cleanup: %s", label, exc)

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -42,7 +42,7 @@ class RuntimePersistenceStack:
 def _create_storage_backend(
     config: Config,
     *,
-    loader: Callable[[StorageConfig], StorageBackend] = load_storage_plugin,
+    loader: Callable[[StorageConfig], StorageBackend],
 ) -> StorageBackend:
     """Create the configured storage backend."""
     return loader(config.storage)
@@ -52,7 +52,7 @@ async def _create_state_store(
     config: StateStoreConfig,
     *,
     resolve_env: Callable[[str], str | None],
-    state_store_factory: Callable[[str], _InitializableStateStore] = PostgresStateStore,
+    state_store_factory: Callable[[str], _InitializableStateStore],
     missing_dsn_message: str,
 ) -> StateStore:
     """Create and initialize the configured state store."""

--- a/src/homesec/runtime/errors.py
+++ b/src/homesec/runtime/errors.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 
+def sanitize_runtime_error(exc: Exception, *, max_length: int = 512) -> str:
+    """Return a bounded runtime error message for status surfaces."""
+    value = str(exc).strip()
+    if not value:
+        value = type(exc).__name__
+    return value[:max_length]
+
+
 class RuntimeReloadConfigError(RuntimeError):
     """Raised when reload request config cannot be used."""
 

--- a/src/homesec/runtime/manager.py
+++ b/src/homesec/runtime/manager.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from homesec.runtime.controller import RuntimeController
+from homesec.runtime.errors import sanitize_runtime_error
 from homesec.runtime.models import (
     ManagedRuntime,
     RuntimeReloadRequest,
@@ -81,7 +82,7 @@ class RuntimeManager:
         except Exception as exc:
             await self._safe_shutdown(candidate, context="initial runtime cleanup")
             self._status.state = RuntimeState.FAILED
-            self._status.last_reload_error = self._sanitize_error(exc)
+            self._status.last_reload_error = sanitize_runtime_error(exc)
             self._status.last_reload_at = self._now_utc()
             raise
 
@@ -96,7 +97,7 @@ class RuntimeManager:
                 self._on_runtime_activated(candidate)
             except Exception as exc:
                 await self._safe_shutdown(candidate, context="initial runtime activation cleanup")
-                error = self._sanitize_error(exc)
+                error = sanitize_runtime_error(exc)
                 self._rollback_to_previous_runtime(
                     old_runtime=None,
                     old_generation=0,
@@ -211,7 +212,7 @@ class RuntimeManager:
         except Exception as exc:
             if candidate is not None:
                 await self._safe_shutdown(candidate, context="failed candidate runtime cleanup")
-            error = self._sanitize_error(exc)
+            error = sanitize_runtime_error(exc)
             self._rollback_to_previous_runtime(
                 old_runtime=old_runtime,
                 old_generation=old_generation,
@@ -234,7 +235,7 @@ class RuntimeManager:
             try:
                 self._on_runtime_activated(candidate)
             except Exception as exc:
-                error = self._sanitize_error(exc)
+                error = sanitize_runtime_error(exc)
                 await self._safe_shutdown(candidate, context="failed candidate runtime cleanup")
                 self._rollback_to_previous_runtime(
                     old_runtime=old_runtime,
@@ -277,13 +278,6 @@ class RuntimeManager:
         self._status.active_config_version = old_config_version
         self._status.last_reload_error = error
         self._status.last_reload_at = self._now_utc()
-
-    @staticmethod
-    def _sanitize_error(exc: Exception) -> str:
-        value = str(exc).strip()
-        if not value:
-            value = type(exc).__name__
-        return value[:512]
 
     @staticmethod
     def _now_utc() -> datetime:

--- a/src/homesec/runtime/subprocess_controller.py
+++ b/src/homesec/runtime/subprocess_controller.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from homesec.runtime.controller import RuntimeController
+from homesec.runtime.errors import sanitize_runtime_error
 from homesec.runtime.models import ManagedRuntime, RuntimeCameraStatus, config_signature
 from homesec.runtime.subprocess_protocol import WorkerEvent, WorkerEventType
 
@@ -189,12 +190,12 @@ class SubprocessRuntimeController(RuntimeController):
                 try:
                     await self._spawn_and_wait_started(previous)
                 except Exception as rollback_exc:
-                    previous.last_error = self._sanitize_error(rollback_exc)
+                    previous.last_error = sanitize_runtime_error(rollback_exc)
                     await self._finalize_handle(previous)
                     self._active_runtime = None
                     raise RuntimeError(
                         "Runtime candidate start failed and rollback failed: "
-                        f"{self._sanitize_error(rollback_exc)}"
+                        f"{sanitize_runtime_error(rollback_exc)}"
                     ) from exc
                 self._active_runtime = previous
             raise
@@ -222,7 +223,7 @@ class SubprocessRuntimeController(RuntimeController):
                     context="shutdown-all",
                 )
             except Exception as exc:
-                errors.append(f"generation={handle.generation} error={self._sanitize_error(exc)}")
+                errors.append(f"generation={handle.generation} error={sanitize_runtime_error(exc)}")
 
         self._active_runtime = None
         if errors:
@@ -475,13 +476,6 @@ class SubprocessRuntimeController(RuntimeController):
     def _drain_queue(queue: asyncio.Queue[WorkerEvent]) -> None:
         while not queue.empty():
             queue.get_nowait()
-
-    @staticmethod
-    def _sanitize_error(exc: Exception) -> str:
-        value = str(exc).strip()
-        if not value:
-            value = type(exc).__name__
-        return value[:512]
 
     def _track_handle(self, handle: SubprocessRuntimeHandle) -> None:
         self._tracked_handles[id(handle)] = handle

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -24,13 +24,18 @@ from homesec.plugins.sources import load_source_plugin
 from homesec.plugins.storage import load_storage_plugin
 from homesec.repository import ClipRepository
 from homesec.runtime.assembly import RuntimeAssembler
+from homesec.runtime.bootstrap import (
+    RuntimePersistenceStack,
+    build_runtime_persistence_stack,
+)
+from homesec.runtime.errors import sanitize_runtime_error
 from homesec.runtime.models import RuntimeBundle
 from homesec.runtime.subprocess_protocol import (
     WorkerCameraStatusPayload,
     WorkerEvent,
     WorkerEventType,
 )
-from homesec.state import NoopEventStore, PostgresStateStore
+from homesec.state import PostgresStateStore
 
 if TYPE_CHECKING:
     from homesec.interfaces import (
@@ -106,17 +111,13 @@ class _RuntimeWorkerService:
         try:
             discover_all_plugins()
 
-            storage = load_storage_plugin(self._config.storage)
-            self._storage = storage
-            self._state_store = await self._create_state_store(self._config)
-            self._event_store = self._create_event_store(self._state_store)
-            self._repository = ClipRepository(
-                self._state_store,
-                self._event_store,
-                retry=self._config.retry,
-            )
+            persistence = await self._build_runtime_persistence_stack()
+            self._storage = persistence.storage
+            self._state_store = persistence.state_store
+            self._event_store = persistence.event_store
+            self._repository = persistence.repository
             self._assembler = RuntimeAssembler(
-                storage=storage,
+                storage=persistence.storage,
                 repository=self._repository,
                 notifier_factory=self._create_notifier,
                 notifier_health_logger=self._log_notifier_health,
@@ -150,7 +151,7 @@ class _RuntimeWorkerService:
     def emit_error(self, exc: Exception) -> None:
         self._emit_event(
             WorkerEventType.ERROR,
-            message=self._sanitize_error(exc),
+            message=sanitize_runtime_error(exc),
         )
 
     async def _heartbeat_loop(self, stop_event: asyncio.Event) -> None:
@@ -177,24 +178,18 @@ class _RuntimeWorkerService:
             await self._storage.shutdown()
             self._storage = None
 
-    async def _create_state_store(self, config: Config) -> StateStore:
-        state_cfg = config.state_store
-        dsn = state_cfg.dsn
-        if state_cfg.dsn_env:
-            dsn = resolve_env_var(state_cfg.dsn_env)
-        if not dsn:
-            raise RuntimeError("Postgres DSN is required for runtime worker state_store backend")
-        store = PostgresStateStore(dsn)
-        await store.initialize()
-        return store
-
-    def _create_event_store(self, state_store: StateStore) -> EventStore:
-        event_store = state_store.create_event_store()
-        if isinstance(event_store, NoopEventStore):
-            logger.warning(
+    async def _build_runtime_persistence_stack(self) -> RuntimePersistenceStack:
+        """Build shared storage and persistence components for the worker runtime."""
+        return await build_runtime_persistence_stack(
+            self._config,
+            resolve_env=resolve_env_var,
+            missing_dsn_message=("Postgres DSN is required for runtime worker state_store backend"),
+            event_store_unavailable_warning=(
                 "Runtime worker event store unavailable (NoopEventStore returned); events dropped"
-            )
-        return event_store
+            ),
+            storage_loader=load_storage_plugin,
+            state_store_factory=PostgresStateStore,
+        )
 
     def _create_notifier(self, config: Config) -> tuple[Notifier, list[NotifierEntry]]:
         entries: list[NotifierEntry] = []
@@ -298,13 +293,6 @@ class _RuntimeWorkerService:
                 )
 
         return statuses
-
-    @staticmethod
-    def _sanitize_error(exc: Exception) -> str:
-        value = str(exc).strip()
-        if not value:
-            value = type(exc).__name__
-        return value[:512]
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -21,8 +21,6 @@ from homesec.plugins import discover_all_plugins
 from homesec.plugins.alert_policies import load_alert_policy
 from homesec.plugins.notifiers import load_notifier_plugin
 from homesec.plugins.sources import load_source_plugin
-from homesec.plugins.storage import load_storage_plugin
-from homesec.repository import ClipRepository
 from homesec.runtime.assembly import RuntimeAssembler
 from homesec.runtime.bootstrap import (
     RuntimePersistenceStack,
@@ -35,7 +33,6 @@ from homesec.runtime.subprocess_protocol import (
     WorkerEvent,
     WorkerEventType,
 )
-from homesec.state import PostgresStateStore
 
 if TYPE_CHECKING:
     from homesec.interfaces import (
@@ -46,6 +43,7 @@ if TYPE_CHECKING:
         StorageBackend,
     )
     from homesec.models.config import Config
+    from homesec.repository import ClipRepository
 
 logger = logging.getLogger(__name__)
 
@@ -187,8 +185,6 @@ class _RuntimeWorkerService:
             event_store_unavailable_warning=(
                 "Runtime worker event store unavailable (NoopEventStore returned); events dropped"
             ),
-            storage_loader=load_storage_plugin,
-            state_store_factory=PostgresStateStore,
         )
 
     def _create_notifier(self, config: Config) -> tuple[Notifier, list[NotifierEntry]]:

--- a/tests/homesec/test_app.py
+++ b/tests/homesec/test_app.py
@@ -503,8 +503,10 @@ async def test_application_run_enters_bootstrap_mode_when_config_missing(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_create_state_store_prefers_env_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_create_state_store should resolve DSN from dsn_env when configured."""
+async def test_build_runtime_persistence_stack_prefers_env_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared runtime bootstrap should resolve DSN from dsn_env when configured."""
     # Given: State store config with both inline DSN and dsn_env override
     config = _make_config([NotifierConfig(backend="mqtt", config={"host": "localhost"})])
     config.state_store = StateStoreConfig(
@@ -521,33 +523,43 @@ async def test_create_state_store_prefers_env_dsn(monkeypatch: pytest.MonkeyPatc
             created["initialized"] = True
             return True
 
+        async def ping(self) -> bool:
+            return True
+
+        def create_event_store(self) -> object:
+            from homesec.state import NoopEventStore
+
+            return NoopEventStore()
+
     app = Application(config_path=Path(__file__))
     monkeypatch.setattr("homesec.app.resolve_env_var", lambda _: "postgresql://from-env")
     monkeypatch.setattr("homesec.app.PostgresStateStore", _RecordingStateStore)
+    monkeypatch.setattr("homesec.app.load_storage_plugin", lambda cfg: _StubStorage(cfg))
 
-    # When: Creating the state store
-    store = await app._create_state_store(config)
+    # When: Building shared runtime persistence
+    persistence = await app._build_runtime_persistence_stack(config)
 
     # Then: The environment DSN is used and initialization is awaited
     assert created["dsn"] == "postgresql://from-env"
     assert created["initialized"] is True
-    assert isinstance(store, _RecordingStateStore)
+    assert isinstance(persistence.state_store, _RecordingStateStore)
 
 
 @pytest.mark.asyncio
-async def test_create_state_store_raises_when_env_resolution_returns_empty(
+async def test_build_runtime_persistence_stack_raises_when_env_resolution_returns_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_create_state_store should fail fast when env DSN resolution yields no value."""
+    """Shared runtime bootstrap should fail fast when env DSN resolution yields no value."""
     # Given: State store config that relies on env resolution for DSN
     config = _make_config([NotifierConfig(backend="mqtt", config={"host": "localhost"})])
     config.state_store = StateStoreConfig(dsn="postgresql://ignored-inline", dsn_env="HOMESEC_DSN")
     app = Application(config_path=Path(__file__))
     monkeypatch.setattr("homesec.app.resolve_env_var", lambda _: "")
+    monkeypatch.setattr("homesec.app.load_storage_plugin", lambda cfg: _StubStorage(cfg))
 
-    # When: Creating the state store without DSN
+    # When: Building shared runtime persistence without a resolved DSN
     with pytest.raises(RuntimeError, match="Postgres DSN is required"):
-        await app._create_state_store(config)
+        await app._build_runtime_persistence_stack(config)
 
 
 def test_get_runtime_status_uses_worker_exit_code_for_stale_runtime() -> None:

--- a/tests/homesec/test_app.py
+++ b/tests/homesec/test_app.py
@@ -190,8 +190,10 @@ def _mock_runtime_environment(monkeypatch: pytest.MonkeyPatch) -> _StubRuntimeCo
     """Mock runtime environment and return controller stub."""
     # Given: Runtime dependencies mocked for deterministic tests
     controller = _StubRuntimeController()
-    monkeypatch.setattr("homesec.app.load_storage_plugin", lambda cfg: _StubStorage(cfg))
-    monkeypatch.setattr("homesec.app.PostgresStateStore", _StubStateStore)
+    monkeypatch.setattr(
+        "homesec.runtime.bootstrap.load_storage_plugin", lambda cfg: _StubStorage(cfg)
+    )
+    monkeypatch.setattr("homesec.runtime.bootstrap.PostgresStateStore", _StubStateStore)
     monkeypatch.setattr("homesec.plugins.discover_all_plugins", lambda: None)
     monkeypatch.setattr("homesec.app.validate_plugin_names", lambda *args, **kwargs: None)
     monkeypatch.setattr("homesec.app.validate_config", lambda *args, **kwargs: None)
@@ -533,8 +535,10 @@ async def test_build_runtime_persistence_stack_prefers_env_dsn(
 
     app = Application(config_path=Path(__file__))
     monkeypatch.setattr("homesec.app.resolve_env_var", lambda _: "postgresql://from-env")
-    monkeypatch.setattr("homesec.app.PostgresStateStore", _RecordingStateStore)
-    monkeypatch.setattr("homesec.app.load_storage_plugin", lambda cfg: _StubStorage(cfg))
+    monkeypatch.setattr("homesec.runtime.bootstrap.PostgresStateStore", _RecordingStateStore)
+    monkeypatch.setattr(
+        "homesec.runtime.bootstrap.load_storage_plugin", lambda cfg: _StubStorage(cfg)
+    )
 
     # When: Building shared runtime persistence
     persistence = await app._build_runtime_persistence_stack(config)
@@ -555,7 +559,9 @@ async def test_build_runtime_persistence_stack_raises_when_env_resolution_return
     config.state_store = StateStoreConfig(dsn="postgresql://ignored-inline", dsn_env="HOMESEC_DSN")
     app = Application(config_path=Path(__file__))
     monkeypatch.setattr("homesec.app.resolve_env_var", lambda _: "")
-    monkeypatch.setattr("homesec.app.load_storage_plugin", lambda cfg: _StubStorage(cfg))
+    monkeypatch.setattr(
+        "homesec.runtime.bootstrap.load_storage_plugin", lambda cfg: _StubStorage(cfg)
+    )
 
     # When: Building shared runtime persistence without a resolved DSN
     with pytest.raises(RuntimeError, match="Postgres DSN is required"):

--- a/tests/homesec/test_runtime_bootstrap.py
+++ b/tests/homesec/test_runtime_bootstrap.py
@@ -118,3 +118,42 @@ async def test_build_runtime_persistence_stack_shuts_down_partial_state_when_eve
     # Then: Both initialized resources are shut down on partial-build failure
     assert store.shutdown_called is True
     assert storage.shutdown_called is True
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_persistence_stack_preserves_primary_failure_when_cleanup_raises() -> (
+    None
+):
+    # Given: Partial-bootstrap cleanup that fails while handling the primary bootstrap error
+    config = _make_config()
+
+    class _FailingStorage:
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+            raise RuntimeError("cleanup failed")
+
+    class _FailingStateStore:
+        def __init__(self, dsn: str) -> None:
+            self.dsn = dsn
+
+        async def initialize(self) -> bool:
+            raise RuntimeError("primary failure")
+
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+        def create_event_store(self) -> object:
+            raise AssertionError("create_event_store should not be reached")
+
+    # When: Building the shared runtime persistence stack
+    with pytest.raises(RuntimeError, match="primary failure"):
+        await build_runtime_persistence_stack(
+            config,
+            resolve_env=lambda env: env,
+            missing_dsn_message="missing dsn",
+            event_store_unavailable_warning="events unavailable",
+            storage_loader=lambda _cfg: _FailingStorage(),
+            state_store_factory=_FailingStateStore,
+        )
+
+    # Then: Cleanup errors do not replace the original bootstrap failure

--- a/tests/homesec/test_runtime_bootstrap.py
+++ b/tests/homesec/test_runtime_bootstrap.py
@@ -1,0 +1,120 @@
+"""Tests for shared runtime bootstrap helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from homesec.models.config import (
+    AlertPolicyConfig,
+    CameraConfig,
+    CameraSourceConfig,
+    Config,
+    StateStoreConfig,
+    StorageConfig,
+)
+from homesec.models.enums import VLMRunMode
+from homesec.models.filter import FilterConfig
+from homesec.models.vlm import VLMConfig
+from homesec.runtime.bootstrap import build_runtime_persistence_stack
+
+
+def _make_config() -> Config:
+    return Config(
+        cameras=[
+            CameraConfig(
+                name="front",
+                source=CameraSourceConfig(backend="local_folder", config={}),
+            )
+        ],
+        storage=StorageConfig(backend="local", config={}),
+        state_store=StateStoreConfig(dsn="postgresql://user:pass@localhost/homesec"),
+        notifiers=[],
+        filter=FilterConfig(backend="yolo", config={}),
+        vlm=VLMConfig(backend="openai", run_mode=VLMRunMode.TRIGGER_ONLY, config={}),
+        alert_policy=AlertPolicyConfig(backend="default", config={}),
+    )
+
+
+class _RecordingStorage:
+    def __init__(self) -> None:
+        self.shutdown_called = False
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        # Given: Bootstrap cleanup calls storage shutdown without depending on timeout
+        _ = timeout
+        self.shutdown_called = True
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_persistence_stack_shuts_down_storage_when_state_init_fails() -> None:
+    # Given: A storage backend created before state-store initialization fails
+    config = _make_config()
+    storage = _RecordingStorage()
+
+    class _FailingStateStore:
+        def __init__(self, dsn: str) -> None:
+            self.dsn = dsn
+
+        async def initialize(self) -> bool:
+            raise RuntimeError("boom")
+
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+        def create_event_store(self) -> object:
+            raise AssertionError("create_event_store should not be reached")
+
+    # When: Building the shared runtime persistence stack
+    with pytest.raises(RuntimeError, match="boom"):
+        await build_runtime_persistence_stack(
+            config,
+            resolve_env=lambda env: env,
+            missing_dsn_message="missing dsn",
+            event_store_unavailable_warning="events unavailable",
+            storage_loader=lambda _cfg: storage,
+            state_store_factory=_FailingStateStore,
+        )
+
+    # Then: Storage is cleaned up even though the worker never captured it
+    assert storage.shutdown_called is True
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_persistence_stack_shuts_down_partial_state_when_event_store_fails() -> (
+    None
+):
+    # Given: A state store initialized successfully but event-store creation raises
+    config = _make_config()
+    storage = _RecordingStorage()
+
+    class _StateStoreWithFailingEvents:
+        def __init__(self, dsn: str) -> None:
+            self.dsn = dsn
+            self.shutdown_called = False
+
+        async def initialize(self) -> bool:
+            return True
+
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+            self.shutdown_called = True
+
+        def create_event_store(self) -> object:
+            raise RuntimeError("event store failed")
+
+    store = _StateStoreWithFailingEvents("unused")
+
+    # When: Building the shared runtime persistence stack
+    with pytest.raises(RuntimeError, match="event store failed"):
+        await build_runtime_persistence_stack(
+            config,
+            resolve_env=lambda env: env,
+            missing_dsn_message="missing dsn",
+            event_store_unavailable_warning="events unavailable",
+            storage_loader=lambda _cfg: storage,
+            state_store_factory=lambda _dsn: store,
+        )
+
+    # Then: Both initialized resources are shut down on partial-build failure
+    assert store.shutdown_called is True
+    assert storage.shutdown_called is True

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -18,8 +18,10 @@ from homesec.models.config import (
     StateStoreConfig,
     StorageConfig,
 )
+from homesec.models.enums import VLMRunMode
 from homesec.models.filter import FilterConfig
 from homesec.models.vlm import VLMConfig
+from homesec.runtime.bootstrap import RuntimePersistenceStack
 
 
 class _StubEmitter:
@@ -30,7 +32,11 @@ class _StubEmitter:
         return None
 
 
-def _make_config(*, notifiers: list[NotifierConfig], run_mode: str = "trigger_only") -> Config:
+def _make_config(
+    *,
+    notifiers: list[NotifierConfig],
+    run_mode: VLMRunMode = VLMRunMode.TRIGGER_ONLY,
+) -> Config:
     return Config(
         cameras=[
             CameraConfig(
@@ -71,7 +77,7 @@ def test_worker_main_uses_shared_logging_configuration(monkeypatch) -> None:
         calls["log_level"] = log_level
         calls["camera_name"] = camera_name
 
-    def _fake_asyncio_run(coro: object) -> None:
+    def _fake_asyncio_run(coro: Any) -> None:
         calls["ran"] = True
         # Avoid un-awaited coroutine warnings in tests.
         coro.close()
@@ -133,7 +139,7 @@ async def test_runtime_worker_run_runtime_skips_analyzer_load_when_run_mode_neve
 ) -> None:
     """run_mode=never should avoid analyzer plugin loading in worker startup."""
     # Given: Runtime worker with VLM disabled and analyzer loader guarded
-    config = _make_config(notifiers=[], run_mode="never")
+    config = _make_config(notifiers=[], run_mode=VLMRunMode.NEVER)
     service = _make_service(config)
     stop_event = asyncio.Event()
     stop_event.set()
@@ -154,13 +160,19 @@ async def test_runtime_worker_run_runtime_skips_analyzer_load_when_run_mode_neve
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
 
-    async def _fake_create_state_store(_config: Config) -> _StubStateStore:
-        return _StubStateStore()
-
     monkeypatch.setattr(worker_module, "discover_all_plugins", lambda: None)
-    monkeypatch.setattr(worker_module, "load_storage_plugin", lambda _cfg: _StubStorage())
-    monkeypatch.setattr(service, "_create_state_store", _fake_create_state_store)
-    monkeypatch.setattr(service, "_create_event_store", lambda _state: _StubEventStore())
+
+    async def _fake_build_runtime_persistence_stack() -> RuntimePersistenceStack:
+        return RuntimePersistenceStack(
+            storage=cast(Any, _StubStorage()),
+            state_store=cast(Any, _StubStateStore()),
+            event_store=cast(Any, _StubEventStore()),
+            repository=cast(Any, object()),
+        )
+
+    monkeypatch.setattr(
+        service, "_build_runtime_persistence_stack", _fake_build_runtime_persistence_stack
+    )
     monkeypatch.setattr(service, "_create_alert_policy", lambda _cfg: cast(Any, object()))
     monkeypatch.setattr(service, "_create_sources", lambda _cfg: ([], {}))
     monkeypatch.setattr("homesec.runtime.assembly.load_filter", lambda _cfg: _StubFilter())


### PR DESCRIPTION
## Summary
- extract shared runtime persistence bootstrap wiring into a shared runtime helper
- route both `Application` and the runtime worker through the same storage/state/event/repository bootstrap path
- dedupe runtime error sanitization and update focused app/worker tests around the new wiring seam

## Why
The main app and runtime worker were each rebuilding the same persistence stack locally. This keeps the existing architecture, but removes the duplicated bootstrap logic so wiring changes land in one place.

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:5432/homesec_bootstrap_ci make check`
