### PR TITLE
refactor: centralize clip status transitions

### DIFF
--- a/src/homesec/repository/clip_repository.py
+++ b/src/homesec/repository/clip_repository.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from homesec.models.clip import Clip, ClipListCursor, ClipListPage, ClipStateData
 from homesec.models.config import RetryConfig
@@ -41,6 +42,52 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TResult = TypeVar("TResult")
+TransitionName = Literal[
+    "upload_completed",
+    "filter_failed",
+    "vlm_completed",
+    "notification_sent",
+    "clip_deleted",
+    "mark_done",
+]
+
+
+@dataclass(frozen=True)
+class _StatusTransition:
+    target: ClipStatus
+    blocked_from: frozenset[ClipStatus] = frozenset()
+
+
+_STATUS_TRANSITIONS: dict[TransitionName, _StatusTransition] = {
+    "upload_completed": _StatusTransition(
+        target=ClipStatus.UPLOADED,
+        blocked_from=frozenset(
+            (
+                ClipStatus.ANALYZED,
+                ClipStatus.DONE,
+                ClipStatus.ERROR,
+                ClipStatus.DELETED,
+            )
+        ),
+    ),
+    "filter_failed": _StatusTransition(
+        target=ClipStatus.ERROR,
+        blocked_from=frozenset((ClipStatus.DELETED,)),
+    ),
+    "vlm_completed": _StatusTransition(
+        target=ClipStatus.ANALYZED,
+        blocked_from=frozenset((ClipStatus.DELETED,)),
+    ),
+    "notification_sent": _StatusTransition(
+        target=ClipStatus.DONE,
+        blocked_from=frozenset((ClipStatus.DELETED,)),
+    ),
+    "clip_deleted": _StatusTransition(target=ClipStatus.DELETED),
+    "mark_done": _StatusTransition(
+        target=ClipStatus.DONE,
+        blocked_from=frozenset((ClipStatus.DONE, ClipStatus.DELETED)),
+    ),
+}
 
 
 class ClipRepository:
@@ -111,13 +158,7 @@ class ClipRepository:
 
         state.storage_uri = storage_uri
         state.view_url = view_url
