### PR TITLE
refactor: narrow api route dependency surfaces

### DIFF
--- a/src/homesec/api/dependencies.py
+++ b/src/homesec/api/dependencies.py
@@ -236,7 +236,12 @@ class StatsRoutesApp(Protocol):
     def uptime_seconds(self) -> float: ...
 
 
-def _get_database_probe_cache(app: object) -> _DatabaseProbeCache:
+def _get_database_probe_cache(app: DatabaseDependencyApp) -> _DatabaseProbeCache:
+    """Return the per-app cache used to throttle repository ping checks.
+
+    The cache is attached dynamically because these dependency helpers operate on
+    protocol-typed app surfaces rather than a concrete Application subclass.
+    """
     cache = cast(_DatabaseProbeCache | None, getattr(app, "_db_probe_cache", None))
     if cache is None:
         cache = _DatabaseProbeCache()

--- a/src/homesec/api/dependencies.py
+++ b/src/homesec/api/dependencies.py
@@ -6,8 +6,11 @@ import asyncio
 import logging
 import secrets
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from fastapi import Depends, Query, Request, status
 
@@ -17,6 +20,10 @@ from homesec.models.config import FastAPIServerConfig
 
 if TYPE_CHECKING:
     from homesec.app import Application
+    from homesec.models.clip import ClipListCursor, ClipListPage, ClipStateData
+    from homesec.models.config import Config
+    from homesec.models.enums import ClipStatus
+    from homesec.runtime.models import RuntimeReloadRequest, RuntimeStatusSnapshot
 
 DB_PING_CACHE_TTL_S = 0.5
 logger = logging.getLogger(__name__)
@@ -29,7 +36,207 @@ class _DatabaseProbeCache:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
-def _get_database_probe_cache(app: Application) -> _DatabaseProbeCache:
+class CameraStatusReadable(Protocol):
+    """Minimal camera/source health view needed by API routes."""
+
+    def is_healthy(self) -> bool: ...
+
+    def last_heartbeat(self) -> float | None: ...
+
+
+class AuthDependencyApp(Protocol):
+    """App surface required by auth dependencies."""
+
+    @property
+    def server_config(self) -> FastAPIServerConfig: ...
+
+
+class ModeDependencyApp(Protocol):
+    """App surface required by mode-gating dependencies."""
+
+    @property
+    def bootstrap_mode(self) -> bool: ...
+
+
+class DatabaseDependencyApp(ModeDependencyApp, Protocol):
+    """App surface required by database availability checks."""
+
+    @property
+    def repository(self) -> RepositoryPingReadable: ...
+
+
+class RepositoryPingReadable(Protocol):
+    """Repository surface needed for availability checks."""
+
+    async def ping(self) -> bool: ...
+
+
+class CameraMutationResultReadable(Protocol):
+    """Config mutation result surface consumed by camera routes."""
+
+    restart_required: bool
+
+
+class CameraConfigManagerReadable(Protocol):
+    """Config-manager surface consumed by camera routes."""
+
+    def get_config(self) -> Config: ...
+
+    async def add_camera(
+        self,
+        *,
+        name: str,
+        enabled: bool,
+        source_backend: str,
+        source_config: dict[str, object],
+    ) -> CameraMutationResultReadable: ...
+
+    async def update_camera(
+        self,
+        *,
+        camera_name: str,
+        enabled: bool | None,
+        source_backend: str | None,
+        source_config: dict[str, object] | None,
+    ) -> CameraMutationResultReadable: ...
+
+    async def remove_camera(self, *, camera_name: str) -> CameraMutationResultReadable: ...
+
+
+class ConfigReader(Protocol):
+    """Config-reader surface consumed by read-only routes."""
+
+    def get_config(self) -> Config: ...
+
+
+class ClipRoutesRepository(Protocol):
+    """Repository surface consumed by clip routes."""
+
+    async def list_clips(
+        self,
+        *,
+        camera: str | None = None,
+        status: ClipStatus | None = None,
+        alerted: bool | None = None,
+        detected: bool | None = None,
+        risk_level: str | None = None,
+        activity_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        cursor: ClipListCursor | None = None,
+        limit: int = 50,
+    ) -> ClipListPage: ...
+
+    async def get_clip(self, clip_id: str) -> ClipStateData | None: ...
+
+    async def delete_clip(self, clip_id: str) -> ClipStateData: ...
+
+
+class StatsRoutesRepository(Protocol):
+    """Repository surface consumed by stats routes."""
+
+    async def count_clips_since(self, since: datetime) -> int: ...
+
+    async def count_alerts_since(self, since: datetime) -> int: ...
+
+
+class StoragePingReadable(Protocol):
+    """Storage surface needed for diagnostics."""
+
+    async def ping(self) -> bool: ...
+
+
+class ClipMediaStorage(Protocol):
+    """Storage surface consumed by clip/media routes."""
+
+    async def get(self, storage_uri: str, local_path: Path) -> None: ...
+
+    async def delete(self, storage_uri: str) -> None: ...
+
+
+class CameraRoutesApp(Protocol):
+    """App surface consumed by camera CRUD routes."""
+
+    @property
+    def config_manager(self) -> CameraConfigManagerReadable: ...
+
+    def get_source(self, camera_name: str) -> CameraStatusReadable | None: ...
+
+    async def request_runtime_reload(self) -> RuntimeReloadRequest: ...
+
+
+class ClipRoutesApp(Protocol):
+    """App surface consumed by clip browsing/media-token routes."""
+
+    @property
+    def repository(self) -> ClipRoutesRepository: ...
+
+    @property
+    def storage(self) -> ClipMediaStorage: ...
+
+    @property
+    def server_config(self) -> FastAPIServerConfig: ...
+
+
+class ConfigRoutesApp(Protocol):
+    """App surface consumed by config routes."""
+
+    @property
+    def config_manager(self) -> ConfigReader: ...
+
+
+class RuntimeRoutesApp(Protocol):
+    """App surface consumed by runtime control routes."""
+
+    def get_runtime_status(self) -> RuntimeStatusSnapshot: ...
+
+    async def request_runtime_reload(self) -> RuntimeReloadRequest: ...
+
+
+class HealthRoutesApp(Protocol):
+    """App surface consumed by health and diagnostics routes."""
+
+    @property
+    def bootstrap_mode(self) -> bool: ...
+
+    @property
+    def pipeline_running(self) -> bool: ...
+
+    @property
+    def repository(self) -> RepositoryPingReadable: ...
+
+    @property
+    def storage(self) -> StoragePingReadable: ...
+
+    @property
+    def config(self) -> Config: ...
+
+    @property
+    def sources(self) -> Sequence[CameraStatusReadable]: ...
+
+    def get_source(self, camera_name: str) -> CameraStatusReadable | None: ...
+
+    @property
+    def uptime_seconds(self) -> float: ...
+
+
+class StatsRoutesApp(Protocol):
+    """App surface consumed by stats routes."""
+
+    @property
+    def repository(self) -> StatsRoutesRepository: ...
+
+    @property
+    def config(self) -> Config: ...
+
+    @property
+    def sources(self) -> Sequence[CameraStatusReadable]: ...
+
+    @property
+    def uptime_seconds(self) -> float: ...
+
+
+def _get_database_probe_cache(app: object) -> _DatabaseProbeCache:
     cache = cast(_DatabaseProbeCache | None, getattr(app, "_db_probe_cache", None))
     if cache is None:
         cache = _DatabaseProbeCache()
@@ -49,7 +256,73 @@ async def get_homesec_app(request: Request) -> Application:
     return app
 
 