-        if state.status not in (
-            ClipStatus.ANALYZED,
-            ClipStatus.DONE,
-            ClipStatus.ERROR,
-            ClipStatus.DELETED,
-        ):
-            state.status = ClipStatus.UPLOADED
+        self._apply_status_transition(state, "upload_completed")
 
         event = UploadCompletedEvent(
             clip_id=clip_id,
@@ -219,8 +260,7 @@ class ClipRepository:
         if state is None:
             return None
 
-        if state.status != ClipStatus.DELETED:
-            state.status = ClipStatus.ERROR
+        self._apply_status_transition(state, "filter_failed")
         await self._safe_upsert(clip_id, state)
         return state
 
@@ -249,8 +289,7 @@ class ClipRepository:
             return None
 
         state.analysis_result = result
-        if state.status != ClipStatus.DELETED:
-            state.status = ClipStatus.ANALYZED
+        self._apply_status_transition(state, "vlm_completed")
 
         event = VLMCompletedEvent(
             clip_id=clip_id,
@@ -339,8 +378,7 @@ class ClipRepository:
         if state is None:
             return None
 
-        if state.status != ClipStatus.DELETED:
-            state.status = ClipStatus.DONE
+        self._apply_status_transition(state, "notification_sent")
 
         event = NotificationSentEvent(
             clip_id=clip_id,
@@ -391,7 +429,7 @@ class ClipRepository:
         if state is None:
             return None
 
-        state.status = ClipStatus.DELETED
+        self._apply_status_transition(state, "clip_deleted")
 
         event = ClipDeletedEvent(
             clip_id=clip_id,
@@ -475,10 +513,9 @@ class ClipRepository:
         if state is None:
             return None
 
-        if state.status in (ClipStatus.DONE, ClipStatus.DELETED):
+        if not self._apply_status_transition(state, "mark_done"):
             return state
 
-        state.status = ClipStatus.DONE
         await self._safe_upsert(clip_id, state)
         return state
 
@@ -670,3 +707,11 @@ class ClipRepository:
     @staticmethod
     def _now_utc() -> datetime:
         return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _apply_status_transition(state: ClipStateData, transition_name: TransitionName) -> bool:
+        transition = _STATUS_TRANSITIONS[transition_name]
+        if state.status in transition.blocked_from:
+            return False
+        state.status = transition.target
+        return True

--- a/src/homesec/repository/clip_repository.py
+++ b/src/homesec/repository/clip_repository.py
@@ -460,6 +460,8 @@ class ClipRepository:
         state = await self._load_state(clip_id, action="clip recheck")
         if state is None:
             return None
+        # Rechecks do not change clip status; deleted clips keep their terminal
+        # status and ignore filter_result mutations.
         if state.status == ClipStatus.DELETED:
             return state
 
@@ -710,6 +712,12 @@ class ClipRepository:
 
     @staticmethod
     def _apply_status_transition(state: ClipStateData, transition_name: TransitionName) -> bool:
+        """Apply a declared status transition to mutable clip state in place.
+
+        This helper is intentionally limited to status-to-status transitions.
+        Status-sensitive guards for other state mutations, such as clip recheck
+        behavior, remain local to the calling method.
+        """
         transition = _STATUS_TRANSITIONS[transition_name]
         if state.status in transition.blocked_from:
             return False

--- a/tests/homesec/test_clip_repository.py
+++ b/tests/homesec/test_clip_repository.py
@@ -9,7 +9,7 @@ import pytest
 
 from homesec.models.alert import AlertDecision
 from homesec.models.clip import Clip, ClipStateData
-from homesec.models.enums import RiskLevel
+from homesec.models.enums import ClipStatus, RiskLevel
 from homesec.models.events import ClipRecheckedEvent
 from homesec.models.filter import FilterResult
 from homesec.models.vlm import (
@@ -19,6 +19,14 @@ from homesec.models.vlm import (
 from homesec.repository import ClipRepository
 from homesec.state.postgres import PostgresEventStore, PostgresStateStore
 from tests.homesec.mocks import MockEventStore, MockStateStore
+
+
+def _build_state(*, status: ClipStatus) -> ClipStateData:
+    return ClipStateData(
+        camera_name="front_door",
+        status=status,
+        local_path="/tmp/test.mp4",
+    )
 
 
 @pytest.mark.asyncio
@@ -392,6 +400,193 @@ async def test_record_notification_sent(
 
     # Cleanup
     await state_store.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_status", "expected_status"),
+    [
+        (ClipStatus.QUEUED_LOCAL, ClipStatus.UPLOADED),
+        (ClipStatus.ANALYZED, ClipStatus.ANALYZED),
+        (ClipStatus.DONE, ClipStatus.DONE),
+        (ClipStatus.ERROR, ClipStatus.ERROR),
+        (ClipStatus.DELETED, ClipStatus.DELETED),
+    ],
+)
+async def test_record_upload_completed_applies_explicit_status_transition_rules(
+    initial_status: ClipStatus,
+    expected_status: ClipStatus,
+) -> None:
+    # Given: A repository with a clip already in a known status
+    state_store = MockStateStore()
+    event_store = MockEventStore()
+    repository = ClipRepository(state_store, event_store)
+    clip_id = f"upload-{initial_status.value}"
+    await state_store.upsert(clip_id, _build_state(status=initial_status))
+
+    # When: Upload completion is recorded
+    state = await repository.record_upload_completed(
+        clip_id,
+        "dropbox://test.mp4",
+        "https://example.com/test.mp4",
+        5000,
+    )
+
+    # Then: The centralized transition rule preserves the existing semantics
+    assert state is not None
+    assert state.status == expected_status
+    persisted = await state_store.get(clip_id)
+    assert persisted is not None
+    assert persisted.status == expected_status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_status", "will_retry", "expected_status"),
+    [
+        (ClipStatus.QUEUED_LOCAL, False, ClipStatus.ERROR),
+        (ClipStatus.DELETED, False, ClipStatus.DELETED),
+        (ClipStatus.UPLOADED, True, ClipStatus.UPLOADED),
+    ],
+)
+async def test_record_filter_failed_applies_explicit_status_transition_rules(
+    initial_status: ClipStatus,
+    will_retry: bool,
+    expected_status: ClipStatus,
+) -> None:
+    # Given: A repository with a clip already in a known status
+    state_store = MockStateStore()
+    event_store = MockEventStore()
+    repository = ClipRepository(state_store, event_store)
+    clip_id = f"filter-failed-{initial_status.value}-{will_retry}"
+    await state_store.upsert(clip_id, _build_state(status=initial_status))
+
+    # When: A filter failure is recorded
+    state = await repository.record_filter_failed(
+        clip_id,
+        "boom",
+        "RuntimeError",
+        will_retry=will_retry,
+    )
+
+    # Then: The centralized transition rule preserves the existing semantics
+    if will_retry:
+        assert state is None
+    else:
+        assert state is not None
+        assert state.status == expected_status
+    persisted = await state_store.get(clip_id)
+    assert persisted is not None
+    assert persisted.status == expected_status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_status", "expected_status"),
+    [
+        (ClipStatus.UPLOADED, ClipStatus.ANALYZED),
+        (ClipStatus.ERROR, ClipStatus.ANALYZED),
+        (ClipStatus.DELETED, ClipStatus.DELETED),
+    ],
+)
+async def test_record_vlm_completed_applies_explicit_status_transition_rules(
+    initial_status: ClipStatus,
+    expected_status: ClipStatus,
+) -> None:
+    # Given: A repository with a clip already in a known status
+    state_store = MockStateStore()
+    event_store = MockEventStore()
+    repository = ClipRepository(state_store, event_store)
+    clip_id = f"vlm-{initial_status.value}"
+    await state_store.upsert(clip_id, _build_state(status=initial_status))
+    result = AnalysisResult(
+        risk_level="low",
+        activity_type="person_walking",
+        summary="Person walking past camera",
+        analysis=SequenceAnalysis(
+            sequence_description="Person walks by",
+            primary_activity="passerby",
+            max_risk_level="low",
+            entities_timeline=[],
+            observations=[],
+            requires_review=False,
+            frame_count=10,
+            video_start_time="00:00:00",
+            video_end_time="00:00:10",
+        ),
+    )
+
+    # When: VLM completion is recorded
+    state = await repository.record_vlm_completed(clip_id, result, 100, 50, 1000)
+
+    # Then: The centralized transition rule preserves the existing semantics
+    assert state is not None
+    assert state.status == expected_status
+    persisted = await state_store.get(clip_id)
+    assert persisted is not None
+    assert persisted.status == expected_status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_status", "expected_status"),
+    [
+        (ClipStatus.ANALYZED, ClipStatus.DONE),
+        (ClipStatus.ERROR, ClipStatus.DONE),
+        (ClipStatus.DELETED, ClipStatus.DELETED),
+    ],
+)
+async def test_record_notification_sent_applies_explicit_status_transition_rules(
+    initial_status: ClipStatus,
+    expected_status: ClipStatus,
+) -> None:
+    # Given: A repository with a clip already in a known status
+    state_store = MockStateStore()
+    event_store = MockEventStore()
+    repository = ClipRepository(state_store, event_store)
+    clip_id = f"notify-{initial_status.value}"
+    await state_store.upsert(clip_id, _build_state(status=initial_status))
+
+    # When: Notification delivery is recorded
+    state = await repository.record_notification_sent(clip_id, "mqtt", clip_id)
+
+    # Then: The centralized transition rule preserves the existing semantics
+    assert state is not None
+    assert state.status == expected_status
+    persisted = await state_store.get(clip_id)
+    assert persisted is not None
+    assert persisted.status == expected_status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_status", "expected_status"),
+    [
+        (ClipStatus.ANALYZED, ClipStatus.DONE),
+        (ClipStatus.DONE, ClipStatus.DONE),
+        (ClipStatus.DELETED, ClipStatus.DELETED),
+    ],
+)
+async def test_mark_done_applies_explicit_status_transition_rules(
+    initial_status: ClipStatus,
+    expected_status: ClipStatus,
+) -> None:
+    # Given: A repository with a clip already in a known status
+    state_store = MockStateStore()
+    event_store = MockEventStore()
+    repository = ClipRepository(state_store, event_store)
+    clip_id = f"done-{initial_status.value}"
+    await state_store.upsert(clip_id, _build_state(status=initial_status))
+
+    # When: Completion is recorded without an event
+    state = await repository.mark_done(clip_id)
+
+    # Then: The centralized transition rule preserves the existing semantics
+    assert state is not None
+    assert state.status == expected_status
+    persisted = await state_store.get(clip_id)
+    assert persisted is not None
+    assert persisted.status == expected_status
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/test_clip_repository.py
+++ b/tests/homesec/test_clip_repository.py
@@ -407,6 +407,7 @@ async def test_record_notification_sent(
     ("initial_status", "expected_status"),
     [
         (ClipStatus.QUEUED_LOCAL, ClipStatus.UPLOADED),
+        (ClipStatus.UPLOADED, ClipStatus.UPLOADED),
         (ClipStatus.ANALYZED, ClipStatus.ANALYZED),
         (ClipStatus.DONE, ClipStatus.DONE),
         (ClipStatus.ERROR, ClipStatus.ERROR),
@@ -556,6 +557,35 @@ async def test_record_notification_sent_applies_explicit_status_transition_rules
     persisted = await state_store.get(clip_id)
     assert persisted is not None
     assert persisted.status == expected_status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial_status", list(ClipStatus))
+async def test_record_clip_deleted_applies_explicit_status_transition_rules(
+    initial_status: ClipStatus,
+) -> None:
+    # Given: A repository with a clip already in a known status
+    state_store = MockStateStore()
+    event_store = MockEventStore()
+    repository = ClipRepository(state_store, event_store)
+    clip_id = f"delete-{initial_status.value}"
+    await state_store.upsert(clip_id, _build_state(status=initial_status))
+
+    # When: Clip deletion is recorded
+    state = await repository.record_clip_deleted(
+        clip_id,
+        reason="cleanup",
+        run_id="run-123",
+        deleted_local=True,
+        deleted_storage=True,
+    )
+
+    # Then: Delete always wins regardless of the prior status
+    assert state is not None
+    assert state.status == ClipStatus.DELETED
+    persisted = await state_store.get(clip_id)
+    assert persisted is not None
+    assert persisted.status == ClipStatus.DELETED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- centralize clip status transition rules inside ClipRepository
- route the guarded status updates through one helper instead of scattered conditionals
- add focused repository tests that lock in the current transition semantics

## Validation
- TEST_DB_DSN=postgresql://homesec:homesec@localhost:5432/homesec_state_machine_ci make check