-async def verify_api_key(request: Request, app: Application = Depends(get_homesec_app)) -> None:
+async def get_auth_dependency_app(
+    app: Application = Depends(get_homesec_app),
+) -> AuthDependencyApp:
+    """Return the minimal app surface needed by auth guards."""
+    return app
+
+
+async def get_mode_dependency_app(
+    app: Application = Depends(get_homesec_app),
+) -> ModeDependencyApp:
+    """Return the minimal app surface needed by mode guards."""
+    return app
+
+
+async def get_database_dependency_app(
+    app: Application = Depends(get_homesec_app),
+) -> DatabaseDependencyApp:
+    """Return the minimal app surface needed by DB availability guards."""
+    return app
+
+
+async def get_camera_routes_app(
+    app: Application = Depends(get_homesec_app),
+) -> CameraRoutesApp:
+    """Return the minimal app surface needed by camera routes."""
+    return app
+
+
+async def get_clip_routes_app(
+    app: Application = Depends(get_homesec_app),
+) -> ClipRoutesApp:
+    """Return the minimal app surface needed by clip/media routes."""
+    return app
+
+
+async def get_config_routes_app(
+    app: Application = Depends(get_homesec_app),
+) -> ConfigRoutesApp:
+    """Return the minimal app surface needed by config routes."""
+    return app
+
+
+async def get_runtime_routes_app(
+    app: Application = Depends(get_homesec_app),
+) -> RuntimeRoutesApp:
+    """Return the minimal app surface needed by runtime routes."""
+    return app
+
+
+async def get_health_routes_app(
+    app: Application = Depends(get_homesec_app),
+) -> HealthRoutesApp:
+    """Return the minimal app surface needed by health routes."""
+    return app
+
+
+async def get_stats_routes_app(
+    app: Application = Depends(get_homesec_app),
+) -> StatsRoutesApp:
+    """Return the minimal app surface needed by stats routes."""
+    return app
+
+
+async def verify_api_key(
+    request: Request,
+    app: AuthDependencyApp = Depends(get_auth_dependency_app),
+) -> None:
     """Verify API key if authentication is enabled."""
     server_config = _get_server_config(app)
     if not server_config.auth_enabled:
@@ -77,7 +350,7 @@ async def verify_media_access(
     request: Request,
     clip_id: str,
     token: str | None = Query(default=None),
-    app: Application = Depends(get_homesec_app),
+    app: AuthDependencyApp = Depends(get_auth_dependency_app),
 ) -> None:
     """Authorize media playback requests with API key or short-lived media token."""
     server_config = _get_server_config(app)
@@ -115,7 +388,9 @@ async def verify_media_access(
         ) from exc
 
 
-async def require_database(app: Application = Depends(get_homesec_app)) -> None:
+async def require_database(
+    app: DatabaseDependencyApp = Depends(get_database_dependency_app),
+) -> None:
     """Ensure the database is reachable for data endpoints."""
     # Defense in depth: most DB-backed routes are also guarded by require_normal_mode,
     # but this keeps DB-only routes safe if they are ever added without that dependency.
@@ -144,7 +419,7 @@ async def require_database(app: Application = Depends(get_homesec_app)) -> None:
         )
 
 
-async def require_normal_mode(app: Application = Depends(get_homesec_app)) -> None:
+async def require_normal_mode(app: ModeDependencyApp = Depends(get_mode_dependency_app)) -> None:
     """Ensure runtime-dependent routes are unavailable in bootstrap mode."""
     if not _is_bootstrap_mode(app):
         return
@@ -155,7 +430,7 @@ async def require_normal_mode(app: Application = Depends(get_homesec_app)) -> No
     )
 
 
-async def require_bootstrap_mode(app: Application = Depends(get_homesec_app)) -> None:
+async def require_bootstrap_mode(app: ModeDependencyApp = Depends(get_mode_dependency_app)) -> None:
     """Ensure setup-finalize route is only available during bootstrap mode."""
     if _is_bootstrap_mode(app):
         return
@@ -166,15 +441,15 @@ async def require_bootstrap_mode(app: Application = Depends(get_homesec_app)) ->
     )
 
 
-def _get_server_config(app: Application) -> FastAPIServerConfig:
+def _get_server_config(app: AuthDependencyApp) -> FastAPIServerConfig:
     return app.server_config
 
 
-def _is_bootstrap_mode(app: Application) -> bool:
+def _is_bootstrap_mode(app: ModeDependencyApp) -> bool:
     return bool(app.bootstrap_mode)
 
 
-def _require_api_key_value(app: Application) -> str:
+def _require_api_key_value(app: AuthDependencyApp) -> str:
     api_key = _get_server_config(app).get_api_key()
     if not api_key:
         raise APIError(

--- a/src/homesec/api/routes/cameras.py
+++ b/src/homesec/api/routes/cameras.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
 
-from homesec.api.dependencies import get_homesec_app
+from homesec.api.dependencies import CameraRoutesApp, get_camera_routes_app
 from homesec.api.errors import APIError, APIErrorCode
 from homesec.api.redaction import redact_config
 from homesec.config.errors import (
@@ -19,9 +19,6 @@ from homesec.config.errors import (
 )
 from homesec.models.config import CameraConfig
 from homesec.runtime.errors import RuntimeReloadConfigError
-
-if TYPE_CHECKING:
-    from homesec.app import Application
 
 router = APIRouter(tags=["cameras"])
 
@@ -67,7 +64,7 @@ def _source_config_to_dict(camera: CameraConfig) -> dict[str, object]:
     return dict(config)
 
 
-def _camera_response(app: Application, camera: CameraConfig) -> CameraResponse:
+def _camera_response(app: CameraRoutesApp, camera: CameraConfig) -> CameraResponse:
     source = app.get_source(camera.name)
     if camera.enabled and source is not None:
         healthy = source.is_healthy()
@@ -119,7 +116,7 @@ def _map_camera_config_error(exc: CameraMutationError) -> APIError:
 async def _reload_runtime_if_requested(
     *,
     apply_changes: bool,
-    app: Application,
+    app: CameraRoutesApp,
 ) -> RuntimeReloadResponse | None:
     if not apply_changes:
         return None
@@ -149,14 +146,19 @@ async def _reload_runtime_if_requested(
 
 
 @router.get("/api/v1/cameras", response_model=list[CameraResponse])
-async def list_cameras(app: Application = Depends(get_homesec_app)) -> list[CameraResponse]:
+async def list_cameras(
+    app: CameraRoutesApp = Depends(get_camera_routes_app),
+) -> list[CameraResponse]:
     """List all cameras."""
     config = await asyncio.to_thread(app.config_manager.get_config)
     return [_camera_response(app, camera) for camera in config.cameras]
 
 
 @router.get("/api/v1/cameras/{name}", response_model=CameraResponse)
-async def get_camera(name: str, app: Application = Depends(get_homesec_app)) -> CameraResponse:
+async def get_camera(
+    name: str,
+    app: CameraRoutesApp = Depends(get_camera_routes_app),
+) -> CameraResponse:
     """Get a single camera."""
     config = await asyncio.to_thread(app.config_manager.get_config)
     camera = next((cam for cam in config.cameras if cam.name == name), None)
@@ -173,7 +175,7 @@ async def get_camera(name: str, app: Application = Depends(get_homesec_app)) -> 
 async def create_camera(
     payload: CameraCreate,
     apply_changes: bool = False,
-    app: Application = Depends(get_homesec_app),
+    app: CameraRoutesApp = Depends(get_camera_routes_app),
 ) -> ConfigChangeResponse:
     """Create a new camera."""
     try:
@@ -201,7 +203,7 @@ async def update_camera(
     name: str,
     payload: CameraUpdate,
     apply_changes: bool = False,
-    app: Application = Depends(get_homesec_app),
+    app: CameraRoutesApp = Depends(get_camera_routes_app),
 ) -> ConfigChangeResponse:
     """Partially update a camera."""
     try:
@@ -235,7 +237,7 @@ async def update_camera(
 async def delete_camera(
     name: str,
     apply_changes: bool = False,
-    app: Application = Depends(get_homesec_app),
+    app: CameraRoutesApp = Depends(get_camera_routes_app),
 ) -> ConfigChangeResponse:
     """Delete a camera."""
     try:

--- a/src/homesec/api/routes/clips.py
+++ b/src/homesec/api/routes/clips.py
@@ -4,19 +4,15 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
 from urllib.parse import quote, urlencode
 
 from fastapi import APIRouter, Depends, Query, status
 from pydantic import BaseModel, Field
 
-from homesec.api.dependencies import get_homesec_app
+from homesec.api.dependencies import ClipRoutesApp, get_clip_routes_app
 from homesec.api.errors import APIError, APIErrorCode
 from homesec.api.media_tokens import issue_clip_media_token
 from homesec.api.pagination import CursorDecodeError, decode_clip_cursor, encode_clip_cursor
-
-if TYPE_CHECKING:
-    from homesec.app import Application
 from homesec.models.clip import ClipStateData
 from homesec.models.enums import ClipStatus
 
@@ -91,7 +87,7 @@ async def list_clips(
     until: datetime | None = None,
     limit: int = Query(50, ge=1, le=100),
     cursor: str | None = None,
-    app: Application = Depends(get_homesec_app),
+    app: ClipRoutesApp = Depends(get_clip_routes_app),
 ) -> ClipListResponse:
     """List clips with filtering and keyset pagination."""
 
@@ -139,7 +135,10 @@ async def list_clips(
 
 
 @router.get("/api/v1/clips/{clip_id}", response_model=ClipResponse)
-async def get_clip(clip_id: str, app: Application = Depends(get_homesec_app)) -> ClipResponse:
+async def get_clip(
+    clip_id: str,
+    app: ClipRoutesApp = Depends(get_clip_routes_app),
+) -> ClipResponse:
     """Get a single clip."""
     state = await app.repository.get_clip(clip_id)
     if state is None:
@@ -154,7 +153,7 @@ async def get_clip(clip_id: str, app: Application = Depends(get_homesec_app)) ->
 @router.post("/api/v1/clips/{clip_id}/media-token", response_model=ClipMediaTokenResponse)
 async def create_clip_media_token(
     clip_id: str,
-    app: Application = Depends(get_homesec_app),
+    app: ClipRoutesApp = Depends(get_clip_routes_app),
 ) -> ClipMediaTokenResponse:
     """Create media playback URL.
 
@@ -197,7 +196,10 @@ async def create_clip_media_token(
 
 
 @router.delete("/api/v1/clips/{clip_id}", response_model=ClipResponse)
-async def delete_clip(clip_id: str, app: Application = Depends(get_homesec_app)) -> ClipResponse:
+async def delete_clip(
+    clip_id: str,
+    app: ClipRoutesApp = Depends(get_clip_routes_app),
+) -> ClipResponse:
     """Delete a clip and its storage object."""
     state = await app.repository.get_clip(clip_id)
     if state is None:

--- a/src/homesec/api/routes/config.py
+++ b/src/homesec/api/routes/config.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from homesec.api.dependencies import get_homesec_app
+from homesec.api.dependencies import ConfigRoutesApp, get_config_routes_app
 from homesec.api.redaction import is_sensitive_key, redact_config, redact_url_credentials
-
-if TYPE_CHECKING:
-    from homesec.app import Application
 
 router = APIRouter(tags=["config"])
 
@@ -30,7 +26,7 @@ _redact_config = redact_config
 
 
 @router.get("/api/v1/config", response_model=ConfigResponse)
-async def get_config(app: Application = Depends(get_homesec_app)) -> ConfigResponse:
+async def get_config(app: ConfigRoutesApp = Depends(get_config_routes_app)) -> ConfigResponse:
     """Return full configuration."""
     config = await asyncio.to_thread(app.config_manager.get_config)
     payload = config.model_dump(mode="json")

--- a/src/homesec/api/routes/health.py
+++ b/src/homesec/api/routes/health.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from homesec.api.dependencies import get_homesec_app, require_normal_mode, verify_api_key
-
-if TYPE_CHECKING:
-    from homesec.app import Application
+from homesec.api.dependencies import (
+    HealthRoutesApp,
+    get_health_routes_app,
+    require_normal_mode,
+    verify_api_key,
+)
 
 router = APIRouter(tags=["health"])
 
@@ -47,7 +49,7 @@ class DiagnosticsResponse(BaseModel):
 
 
 async def _compute_health_response(
-    app: Application,
+    app: HealthRoutesApp,
 ) -> HealthResponse | JSONResponse:
     """Compute shared health payload for public and versioned health endpoints."""
     if app.bootstrap_mode:
@@ -85,14 +87,16 @@ async def _compute_health_response(
 
 @router.get("/health", response_model=HealthResponse, include_in_schema=False)
 async def get_root_health(
-    app: Application = Depends(get_homesec_app),
+    app: HealthRoutesApp = Depends(get_health_routes_app),
 ) -> HealthResponse | JSONResponse:
     """Public liveness/readiness health check for ops probes."""
     return await _compute_health_response(app)
 
 
 @router.get("/api/v1/health", response_model=HealthResponse)
-async def get_health(app: Application = Depends(get_homesec_app)) -> HealthResponse | JSONResponse:
+async def get_health(
+    app: HealthRoutesApp = Depends(get_health_routes_app),
+) -> HealthResponse | JSONResponse:
     """Versioned health check endpoint."""
     return await _compute_health_response(app)
 
@@ -102,7 +106,9 @@ async def get_health(app: Application = Depends(get_homesec_app)) -> HealthRespo
     response_model=DiagnosticsResponse,
     dependencies=[Depends(verify_api_key), Depends(require_normal_mode)],
 )
-async def get_diagnostics(app: Application = Depends(get_homesec_app)) -> DiagnosticsResponse:
+async def get_diagnostics(
+    app: HealthRoutesApp = Depends(get_health_routes_app),
+) -> DiagnosticsResponse:
     """Detailed component diagnostics."""
     pipeline_running = app.pipeline_running
 

--- a/src/homesec/api/routes/media.py
+++ b/src/homesec/api/routes/media.py
@@ -7,24 +7,23 @@ import mimetypes
 import shutil
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import FileResponse
 from starlette.background import BackgroundTask
 
-from homesec.api.dependencies import get_homesec_app
+from homesec.api.dependencies import ClipRoutesApp, get_clip_routes_app
 from homesec.api.errors import APIError, APIErrorCode
-
-if TYPE_CHECKING:
-    from homesec.app import Application
 
 router = APIRouter(tags=["clips"])
 logger = logging.getLogger(__name__)
 
 
 @router.get("/api/v1/clips/{clip_id}/media")
-async def get_clip_media(clip_id: str, app: Application = Depends(get_homesec_app)) -> FileResponse:
+async def get_clip_media(
+    clip_id: str,
+    app: ClipRoutesApp = Depends(get_clip_routes_app),
+) -> FileResponse:
     """Stream clip media through HomeSec for in-app playback."""
     state = await app.repository.get_clip(clip_id)
     if state is None:

--- a/src/homesec/api/routes/runtime.py
+++ b/src/homesec/api/routes/runtime.py
@@ -3,18 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
 
-from homesec.api.dependencies import get_homesec_app
+from homesec.api.dependencies import RuntimeRoutesApp, get_runtime_routes_app
 from homesec.api.errors import APIError, APIErrorCode
 from homesec.runtime.errors import RuntimeReloadConfigError
 from homesec.runtime.models import RuntimeState
-
-if TYPE_CHECKING:
-    from homesec.app import Application
 
 router = APIRouter(tags=["runtime"])
 
@@ -35,7 +31,9 @@ class RuntimeReloadResponse(BaseModel):
 
 
 @router.get("/api/v1/runtime/status", response_model=RuntimeStatusResponse)
-async def get_runtime_status(app: Application = Depends(get_homesec_app)) -> RuntimeStatusResponse:
+async def get_runtime_status(
+    app: RuntimeRoutesApp = Depends(get_runtime_routes_app),
+) -> RuntimeStatusResponse:
     """Return runtime-manager status."""
     status = app.get_runtime_status()
     return RuntimeStatusResponse(
@@ -50,7 +48,7 @@ async def get_runtime_status(app: Application = Depends(get_homesec_app)) -> Run
 
 @router.post("/api/v1/runtime/reload", response_model=RuntimeReloadResponse, status_code=202)
 async def reload_runtime(
-    app: Application = Depends(get_homesec_app),
+    app: RuntimeRoutesApp = Depends(get_runtime_routes_app),
 ) -> RuntimeReloadResponse:
     """Trigger runtime reload and return async acceptance outcome."""
     try:

--- a/src/homesec/api/routes/stats.py
+++ b/src/homesec/api/routes/stats.py
@@ -3,15 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from homesec.api.dependencies import get_homesec_app
-
-if TYPE_CHECKING:
-    from homesec.app import Application
+from homesec.api.dependencies import StatsRoutesApp, get_stats_routes_app
 
 router = APIRouter(tags=["stats"])
 
@@ -25,7 +21,7 @@ class StatsResponse(BaseModel):
 
 
 @router.get("/api/v1/stats", response_model=StatsResponse)
-async def get_stats(app: Application = Depends(get_homesec_app)) -> StatsResponse:
+async def get_stats(app: StatsRoutesApp = Depends(get_stats_routes_app)) -> StatsResponse:
     """Return system statistics."""
     today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
     clips_today = await app.repository.count_clips_since(today_start)

--- a/tests/homesec/test_api_dependencies.py
+++ b/tests/homesec/test_api_dependencies.py
@@ -1,0 +1,112 @@
+"""Tests for API dependency helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from starlette.requests import Request
+
+from homesec.api.dependencies import require_database, require_normal_mode, verify_api_key
+from homesec.api.errors import APIError
+from homesec.models.config import FastAPIServerConfig
+
+
+class _StubRepository:
+    def __init__(self, *, ok: bool) -> None:
+        self._ok = ok
+        self.ping_calls = 0
+
+    async def ping(self) -> bool:
+        self.ping_calls += 1
+        return self._ok
+
+
+@dataclass
+class _MinimalDatabaseApp:
+    bootstrap_mode: bool
+    repository: _StubRepository
+
+
+@dataclass
+class _MinimalModeApp:
+    bootstrap_mode: bool
+
+
+@dataclass
+class _MinimalAuthApp:
+    server_config: FastAPIServerConfig
+
+
+def _request_with_bearer(token: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_require_database_accepts_minimal_protocol_app() -> None:
+    """require_database should only need bootstrap flag plus repository ping."""
+    # Given: A minimal app-shaped object with bootstrap flag and repository
+    repository = _StubRepository(ok=True)
+    app = _MinimalDatabaseApp(bootstrap_mode=False, repository=repository)
+
+    # When: Enforcing database availability
+    await require_database(app)
+
+    # Then: The repository ping succeeds without needing a full Application
+    assert repository.ping_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_require_normal_mode_accepts_minimal_protocol_app() -> None:
+    """require_normal_mode should only need the bootstrap flag."""
+    # Given: A minimal app-shaped object in normal mode
+    app = _MinimalModeApp(bootstrap_mode=False)
+
+    # When: Enforcing normal runtime mode
+    await require_normal_mode(app)
+
+    # Then: No error is raised without any wider Application surface
+
+
+@pytest.mark.asyncio
+async def test_verify_api_key_accepts_minimal_auth_protocol_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """verify_api_key should only require server_config plus request headers."""
+    # Given: A minimal app-shaped object exposing only server_config
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret-key")
+    app = _MinimalAuthApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    request = _request_with_bearer("secret-key")
+
+    # When: Verifying the request API key
+    await verify_api_key(request, app)
+
+    # Then: Auth succeeds without needing a full Application
+
+
+@pytest.mark.asyncio
+async def test_verify_api_key_rejects_invalid_token_with_minimal_auth_protocol_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """verify_api_key should still reject invalid bearer tokens."""
+    # Given: A minimal auth app with a configured API key and wrong bearer token
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret-key")
+    app = _MinimalAuthApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    request = _request_with_bearer("wrong-key")
+
+    # When: Verifying the request API key
+    with pytest.raises(APIError) as exc_info:
+        await verify_api_key(request, app)
+
+    # Then: The helper returns the canonical unauthorized API error
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.error_code == "UNAUTHORIZED"

--- a/tests/homesec/test_api_dependencies.py
+++ b/tests/homesec/test_api_dependencies.py
@@ -62,6 +62,23 @@ async def test_require_database_accepts_minimal_protocol_app() -> None:
 
 
 @pytest.mark.asyncio
+async def test_require_database_short_circuits_in_bootstrap_mode() -> None:
+    """require_database should reject bootstrap mode without probing the DB."""
+    # Given: A minimal app-shaped object in bootstrap mode with a repository stub
+    repository = _StubRepository(ok=True)
+    app = _MinimalDatabaseApp(bootstrap_mode=True, repository=repository)
+
+    # When: Enforcing database availability during bootstrap mode
+    with pytest.raises(APIError) as exc_info:
+        await require_database(app)
+
+    # Then: The route is rejected before repository.ping is called
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.error_code == "SETUP_REQUIRED"
+    assert repository.ping_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_require_normal_mode_accepts_minimal_protocol_app() -> None:
     """require_normal_mode should only need the bootstrap flag."""
     # Given: A minimal app-shaped object in normal mode


### PR DESCRIPTION
## Summary
- narrow API route dependencies from broad `Application` typing to route-specific protocol surfaces
- move auth, mode, and database guards onto smaller protocol-based app dependencies
- add focused dependency tests for minimal protocol-shaped app objects

## Testing
- TEST_DB_DSN=postgresql://homesec:homesec@localhost:5432/homesec_api_deps_ci make check