### PR TITLE
refactor: move setup probes beside backends

### DIFF
--- a/src/homesec/onvif/setup_probe.py
+++ b/src/homesec/onvif/setup_probe.py
@@ -5,26 +5,42 @@ from __future__ import annotations
 import logging
 import time
 
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 from homesec.models.setup import TestConnectionResponse
 from homesec.onvif.client import OnvifCameraClient
 from homesec.onvif.discovery import discover_cameras
 from homesec.onvif.service import (
+    DEFAULT_ONVIF_PORT,
     OnvifProbeError,
     OnvifProbeOptions,
     OnvifProbeTimeoutError,
     OnvifService,
 )
 from homesec.services.setup_probe_support import (
-    ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S,
-    OnvifSetupProbeConfig,
     build_test_connection_response,
     format_validation_error,
 )
 from homesec.services.setup_probes import setup_probe
 
 logger = logging.getLogger(__name__)
+
+ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S = 30.0
+ONVIF_TEST_CONNECTION_TIMEOUT_S = 15.0
+
+
+class OnvifSetupProbeConfig(BaseModel):
+    """Validated payload for setup-time ONVIF connectivity probes."""
+
+    host: str = Field(min_length=1)
+    username: str = Field(min_length=1)
+    password: str = Field(min_length=1)
+    port: int = Field(default=DEFAULT_ONVIF_PORT, ge=1, le=65535)
+    timeout_s: float = Field(
+        default=ONVIF_TEST_CONNECTION_TIMEOUT_S,
+        gt=0.0,
+        le=ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S,
+    )
 
 
 @setup_probe("camera", "onvif", timeout_s=ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S + 1.0)

--- a/src/homesec/onvif/setup_probe.py
+++ b/src/homesec/onvif/setup_probe.py
@@ -1,0 +1,83 @@
+"""Setup-only ONVIF connectivity probe."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from pydantic import ValidationError
+
+from homesec.models.setup import TestConnectionResponse
+from homesec.onvif.client import OnvifCameraClient
+from homesec.onvif.discovery import discover_cameras
+from homesec.onvif.service import (
+    OnvifProbeError,
+    OnvifProbeOptions,
+    OnvifProbeTimeoutError,
+    OnvifService,
+)
+from homesec.services.setup_probe_support import (
+    ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S,
+    OnvifSetupProbeConfig,
+    build_test_connection_response,
+    format_validation_error,
+)
+from homesec.services.setup_probes import setup_probe
+
+logger = logging.getLogger(__name__)
+
+
+@setup_probe("camera", "onvif", timeout_s=ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S + 1.0)
+async def test_onvif_camera_connection(
+    *,
+    config: dict[str, object],
+) -> TestConnectionResponse:
+    """Validate ONVIF probe settings and fetch stream/profile metadata."""
+    start = time.perf_counter()
+    try:
+        request = OnvifSetupProbeConfig.model_validate(config)
+    except ValidationError as exc:
+        return build_test_connection_response(
+            success=False,
+            message=format_validation_error(exc),
+            start=start,
+        )
+
+    service = OnvifService(
+        discover_fn=discover_cameras,
+        client_factory=OnvifCameraClient,
+    )
+    timeout_s = request.timeout_s
+    try:
+        probe_result = await service.probe(
+            OnvifProbeOptions(
+                host=request.host,
+                username=request.username,
+                password=request.password,
+                port=int(request.port),
+                timeout_s=timeout_s,
+            )
+        )
+    except OnvifProbeTimeoutError:
+        return build_test_connection_response(
+            success=False,
+            message=f"ONVIF probe timed out after {timeout_s:.1f}s.",
+            start=start,
+        )
+    except OnvifProbeError:
+        logger.warning("ONVIF setup test probe failed", exc_info=True)
+        return build_test_connection_response(
+            success=False,
+            message="ONVIF probe failed. Check host, credentials, and camera reachability.",
+            start=start,
+        )
+
+    return build_test_connection_response(
+        success=True,
+        message="ONVIF probe succeeded.",
+        start=start,
+        details={
+            "profiles": len(probe_result.profiles),
+            "streams": len(probe_result.streams),
+        },
+    )

--- a/src/homesec/plugins/storage/local_setup_probe.py
+++ b/src/homesec/plugins/storage/local_setup_probe.py
@@ -15,9 +15,18 @@ from homesec.plugins.storage.local import LocalStorageConfig
 from homesec.services.setup_probe_support import (
     build_test_connection_response,
     format_validation_error,
-    nearest_existing_parent,
 )
 from homesec.services.setup_probes import setup_probe
+
+
+def nearest_existing_parent(path: Path) -> Path | None:
+    """Return the closest existing ancestor for a path, if any."""
+    current = path
+    while not current.exists():
+        if current == current.parent:
+            return None
+        current = current.parent
+    return current
 
 
 @setup_probe("storage", "local")

--- a/src/homesec/plugins/storage/local_setup_probe.py
+++ b/src/homesec/plugins/storage/local_setup_probe.py
@@ -1,0 +1,83 @@
+"""Setup-only local storage connectivity probe."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from homesec.models.setup import TestConnectionResponse
+from homesec.plugins.registry import PluginType, validate_plugin
+from homesec.plugins.storage.local import LocalStorageConfig
+from homesec.services.setup_probe_support import (
+    build_test_connection_response,
+    format_validation_error,
+    nearest_existing_parent,
+)
+from homesec.services.setup_probes import setup_probe
+
+
+@setup_probe("storage", "local")
+async def test_local_storage_connection(*, config: dict[str, object]) -> TestConnectionResponse:
+    """Validate local storage config and confirm the target path is usable."""
+    start = time.perf_counter()
+    try:
+        validated = validate_plugin(PluginType.STORAGE, "local", config)
+    except ValidationError as exc:
+        return build_test_connection_response(
+            success=False,
+            message=format_validation_error(exc),
+            start=start,
+        )
+
+    if not isinstance(validated, LocalStorageConfig):
+        return build_test_connection_response(
+            success=False,
+            message=f"Unexpected local storage config model: {type(validated).__name__}",
+            start=start,
+        )
+
+    root = Path(validated.root).expanduser()
+    if await asyncio.to_thread(root.exists):
+        if not await asyncio.to_thread(root.is_dir):
+            return build_test_connection_response(
+                success=False,
+                message=f"Storage root is not a directory: {root}",
+                start=start,
+            )
+        if not await asyncio.to_thread(os.access, root, os.R_OK | os.W_OK | os.X_OK):
+            return build_test_connection_response(
+                success=False,
+                message=f"Storage root is not readable/writable: {root}",
+                start=start,
+            )
+        resolved_root = await asyncio.to_thread(root.resolve)
+        return build_test_connection_response(
+            success=True,
+            message="Local storage root is accessible.",
+            start=start,
+            details={"root": str(resolved_root)},
+        )
+
+    parent = await asyncio.to_thread(nearest_existing_parent, root)
+    if parent is None:
+        return build_test_connection_response(
+            success=False,
+            message=f"No existing parent directory for storage root: {root}",
+            start=start,
+        )
+    if not await asyncio.to_thread(os.access, parent, os.W_OK | os.X_OK):
+        return build_test_connection_response(
+            success=False,
+            message=f"Storage root parent is not writable: {parent}",
+            start=start,
+        )
+    return build_test_connection_response(
+        success=True,
+        message="Local storage root can be created.",
+        start=start,
+        details={"root": str(root), "writable_parent": str(parent)},
+    )

--- a/src/homesec/services/AGENTS.md
+++ b/src/homesec/services/AGENTS.md
@@ -1,0 +1,21 @@
+# Services Development Notes
+
+## Setup Probes
+
+Setup probes validate backend connectivity during onboarding. Each probe lives beside its backend:
+
+| Backend | Probe module |
+|---------|-------------|
+| RTSP | `sources/rtsp/setup_probe.py` |
+| FTP | `sources/ftp_setup_probe.py` |
+| Local folder | `sources/local_folder_setup_probe.py` |
+| ONVIF | `onvif/setup_probe.py` |
+| Local storage | `plugins/storage/local_setup_probe.py` |
+
+**Registry:** `services/setup_probes.py` — contains `SetupProbeRegistry`, the `@setup_probe` decorator, and `_BUILTIN_SETUP_PROBE_MODULES` manifest.
+
+**Adding a new probe:** Create a module beside the backend, decorate with `@setup_probe(target, backend)`, add the module path to `_BUILTIN_SETUP_PROBE_MODULES` in `setup_probes.py`.
+
+**Shared helpers:** `services/setup_probe_support.py` has `build_test_connection_response`, `format_validation_error`, and `SETUP_TEST_CAMERA_NAME`. Domain-specific helpers (timeout constants, config models, URL resolvers) live in the probe module that uses them.
+
+**Testing:** Patch the probe module directly (e.g., `rtsp_setup_probe.validate_plugin`), not `setup_service`. See `tests/homesec/test_setup_test_connection_service.py`.

--- a/src/homesec/services/setup.py
+++ b/src/homesec/services/setup.py
@@ -6,13 +6,12 @@ import asyncio
 import logging
 import os
 import socket
-import tempfile
 import time
 from collections.abc import Awaitable
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import ValidationError
 
 from homesec.config.loader import ConfigError, ConfigErrorCode
 from homesec.models.config import (
@@ -35,29 +34,17 @@ from homesec.models.setup import (
     TestConnectionResponse,
 )
 from homesec.models.vlm import VLMConfig
-from homesec.onvif.client import OnvifCameraClient
-from homesec.onvif.discovery import discover_cameras
-from homesec.onvif.service import (
-    DEFAULT_ONVIF_PORT,
-    OnvifProbeError,
-    OnvifProbeOptions,
-    OnvifProbeTimeoutError,
-    OnvifService,
-)
 from homesec.plugins.registry import PluginType, get_plugin_names, load_plugin, validate_plugin
-from homesec.plugins.storage.local import LocalStorageConfig
+from homesec.services.setup_probe_support import (
+    build_test_connection_response,
+    format_validation_error,
+)
 from homesec.services.setup_probes import (
     SetupProbeTarget,
     get_setup_probe,
     get_setup_probe_backends,
     get_setup_probe_timeout,
-    setup_probe,
 )
-from homesec.sources.ftp import FtpSourceConfig
-from homesec.sources.local_folder import LocalFolderSourceConfig
-from homesec.sources.rtsp.core import RTSPSourceConfig
-from homesec.sources.rtsp.preflight import PreflightError, RTSPStartupPreflight
-from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 from homesec.state.postgres import PostgresStateStore
 
 if TYPE_CHECKING:
@@ -72,13 +59,7 @@ _NETWORK_PROBE_PORT_ENV = "HOMESEC_SETUP_NETWORK_PROBE_PORT"
 _NETWORK_PROBE_DEFAULT_HOST = "example.com"
 _NETWORK_PROBE_DEFAULT_PORT = 443
 _PREFLIGHT_CHECK_TIMEOUT_S = 10.0
-_ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S = 30.0
-_RTSP_TEST_CONNECTION_TIMEOUT_S = 10.0
-_RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S = 8.0
-_FTP_TEST_CONNECTION_TIMEOUT_S = 5.0
-_ONVIF_TEST_CONNECTION_TIMEOUT_S = 15.0
 _PLUGIN_TEST_CONNECTION_TIMEOUT_S = 5.0
-_SETUP_TEST_CAMERA_NAME = "setup-test-camera"
 SectionT = TypeVar("SectionT")
 
 
@@ -108,18 +89,6 @@ class _PingablePlugin(Protocol):
     async def ping(self) -> bool: ...
 
     async def shutdown(self, timeout: float | None = None) -> None: ...
-
-
-class _OnvifTestConnectionConfig(BaseModel):
-    host: str = Field(min_length=1)
-    username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
-    port: int = Field(default=DEFAULT_ONVIF_PORT, ge=1, le=65535)
-    timeout_s: float = Field(
-        default=_ONVIF_TEST_CONNECTION_TIMEOUT_S,
-        gt=0.0,
-        le=_ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S,
-    )
 
 
 async def get_setup_status(app: Application) -> SetupStatusResponse:
@@ -198,17 +167,9 @@ async def _test_camera_connection(
         )
 
     match backend:
-        case "rtsp":
-            return await _test_rtsp_camera_connection(config=config)
-        case "ftp":
-            return await _test_ftp_camera_connection(config=config)
-        case "local_folder":
-            return await _test_local_folder_camera_connection(config=config)
-        case "onvif":
-            return await _test_onvif_camera_connection(config=config)
         case _:
             # Defensive fallback for known-but-not-yet-probed camera source plugins.
-            return _result(
+            return build_test_connection_response(
                 success=False,
                 message=f"Camera backend {backend!r} does not implement connection testing yet.",
             )
@@ -261,329 +222,6 @@ async def _test_analyzer_connection(
     )
 
 
-@setup_probe("camera", "rtsp", timeout_s=_RTSP_TEST_CONNECTION_TIMEOUT_S + 1.0)
-async def _test_rtsp_camera_connection(
-    *,
-    config: dict[str, object],
-) -> TestConnectionResponse:
-    start = time.perf_counter()
-    try:
-        validated = validate_plugin(
-            PluginType.SOURCE,
-            "rtsp",
-            config,
-            camera_name=_SETUP_TEST_CAMERA_NAME,
-        )
-    except ValidationError as exc:
-        return _result(
-            success=False,
-            message=_format_validation_error(exc),
-            start=start,
-        )
-
-    if not isinstance(validated, RTSPSourceConfig):
-        return _result(
-            success=False,
-            message=f"Unexpected rtsp config model: {type(validated).__name__}",
-            start=start,
-        )
-
-    primary_url = _resolve_rtsp_primary_url(validated)
-    if not primary_url:
-        return _result(
-            success=False,
-            message="RTSP URL not resolved. Provide rtsp_url or set rtsp_url_env.",
-            start=start,
-        )
-    detect_url = _resolve_rtsp_detect_url(validated, primary_url)
-
-    with tempfile.TemporaryDirectory(prefix="homesec-rtsp-probe-") as temp_dir:
-        preflight = RTSPStartupPreflight(
-            output_dir=Path(temp_dir),
-            rtsp_connect_timeout_s=float(validated.stream.connect_timeout_s),
-            rtsp_io_timeout_s=float(validated.stream.io_timeout_s),
-            # Keep ffmpeg command execution bounded tighter than full request timeout.
-            command_timeout_s=min(
-                _RTSP_TEST_CONNECTION_TIMEOUT_S,
-                _RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S,
-            ),
-        )
-        try:
-            outcome = await asyncio.wait_for(
-                asyncio.to_thread(
-                    preflight.run,
-                    camera_name=validated.camera_name or _SETUP_TEST_CAMERA_NAME,
-                    primary_rtsp_url=primary_url,
-                    detect_rtsp_url=detect_url,
-                ),
-                timeout=_RTSP_TEST_CONNECTION_TIMEOUT_S,
-            )
-        except asyncio.TimeoutError:
-            return _result(
-                success=False,
-                message=f"RTSP probe timed out after {_RTSP_TEST_CONNECTION_TIMEOUT_S:.1f}s.",
-                start=start,
-            )
-        except Exception:
-            logger.warning("RTSP setup test probe failed", exc_info=True)
-            return _result(
-                success=False,
-                message="RTSP probe failed. Check stream URL, credentials, and network connectivity.",
-                start=start,
-            )
-
-    if isinstance(outcome, PreflightError):
-        return _result(
-            success=False,
-            message=outcome.message,
-            start=start,
-            details={
-                "stage": outcome.stage,
-                "camera_key": outcome.camera_key,
-            },
-        )
-
-    return _result(
-        success=True,
-        message="RTSP probe succeeded.",
-        start=start,
-        details={
-            "session_mode": outcome.diagnostics.session_mode,
-            "selected_recording_profile": outcome.diagnostics.selected_recording_profile,
-            "probed_streams": len(outcome.diagnostics.probes),
-        },
-    )
-
-
-@setup_probe("camera", "ftp", timeout_s=_FTP_TEST_CONNECTION_TIMEOUT_S + 1.0)
-async def _test_ftp_camera_connection(
-    *,
-    config: dict[str, object],
-) -> TestConnectionResponse:
-    start = time.perf_counter()
-    try:
-        validated = validate_plugin(
-            PluginType.SOURCE,
-            "ftp",
-            config,
-            camera_name=_SETUP_TEST_CAMERA_NAME,
-        )
-    except ValidationError as exc:
-        return _result(
-            success=False,
-            message=_format_validation_error(exc),
-            start=start,
-        )
-
-    if not isinstance(validated, FtpSourceConfig):
-        return _result(
-            success=False,
-            message=f"Unexpected ftp config model: {type(validated).__name__}",
-            start=start,
-        )
-
-    try:
-        bound_port = await asyncio.wait_for(
-            asyncio.to_thread(_probe_tcp_bind, validated.host, int(validated.port)),
-            timeout=_FTP_TEST_CONNECTION_TIMEOUT_S,
-        )
-    except asyncio.TimeoutError:
-        return _result(
-            success=False,
-            message=f"FTP bind probe timed out after {_FTP_TEST_CONNECTION_TIMEOUT_S:.1f}s.",
-            start=start,
-        )
-    except OSError:
-        logger.warning("FTP setup test probe failed", exc_info=True)
-        return _result(
-            success=False,
-            message="FTP bind probe failed. Check bind host/port availability and permissions.",
-            start=start,
-        )
-
-    return _result(
-        success=True,
-        message="FTP listen address is available.",
-        start=start,
-        details={"host": validated.host, "bound_port": bound_port},
-    )
-
-
-@setup_probe("camera", "local_folder")
-async def _test_local_folder_camera_connection(
-    *,
-    config: dict[str, object],
-) -> TestConnectionResponse:
-    start = time.perf_counter()
-    try:
-        validated = validate_plugin(
-            PluginType.SOURCE,
-            "local_folder",
-            config,
-            camera_name=_SETUP_TEST_CAMERA_NAME,
-        )
-    except ValidationError as exc:
-        return _result(
-            success=False,
-            message=_format_validation_error(exc),
-            start=start,
-        )
-
-    if not isinstance(validated, LocalFolderSourceConfig):
-        return _result(
-            success=False,
-            message=f"Unexpected local_folder config model: {type(validated).__name__}",
-            start=start,
-        )
-
-    watch_dir = Path(validated.watch_dir).expanduser()
-    if not await asyncio.to_thread(watch_dir.exists):
-        return _result(
-            success=False,
-            message=f"Watch directory does not exist: {watch_dir}",
-            start=start,
-        )
-    if not await asyncio.to_thread(watch_dir.is_dir):
-        return _result(
-            success=False,
-            message=f"Watch path is not a directory: {watch_dir}",
-            start=start,
-        )
-    if not await asyncio.to_thread(os.access, watch_dir, os.R_OK | os.W_OK | os.X_OK):
-        return _result(
-            success=False,
-            message=f"Watch directory is not readable/writable: {watch_dir}",
-            start=start,
-        )
-
-    resolved_watch_dir = await asyncio.to_thread(watch_dir.resolve)
-
-    return _result(
-        success=True,
-        message="Local folder path is accessible.",
-        start=start,
-        details={"watch_dir": str(resolved_watch_dir)},
-    )
-
-
-@setup_probe("camera", "onvif", timeout_s=_ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S + 1.0)
-async def _test_onvif_camera_connection(
-    *,
-    config: dict[str, object],
-) -> TestConnectionResponse:
-    start = time.perf_counter()
-    try:
-        request = _OnvifTestConnectionConfig.model_validate(config)
-    except ValidationError as exc:
-        return _result(
-            success=False,
-            message=_format_validation_error(exc),
-            start=start,
-        )
-
-    service = OnvifService(
-        discover_fn=discover_cameras,
-        client_factory=OnvifCameraClient,
-    )
-    timeout_s = request.timeout_s
-    try:
-        probe_result = await service.probe(
-            OnvifProbeOptions(
-                host=request.host,
-                username=request.username,
-                password=request.password,
-                port=int(request.port),
-                timeout_s=timeout_s,
-            )
-        )
-    except OnvifProbeTimeoutError:
-        return _result(
-            success=False,
-            message=f"ONVIF probe timed out after {timeout_s:.1f}s.",
-            start=start,
-        )
-    except OnvifProbeError:
-        logger.warning("ONVIF setup test probe failed", exc_info=True)
-        return _result(
-            success=False,
-            message="ONVIF probe failed. Check host, credentials, and camera reachability.",
-            start=start,
-        )
-
-    return _result(
-        success=True,
-        message="ONVIF probe succeeded.",
-        start=start,
-        details={
-            "profiles": len(probe_result.profiles),
-            "streams": len(probe_result.streams),
-        },
-    )
-
-
-@setup_probe("storage", "local")
-async def _test_local_storage_connection(*, config: dict[str, object]) -> TestConnectionResponse:
-    start = time.perf_counter()
-    _ensure_known_backend(PluginType.STORAGE, "local")
-    try:
-        validated = validate_plugin(PluginType.STORAGE, "local", config)
-    except ValidationError as exc:
-        return _result(
-            success=False,
-            message=_format_validation_error(exc),
-            start=start,
-        )
-
-    if not isinstance(validated, LocalStorageConfig):
-        return _result(
-            success=False,
-            message=f"Unexpected local storage config model: {type(validated).__name__}",
-            start=start,
-        )
-
-    root = Path(validated.root).expanduser()
-    if await asyncio.to_thread(root.exists):
-        if not await asyncio.to_thread(root.is_dir):
-            return _result(
-                success=False,
-                message=f"Storage root is not a directory: {root}",
-                start=start,
-            )
-        if not await asyncio.to_thread(os.access, root, os.R_OK | os.W_OK | os.X_OK):
-            return _result(
-                success=False,
-                message=f"Storage root is not readable/writable: {root}",
-                start=start,
-            )
-        resolved_root = await asyncio.to_thread(root.resolve)
-        return _result(
-            success=True,
-            message="Local storage root is accessible.",
-            start=start,
-            details={"root": str(resolved_root)},
-        )
-
-    parent = await asyncio.to_thread(_nearest_existing_parent, root)
-    if parent is None:
-        return _result(
-            success=False,
-            message=f"No existing parent directory for storage root: {root}",
-            start=start,
-        )
-    if not await asyncio.to_thread(os.access, parent, os.W_OK | os.X_OK):
-        return _result(
-            success=False,
-            message=f"Storage root parent is not writable: {parent}",
-            start=start,
-        )
-    return _result(
-        success=True,
-        message="Local storage root can be created.",
-        start=start,
-        details={"root": str(root), "writable_parent": str(parent)},
-    )
-
-
 async def _test_plugin_ping_connection(
     *,
     plugin_type: PluginType,
@@ -596,9 +234,9 @@ async def _test_plugin_ping_connection(
     try:
         validated_config = validate_plugin(plugin_type, backend, config)
     except ValidationError as exc:
-        return _result(
+        return build_test_connection_response(
             success=False,
-            message=_format_validation_error(exc),
+            message=format_validation_error(exc),
             start=start,
         )
 
@@ -618,7 +256,7 @@ async def _test_plugin_ping_connection(
             backend,
             exc_info=True,
         )
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=(
                 f"{plugin_type.value} probe load timed out after "
@@ -633,7 +271,7 @@ async def _test_plugin_ping_connection(
             backend,
             exc_info=True,
         )
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=(
                 f"{plugin_type.value} probe failed during plugin load. "
@@ -651,7 +289,7 @@ async def _test_plugin_ping_connection(
             backend,
             exc_info=True,
         )
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=(
                 f"{plugin_type.value} probe ping timed out after "
@@ -666,7 +304,7 @@ async def _test_plugin_ping_connection(
             backend,
             exc_info=True,
         )
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=(
                 f"{plugin_type.value} probe failed during ping. "
@@ -679,12 +317,12 @@ async def _test_plugin_ping_connection(
             await _shutdown_plugin(plugin)
 
     if not ok:
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=f"{plugin_type.value} probe did not pass health checks.",
             start=start,
         )
-    return _result(
+    return build_test_connection_response(
         success=True,
         message=f"{plugin_type.value} probe succeeded.",
         start=start,
@@ -727,9 +365,9 @@ async def _run_registered_setup_probe(
     except SetupTestConnectionRequestError:
         raise
     except ValidationError as exc:
-        return _result(
+        return build_test_connection_response(
             success=False,
-            message=_format_validation_error(exc),
+            message=format_validation_error(exc),
             start=start,
         )
     except asyncio.TimeoutError:
@@ -739,7 +377,7 @@ async def _run_registered_setup_probe(
             backend,
             exc_info=True,
         )
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=f"{target} probe timed out after {timeout_s:.1f}s.",
             start=start,
@@ -751,7 +389,7 @@ async def _run_registered_setup_probe(
             backend,
             exc_info=True,
         )
-        return _result(
+        return build_test_connection_response(
             success=False,
             message=(
                 f"{target} probe failed during connectivity test. "
@@ -761,82 +399,12 @@ async def _run_registered_setup_probe(
         )
 
 
-def _resolve_rtsp_primary_url(config: RTSPSourceConfig) -> str | None:
-    if config.rtsp_url_env:
-        env_url = os.getenv(config.rtsp_url_env)
-        if env_url:
-            return env_url
-    return config.rtsp_url
-
-
-def _resolve_rtsp_detect_url(config: RTSPSourceConfig, primary_url: str) -> str:
-    if config.detect_rtsp_url_env:
-        env_url = os.getenv(config.detect_rtsp_url_env)
-        if env_url:
-            return env_url
-    if config.detect_rtsp_url:
-        return config.detect_rtsp_url
-    derived = derive_detect_rtsp_url(primary_url)
-    if derived is not None:
-        return derived.url
-    return primary_url
-
-
-def _probe_tcp_bind(host: str, port: int) -> int:
-    family = socket.AF_INET6 if ":" in host else socket.AF_INET
-    with socket.socket(family, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((host, port))
-        return int(sock.getsockname()[1])
-
-
 async def _shutdown_plugin(plugin: _PingablePlugin) -> None:
     try:
         await asyncio.wait_for(plugin.shutdown(timeout=5.0), timeout=5.0)
     except Exception:
         # Shutdown failure should not hide probe result.
         return
-
-
-def _nearest_existing_parent(path: Path) -> Path | None:
-    current = path
-    while not current.exists():
-        if current == current.parent:
-            return None
-        current = current.parent
-    return current
-
-
-def _format_validation_error(exc: ValidationError) -> str:
-    # Return only the first validation issue to keep setup probe UX concise.
-    errors = exc.errors(include_url=False)
-    if not errors:
-        return "Configuration validation failed."
-    first = errors[0]
-    loc_parts = [str(part) for part in first.get("loc", []) if str(part)]
-    location = ".".join(loc_parts)
-    message = str(first.get("msg", "invalid value"))
-    if location:
-        return f"Configuration validation failed at {location}: {message}"
-    return f"Configuration validation failed: {message}"
-
-
-def _result(
-    *,
-    success: bool,
-    message: str,
-    start: float | None = None,
-    details: dict[str, object] | None = None,
-) -> TestConnectionResponse:
-    latency_ms = None
-    if start is not None:
-        latency_ms = (time.perf_counter() - start) * 1000.0
-    return TestConnectionResponse(
-        success=success,
-        message=message,
-        latency_ms=latency_ms,
-        details=details,
-    )
 
 
 async def _run_preflight_check(

--- a/src/homesec/services/setup.py
+++ b/src/homesec/services/setup.py
@@ -166,13 +166,11 @@ async def _test_camera_connection(
             available_backends=available_backends,
         )
 
-    match backend:
-        case _:
-            # Defensive fallback for known-but-not-yet-probed camera source plugins.
-            return build_test_connection_response(
-                success=False,
-                message=f"Camera backend {backend!r} does not implement connection testing yet.",
-            )
+    # Defensive fallback for known-but-not-yet-probed camera source plugins.
+    return build_test_connection_response(
+        success=False,
+        message=f"Camera backend {backend!r} does not implement connection testing yet.",
+    )
 
 
 async def _test_storage_connection(

--- a/src/homesec/services/setup_probe_support.py
+++ b/src/homesec/services/setup_probe_support.py
@@ -1,0 +1,111 @@
+"""Shared helpers for setup-only probe implementations."""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from pathlib import Path
+
+from pydantic import BaseModel, Field, ValidationError
+
+from homesec.models.setup import TestConnectionResponse
+from homesec.onvif.service import DEFAULT_ONVIF_PORT
+from homesec.sources.rtsp.core import RTSPSourceConfig
+from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
+
+SETUP_TEST_CAMERA_NAME = "setup-test-camera"
+ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S = 30.0
+RTSP_TEST_CONNECTION_TIMEOUT_S = 10.0
+RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S = 8.0
+FTP_TEST_CONNECTION_TIMEOUT_S = 5.0
+ONVIF_TEST_CONNECTION_TIMEOUT_S = 15.0
+
+
+class OnvifSetupProbeConfig(BaseModel):
+    """Validated payload for setup-time ONVIF connectivity probes."""
+
+    host: str = Field(min_length=1)
+    username: str = Field(min_length=1)
+    password: str = Field(min_length=1)
+    port: int = Field(default=DEFAULT_ONVIF_PORT, ge=1, le=65535)
+    timeout_s: float = Field(
+        default=ONVIF_TEST_CONNECTION_TIMEOUT_S,
+        gt=0.0,
+        le=ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S,
+    )
+
+
+def format_validation_error(exc: ValidationError) -> str:
+    """Return a concise single-error validation message for setup UX."""
+    errors = exc.errors(include_url=False)
+    if not errors:
+        return "Configuration validation failed."
+    first = errors[0]
+    loc_parts = [str(part) for part in first.get("loc", []) if str(part)]
+    location = ".".join(loc_parts)
+    message = str(first.get("msg", "invalid value"))
+    if location:
+        return f"Configuration validation failed at {location}: {message}"
+    return f"Configuration validation failed: {message}"
+
+
+def build_test_connection_response(
+    *,
+    success: bool,
+    message: str,
+    start: float | None = None,
+    details: dict[str, object] | None = None,
+) -> TestConnectionResponse:
+    """Build a setup test-connection response with optional latency metadata."""
+    latency_ms = None
+    if start is not None:
+        latency_ms = (time.perf_counter() - start) * 1000.0
+    return TestConnectionResponse(
+        success=success,
+        message=message,
+        latency_ms=latency_ms,
+        details=details,
+    )
+
+
+def nearest_existing_parent(path: Path) -> Path | None:
+    """Return the closest existing ancestor for a path, if any."""
+    current = path
+    while not current.exists():
+        if current == current.parent:
+            return None
+        current = current.parent
+    return current
+
+
+def probe_tcp_bind(host: str, port: int) -> int:
+    """Bind a temporary TCP socket and return the bound port."""
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    with socket.socket(family, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        return int(sock.getsockname()[1])
+
+
+def resolve_rtsp_primary_url(config: RTSPSourceConfig) -> str | None:
+    """Resolve the primary RTSP URL from config or env indirection."""
+    if config.rtsp_url_env:
+        env_url = os.getenv(config.rtsp_url_env)
+        if env_url:
+            return env_url
+    return config.rtsp_url
+
+
+def resolve_rtsp_detect_url(config: RTSPSourceConfig, primary_url: str) -> str:
+    """Resolve or derive the RTSP URL used for motion-stream detection."""
+    if config.detect_rtsp_url_env:
+        env_url = os.getenv(config.detect_rtsp_url_env)
+        if env_url:
+            return env_url
+    if config.detect_rtsp_url:
+        return config.detect_rtsp_url
+    derived = derive_detect_rtsp_url(primary_url)
+    if derived is not None:
+        return derived.url
+    return primary_url

--- a/src/homesec/services/setup_probe_support.py
+++ b/src/homesec/services/setup_probe_support.py
@@ -2,38 +2,13 @@
 
 from __future__ import annotations
 
-import os
-import socket
 import time
-from pathlib import Path
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import ValidationError
 
 from homesec.models.setup import TestConnectionResponse
-from homesec.onvif.service import DEFAULT_ONVIF_PORT
-from homesec.sources.rtsp.core import RTSPSourceConfig
-from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 
 SETUP_TEST_CAMERA_NAME = "setup-test-camera"
-ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S = 30.0
-RTSP_TEST_CONNECTION_TIMEOUT_S = 10.0
-RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S = 8.0
-FTP_TEST_CONNECTION_TIMEOUT_S = 5.0
-ONVIF_TEST_CONNECTION_TIMEOUT_S = 15.0
-
-
-class OnvifSetupProbeConfig(BaseModel):
-    """Validated payload for setup-time ONVIF connectivity probes."""
-
-    host: str = Field(min_length=1)
-    username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
-    port: int = Field(default=DEFAULT_ONVIF_PORT, ge=1, le=65535)
-    timeout_s: float = Field(
-        default=ONVIF_TEST_CONNECTION_TIMEOUT_S,
-        gt=0.0,
-        le=ONVIF_TEST_CONNECTION_TIMEOUT_CAP_S,
-    )
 
 
 def format_validation_error(exc: ValidationError) -> str:
@@ -67,45 +42,3 @@ def build_test_connection_response(
         latency_ms=latency_ms,
         details=details,
     )
-
-
-def nearest_existing_parent(path: Path) -> Path | None:
-    """Return the closest existing ancestor for a path, if any."""
-    current = path
-    while not current.exists():
-        if current == current.parent:
-            return None
-        current = current.parent
-    return current
-
-
-def probe_tcp_bind(host: str, port: int) -> int:
-    """Bind a temporary TCP socket and return the bound port."""
-    family = socket.AF_INET6 if ":" in host else socket.AF_INET
-    with socket.socket(family, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((host, port))
-        return int(sock.getsockname()[1])
-
-
-def resolve_rtsp_primary_url(config: RTSPSourceConfig) -> str | None:
-    """Resolve the primary RTSP URL from config or env indirection."""
-    if config.rtsp_url_env:
-        env_url = os.getenv(config.rtsp_url_env)
-        if env_url:
-            return env_url
-    return config.rtsp_url
-
-
-def resolve_rtsp_detect_url(config: RTSPSourceConfig, primary_url: str) -> str:
-    """Resolve or derive the RTSP URL used for motion-stream detection."""
-    if config.detect_rtsp_url_env:
-        env_url = os.getenv(config.detect_rtsp_url_env)
-        if env_url:
-            return env_url
-    if config.detect_rtsp_url:
-        return config.detect_rtsp_url
-    derived = derive_detect_rtsp_url(primary_url)
-    if derived is not None:
-        return derived.url
-    return primary_url

--- a/src/homesec/services/setup_probes.py
+++ b/src/homesec/services/setup_probes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Literal
@@ -76,6 +77,24 @@ class SetupProbeRegistry:
 
 
 _SETUP_PROBE_REGISTRY = SetupProbeRegistry()
+_BUILTIN_SETUP_PROBE_MODULES = (
+    "homesec.sources.rtsp.setup_probe",
+    "homesec.sources.ftp_setup_probe",
+    "homesec.sources.local_folder_setup_probe",
+    "homesec.onvif.setup_probe",
+    "homesec.plugins.storage.local_setup_probe",
+)
+_builtin_setup_probes_loaded = False
+
+
+def load_builtin_setup_probes() -> None:
+    """Import built-in setup-probe modules once so decorators can register handlers."""
+    global _builtin_setup_probes_loaded
+    if _builtin_setup_probes_loaded:
+        return
+    for module_name in _BUILTIN_SETUP_PROBE_MODULES:
+        importlib.import_module(module_name)
+    _builtin_setup_probes_loaded = True
 
 
 def setup_probe(
@@ -90,14 +109,17 @@ def setup_probe(
 
 def get_setup_probe(target: SetupProbeTarget, backend: str) -> SetupProbeFn | None:
     """Look up a setup-only probe handler."""
+    load_builtin_setup_probes()
     return _SETUP_PROBE_REGISTRY.get(target, backend)
 
 
 def get_setup_probe_timeout(target: SetupProbeTarget, backend: str) -> float | None:
     """Look up the registered timeout budget for a setup-only probe handler."""
+    load_builtin_setup_probes()
     return _SETUP_PROBE_REGISTRY.get_timeout(target, backend)
 
 
 def get_setup_probe_backends(target: SetupProbeTarget) -> list[str]:
     """List special-case backends registered for a setup target."""
+    load_builtin_setup_probes()
     return _SETUP_PROBE_REGISTRY.get_backends(target)

--- a/src/homesec/sources/ftp_setup_probe.py
+++ b/src/homesec/sources/ftp_setup_probe.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import socket
 import time
 
 from pydantic import ValidationError
@@ -11,16 +12,25 @@ from pydantic import ValidationError
 from homesec.models.setup import TestConnectionResponse
 from homesec.plugins.registry import PluginType, validate_plugin
 from homesec.services.setup_probe_support import (
-    FTP_TEST_CONNECTION_TIMEOUT_S,
     SETUP_TEST_CAMERA_NAME,
     build_test_connection_response,
     format_validation_error,
-    probe_tcp_bind,
 )
 from homesec.services.setup_probes import setup_probe
 from homesec.sources.ftp import FtpSourceConfig
 
 logger = logging.getLogger(__name__)
+
+FTP_TEST_CONNECTION_TIMEOUT_S = 5.0
+
+
+def probe_tcp_bind(host: str, port: int) -> int:
+    """Bind a temporary TCP socket and return the bound port."""
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    with socket.socket(family, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        return int(sock.getsockname()[1])
 
 
 @setup_probe("camera", "ftp", timeout_s=FTP_TEST_CONNECTION_TIMEOUT_S + 1.0)

--- a/src/homesec/sources/ftp_setup_probe.py
+++ b/src/homesec/sources/ftp_setup_probe.py
@@ -1,0 +1,78 @@
+"""Setup-only FTP source connectivity probe."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from pydantic import ValidationError
+
+from homesec.models.setup import TestConnectionResponse
+from homesec.plugins.registry import PluginType, validate_plugin
+from homesec.services.setup_probe_support import (
+    FTP_TEST_CONNECTION_TIMEOUT_S,
+    SETUP_TEST_CAMERA_NAME,
+    build_test_connection_response,
+    format_validation_error,
+    probe_tcp_bind,
+)
+from homesec.services.setup_probes import setup_probe
+from homesec.sources.ftp import FtpSourceConfig
+
+logger = logging.getLogger(__name__)
+
+
+@setup_probe("camera", "ftp", timeout_s=FTP_TEST_CONNECTION_TIMEOUT_S + 1.0)
+async def test_ftp_camera_connection(
+    *,
+    config: dict[str, object],
+) -> TestConnectionResponse:
+    """Validate FTP source config and confirm the listen socket can bind."""
+    start = time.perf_counter()
+    try:
+        validated = validate_plugin(
+            PluginType.SOURCE,
+            "ftp",
+            config,
+            camera_name=SETUP_TEST_CAMERA_NAME,
+        )
+    except ValidationError as exc:
+        return build_test_connection_response(
+            success=False,
+            message=format_validation_error(exc),
+            start=start,
+        )
+
+    if not isinstance(validated, FtpSourceConfig):
+        return build_test_connection_response(
+            success=False,
+            message=f"Unexpected ftp config model: {type(validated).__name__}",
+            start=start,
+        )
+
+    try:
+        bound_port = await asyncio.wait_for(
+            asyncio.to_thread(probe_tcp_bind, validated.host, int(validated.port)),
+            timeout=FTP_TEST_CONNECTION_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        return build_test_connection_response(
+            success=False,
+            message=f"FTP bind probe timed out after {FTP_TEST_CONNECTION_TIMEOUT_S:.1f}s.",
+            start=start,
+        )
+    except OSError:
+        logger.warning("FTP setup test probe failed", exc_info=True)
+        return build_test_connection_response(
+            success=False,
+            message="FTP bind probe failed. Check bind host/port availability and permissions.",
+            start=start,
+        )
+
+    return build_test_connection_response(
+        success=True,
+        message="FTP listen address is available.",
+        start=start,
+        details={"host": validated.host, "bound_port": bound_port},
+    )

--- a/src/homesec/sources/local_folder_setup_probe.py
+++ b/src/homesec/sources/local_folder_setup_probe.py
@@ -1,0 +1,77 @@
+"""Setup-only local-folder source connectivity probe."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from homesec.models.setup import TestConnectionResponse
+from homesec.plugins.registry import PluginType, validate_plugin
+from homesec.services.setup_probe_support import (
+    SETUP_TEST_CAMERA_NAME,
+    build_test_connection_response,
+    format_validation_error,
+)
+from homesec.services.setup_probes import setup_probe
+from homesec.sources.local_folder import LocalFolderSourceConfig
+
+
+@setup_probe("camera", "local_folder")
+async def test_local_folder_camera_connection(
+    *,
+    config: dict[str, object],
+) -> TestConnectionResponse:
+    """Validate local-folder config and ensure the watch directory is accessible."""
+    start = time.perf_counter()
+    try:
+        validated = validate_plugin(
+            PluginType.SOURCE,
+            "local_folder",
+            config,
+            camera_name=SETUP_TEST_CAMERA_NAME,
+        )
+    except ValidationError as exc:
+        return build_test_connection_response(
+            success=False,
+            message=format_validation_error(exc),
+            start=start,
+        )
+
+    if not isinstance(validated, LocalFolderSourceConfig):
+        return build_test_connection_response(
+            success=False,
+            message=f"Unexpected local_folder config model: {type(validated).__name__}",
+            start=start,
+        )
+
+    watch_dir = Path(validated.watch_dir).expanduser()
+    if not await asyncio.to_thread(watch_dir.exists):
+        return build_test_connection_response(
+            success=False,
+            message=f"Watch directory does not exist: {watch_dir}",
+            start=start,
+        )
+    if not await asyncio.to_thread(watch_dir.is_dir):
+        return build_test_connection_response(
+            success=False,
+            message=f"Watch path is not a directory: {watch_dir}",
+            start=start,
+        )
+    if not await asyncio.to_thread(os.access, watch_dir, os.R_OK | os.W_OK | os.X_OK):
+        return build_test_connection_response(
+            success=False,
+            message=f"Watch directory is not readable/writable: {watch_dir}",
+            start=start,
+        )
+
+    resolved_watch_dir = await asyncio.to_thread(watch_dir.resolve)
+    return build_test_connection_response(
+        success=True,
+        message="Local folder path is accessible.",
+        start=start,
+        details={"watch_dir": str(resolved_watch_dir)},
+    )

--- a/src/homesec/sources/rtsp/setup_probe.py
+++ b/src/homesec/sources/rtsp/setup_probe.py
@@ -1,0 +1,122 @@
+"""Setup-only RTSP connectivity probe."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+import time
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from homesec.models.setup import TestConnectionResponse
+from homesec.plugins.registry import PluginType, validate_plugin
+from homesec.services.setup_probe_support import (
+    RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S,
+    RTSP_TEST_CONNECTION_TIMEOUT_S,
+    SETUP_TEST_CAMERA_NAME,
+    build_test_connection_response,
+    format_validation_error,
+    resolve_rtsp_detect_url,
+    resolve_rtsp_primary_url,
+)
+from homesec.services.setup_probes import setup_probe
+from homesec.sources.rtsp.core import RTSPSourceConfig
+from homesec.sources.rtsp.preflight import PreflightError, RTSPStartupPreflight
+
+logger = logging.getLogger(__name__)
+
+
+@setup_probe("camera", "rtsp", timeout_s=RTSP_TEST_CONNECTION_TIMEOUT_S + 1.0)
+async def test_rtsp_camera_connection(
+    *,
+    config: dict[str, object],
+) -> TestConnectionResponse:
+    """Validate RTSP config and run bounded startup preflight."""
+    start = time.perf_counter()
+    try:
+        validated = validate_plugin(
+            PluginType.SOURCE,
+            "rtsp",
+            config,
+            camera_name=SETUP_TEST_CAMERA_NAME,
+        )
+    except ValidationError as exc:
+        return build_test_connection_response(
+            success=False,
+            message=format_validation_error(exc),
+            start=start,
+        )
+
+    if not isinstance(validated, RTSPSourceConfig):
+        return build_test_connection_response(
+            success=False,
+            message=f"Unexpected rtsp config model: {type(validated).__name__}",
+            start=start,
+        )
+
+    primary_url = resolve_rtsp_primary_url(validated)
+    if not primary_url:
+        return build_test_connection_response(
+            success=False,
+            message="RTSP URL not resolved. Provide rtsp_url or set rtsp_url_env.",
+            start=start,
+        )
+    detect_url = resolve_rtsp_detect_url(validated, primary_url)
+
+    with tempfile.TemporaryDirectory(prefix="homesec-rtsp-probe-") as temp_dir:
+        preflight = RTSPStartupPreflight(
+            output_dir=Path(temp_dir),
+            rtsp_connect_timeout_s=float(validated.stream.connect_timeout_s),
+            rtsp_io_timeout_s=float(validated.stream.io_timeout_s),
+            command_timeout_s=min(
+                RTSP_TEST_CONNECTION_TIMEOUT_S,
+                RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S,
+            ),
+        )
+        try:
+            outcome = await asyncio.wait_for(
+                asyncio.to_thread(
+                    preflight.run,
+                    camera_name=validated.camera_name or SETUP_TEST_CAMERA_NAME,
+                    primary_rtsp_url=primary_url,
+                    detect_rtsp_url=detect_url,
+                ),
+                timeout=RTSP_TEST_CONNECTION_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            return build_test_connection_response(
+                success=False,
+                message=f"RTSP probe timed out after {RTSP_TEST_CONNECTION_TIMEOUT_S:.1f}s.",
+                start=start,
+            )
+        except Exception:
+            logger.warning("RTSP setup test probe failed", exc_info=True)
+            return build_test_connection_response(
+                success=False,
+                message="RTSP probe failed. Check stream URL, credentials, and network connectivity.",
+                start=start,
+            )
+
+    if isinstance(outcome, PreflightError):
+        return build_test_connection_response(
+            success=False,
+            message=outcome.message,
+            start=start,
+            details={
+                "stage": outcome.stage,
+                "camera_key": outcome.camera_key,
+            },
+        )
+
+    return build_test_connection_response(
+        success=True,
+        message="RTSP probe succeeded.",
+        start=start,
+        details={
+            "session_mode": outcome.diagnostics.session_mode,
+            "selected_recording_profile": outcome.diagnostics.selected_recording_profile,
+            "probed_streams": len(outcome.diagnostics.probes),
+        },
+    )

--- a/src/homesec/sources/rtsp/setup_probe.py
+++ b/src/homesec/sources/rtsp/setup_probe.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import tempfile
 import time
 from pathlib import Path
@@ -13,19 +14,42 @@ from pydantic import ValidationError
 from homesec.models.setup import TestConnectionResponse
 from homesec.plugins.registry import PluginType, validate_plugin
 from homesec.services.setup_probe_support import (
-    RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S,
-    RTSP_TEST_CONNECTION_TIMEOUT_S,
     SETUP_TEST_CAMERA_NAME,
     build_test_connection_response,
     format_validation_error,
-    resolve_rtsp_detect_url,
-    resolve_rtsp_primary_url,
 )
 from homesec.services.setup_probes import setup_probe
 from homesec.sources.rtsp.core import RTSPSourceConfig
 from homesec.sources.rtsp.preflight import PreflightError, RTSPStartupPreflight
+from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 
 logger = logging.getLogger(__name__)
+
+RTSP_TEST_CONNECTION_TIMEOUT_S = 10.0
+RTSP_PREFLIGHT_COMMAND_TIMEOUT_CAP_S = 8.0
+
+
+def resolve_rtsp_primary_url(config: RTSPSourceConfig) -> str | None:
+    """Resolve the primary RTSP URL from config or env indirection."""
+    if config.rtsp_url_env:
+        env_url = os.getenv(config.rtsp_url_env)
+        if env_url:
+            return env_url
+    return config.rtsp_url
+
+
+def resolve_rtsp_detect_url(config: RTSPSourceConfig, primary_url: str) -> str:
+    """Resolve or derive the RTSP URL used for motion-stream detection."""
+    if config.detect_rtsp_url_env:
+        env_url = os.getenv(config.detect_rtsp_url_env)
+        if env_url:
+            return env_url
+    if config.detect_rtsp_url:
+        return config.detect_rtsp_url
+    derived = derive_detect_rtsp_url(primary_url)
+    if derived is not None:
+        return derived.url
+    return primary_url
 
 
 @setup_probe("camera", "rtsp", timeout_s=RTSP_TEST_CONNECTION_TIMEOUT_S + 1.0)

--- a/tests/homesec/test_setup_probes.py
+++ b/tests/homesec/test_setup_probes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from homesec.models.setup import TestConnectionResponse as SetupTestConnectionResponse
+from homesec.services import setup_probes
 from homesec.services.setup_probes import SetupProbeRegistry
 
 
@@ -61,3 +62,18 @@ def test_setup_probe_registry_tracks_custom_timeout_budget() -> None:
     # When / Then: Lookup returns the probe and its configured timeout budget
     assert registry.get("camera", "rtsp") is _probe
     assert registry.get_timeout("camera", "rtsp") == 11.0
+
+
+def test_load_builtin_setup_probes_registers_backend_adjacent_modules() -> None:
+    """Builtin loader should expose built-in camera and storage probe backends."""
+    # Given / When: Loading the builtin setup probes through the shared loader
+    setup_probes.load_builtin_setup_probes()
+
+    # Then: The registry reports backend-adjacent builtins without setup.py-owned decorators
+    assert setup_probes.get_setup_probe_backends("camera") == [
+        "ftp",
+        "local_folder",
+        "onvif",
+        "rtsp",
+    ]
+    assert setup_probes.get_setup_probe_backends("storage") == ["local"]

--- a/tests/homesec/test_setup_test_connection_service.py
+++ b/tests/homesec/test_setup_test_connection_service.py
@@ -12,8 +12,19 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
+import homesec.onvif.setup_probe as onvif_setup_probe
+import homesec.plugins.storage.local_setup_probe as local_storage_setup_probe
+import homesec.sources.ftp_setup_probe as ftp_setup_probe
+import homesec.sources.local_folder_setup_probe as local_folder_setup_probe
+import homesec.sources.rtsp.setup_probe as rtsp_setup_probe
 from homesec.models.setup import TestConnectionRequest as SetupTestConnectionRequest
+from homesec.onvif.service import OnvifProbeError, OnvifProbeOptions, OnvifProbeTimeoutError
+from homesec.plugins.storage.local import LocalStorageConfig
 from homesec.services import setup as setup_service
+from homesec.sources.ftp import FtpSourceConfig
+from homesec.sources.local_folder import LocalFolderSourceConfig
+from homesec.sources.rtsp.core import RTSPSourceConfig
+from homesec.sources.rtsp.preflight import PreflightError
 
 
 @dataclass
@@ -65,9 +76,9 @@ async def test_test_connection_camera_local_folder_success(
     ) -> object:
         _ = (plugin_type, config, runtime_context)
         assert backend == "local_folder"
-        return setup_service.LocalFolderSourceConfig(watch_dir=str(watch_dir))
+        return LocalFolderSourceConfig(watch_dir=str(watch_dir))
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_folder_setup_probe, "validate_plugin", _fake_validate_plugin)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -104,9 +115,9 @@ async def test_test_connection_camera_local_folder_missing_directory(
     ) -> object:
         _ = (plugin_type, config, runtime_context)
         assert backend == "local_folder"
-        return setup_service.LocalFolderSourceConfig(watch_dir=str(watch_dir))
+        return LocalFolderSourceConfig(watch_dir=str(watch_dir))
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_folder_setup_probe, "validate_plugin", _fake_validate_plugin)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -354,7 +365,7 @@ async def test_test_connection_camera_rtsp_success(
     ) -> object:
         _ = (plugin_type, config, runtime_context)
         assert backend == "rtsp"
-        return setup_service.RTSPSourceConfig(rtsp_url="rtsp://example.local/stream")
+        return RTSPSourceConfig(rtsp_url="rtsp://example.local/stream")
 
     class _FakeStartupPreflight:
         def __init__(
@@ -383,8 +394,8 @@ async def test_test_connection_camera_rtsp_success(
                 )
             )
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "RTSPStartupPreflight", _FakeStartupPreflight)
+    monkeypatch.setattr(rtsp_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(rtsp_setup_probe, "RTSPStartupPreflight", _FakeStartupPreflight)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -417,9 +428,9 @@ async def test_test_connection_camera_rtsp_validation_failure(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.RTSPSourceConfig.model_validate({})
+        return RTSPSourceConfig.model_validate({})
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(rtsp_setup_probe, "validate_plugin", _fake_validate_plugin)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -449,10 +460,10 @@ async def test_test_connection_camera_rtsp_env_url_missing_returns_failure(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.RTSPSourceConfig(rtsp_url_env="HOMESEC_RTSP_MISSING")
+        return RTSPSourceConfig(rtsp_url_env="HOMESEC_RTSP_MISSING")
 
     monkeypatch.delenv("HOMESEC_RTSP_MISSING", raising=False)
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(rtsp_setup_probe, "validate_plugin", _fake_validate_plugin)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -482,7 +493,7 @@ async def test_test_connection_camera_rtsp_timeout_returns_failure(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.RTSPSourceConfig(rtsp_url="rtsp://example.local/stream")
+        return RTSPSourceConfig(rtsp_url="rtsp://example.local/stream")
 
     class _SlowStartupPreflight:
         def __init__(
@@ -512,9 +523,9 @@ async def test_test_connection_camera_rtsp_timeout_returns_failure(
                 )
             )
 
-    monkeypatch.setattr(setup_service, "_RTSP_TEST_CONNECTION_TIMEOUT_S", 0.01)
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "RTSPStartupPreflight", _SlowStartupPreflight)
+    monkeypatch.setattr(rtsp_setup_probe, "RTSP_TEST_CONNECTION_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(rtsp_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(rtsp_setup_probe, "RTSPStartupPreflight", _SlowStartupPreflight)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -544,7 +555,7 @@ async def test_test_connection_camera_rtsp_preflight_error_details(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.RTSPSourceConfig(rtsp_url="rtsp://example.local/stream")
+        return RTSPSourceConfig(rtsp_url="rtsp://example.local/stream")
 
     class _FailingStartupPreflight:
         def __init__(
@@ -565,14 +576,14 @@ async def test_test_connection_camera_rtsp_preflight_error_details(
             detect_rtsp_url: str,
         ) -> object:
             _ = (camera_name, primary_rtsp_url, detect_rtsp_url)
-            return setup_service.PreflightError(
+            return PreflightError(
                 camera_key="front-door",
                 stage="selection",
                 message="No compatible streams found",
             )
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "RTSPStartupPreflight", _FailingStartupPreflight)
+    monkeypatch.setattr(rtsp_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(rtsp_setup_probe, "RTSPStartupPreflight", _FailingStartupPreflight)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -603,10 +614,10 @@ async def test_test_connection_camera_ftp_success(
     ) -> object:
         _ = (plugin_type, config, runtime_context)
         assert backend == "ftp"
-        return setup_service.FtpSourceConfig(host="127.0.0.1", port=0)
+        return FtpSourceConfig(host="127.0.0.1", port=0)
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "_probe_tcp_bind", lambda *_args: 42424)
+    monkeypatch.setattr(ftp_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(ftp_setup_probe, "probe_tcp_bind", lambda *_args: 42424)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -637,15 +648,15 @@ async def test_test_connection_camera_ftp_timeout_returns_failure(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.FtpSourceConfig(host="127.0.0.1", port=0)
+        return FtpSourceConfig(host="127.0.0.1", port=0)
 
     def _slow_probe(*_args: object, **_kwargs: object) -> int:
         time.sleep(0.05)
         return 42424
 
-    monkeypatch.setattr(setup_service, "_FTP_TEST_CONNECTION_TIMEOUT_S", 0.01)
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "_probe_tcp_bind", _slow_probe)
+    monkeypatch.setattr(ftp_setup_probe, "FTP_TEST_CONNECTION_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(ftp_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(ftp_setup_probe, "probe_tcp_bind", _slow_probe)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -675,13 +686,13 @@ async def test_test_connection_camera_ftp_bind_oserror_returns_failure(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.FtpSourceConfig(host="127.0.0.1", port=2121)
+        return FtpSourceConfig(host="127.0.0.1", port=2121)
 
     def _failing_probe(*_args: object, **_kwargs: object) -> int:
         raise OSError("Address already in use")
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "_probe_tcp_bind", _failing_probe)
+    monkeypatch.setattr(ftp_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(ftp_setup_probe, "probe_tcp_bind", _failing_probe)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -712,7 +723,7 @@ async def test_test_connection_camera_onvif_success(
             _ = options
             return SimpleNamespace(profiles=[object(), object()], streams=[object()])
 
-    monkeypatch.setattr(setup_service, "OnvifService", _FakeOnvifService)
+    monkeypatch.setattr(onvif_setup_probe, "OnvifService", _FakeOnvifService)
     request = SetupTestConnectionRequest(
         type="camera",
         backend="onvif",
@@ -744,13 +755,13 @@ async def test_test_connection_camera_onvif_uses_requested_timeout_budget(
         def __init__(self, *, discover_fn: object, client_factory: object) -> None:
             _ = (discover_fn, client_factory)
 
-        async def probe(self, options: setup_service.OnvifProbeOptions) -> object:
+        async def probe(self, options: OnvifProbeOptions) -> object:
             assert options.timeout_s == 0.05
             await asyncio.sleep(0.02)
             return SimpleNamespace(profiles=[object()], streams=[object()])
 
     monkeypatch.setattr(setup_service, "_PLUGIN_TEST_CONNECTION_TIMEOUT_S", 0.01)
-    monkeypatch.setattr(setup_service, "OnvifService", _SlowSuccessfulOnvifService)
+    monkeypatch.setattr(onvif_setup_probe, "OnvifService", _SlowSuccessfulOnvifService)
     request = SetupTestConnectionRequest(
         type="camera",
         backend="onvif",
@@ -797,9 +808,9 @@ async def test_test_connection_camera_onvif_timeout_returns_failure(
 
         async def probe(self, options: object) -> object:
             _ = options
-            raise setup_service.OnvifProbeTimeoutError(1.0, cause=TimeoutError())
+            raise OnvifProbeTimeoutError(1.0, cause=TimeoutError())
 
-    monkeypatch.setattr(setup_service, "OnvifService", _TimeoutOnvifService)
+    monkeypatch.setattr(onvif_setup_probe, "OnvifService", _TimeoutOnvifService)
     request = SetupTestConnectionRequest(
         type="camera",
         backend="onvif",
@@ -831,9 +842,9 @@ async def test_test_connection_camera_onvif_probe_error_returns_failure(
 
         async def probe(self, options: object) -> object:
             _ = options
-            raise setup_service.OnvifProbeError("Authentication failed", cause=RuntimeError())
+            raise OnvifProbeError("Authentication failed", cause=RuntimeError())
 
-    monkeypatch.setattr(setup_service, "OnvifService", _FailingOnvifService)
+    monkeypatch.setattr(onvif_setup_probe, "OnvifService", _FailingOnvifService)
     request = SetupTestConnectionRequest(
         type="camera",
         backend="onvif",
@@ -870,9 +881,9 @@ async def test_test_connection_storage_local_success(
     ) -> object:
         _ = (plugin_type, config, runtime_context)
         assert backend == "local"
-        return setup_service.LocalStorageConfig(root=str(root))
+        return LocalStorageConfig(root=str(root))
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_storage_setup_probe, "validate_plugin", _fake_validate_plugin)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -906,9 +917,9 @@ async def test_test_connection_storage_local_rejects_file_path(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.LocalStorageConfig(root=str(file_root))
+        return LocalStorageConfig(root=str(file_root))
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_storage_setup_probe, "validate_plugin", _fake_validate_plugin)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -941,19 +952,21 @@ async def test_test_connection_storage_local_rejects_unwritable_existing_directo
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.LocalStorageConfig(root=str(root))
+        return LocalStorageConfig(root=str(root))
 
-    original_access = setup_service.os.access
+    original_access = local_storage_setup_probe.os.access
 
     def _fake_access(path: object, mode: int) -> bool:
         if Path(str(path)) == root and mode == (
-            setup_service.os.R_OK | setup_service.os.W_OK | setup_service.os.X_OK
+            local_storage_setup_probe.os.R_OK
+            | local_storage_setup_probe.os.W_OK
+            | local_storage_setup_probe.os.X_OK
         ):
             return False
         return original_access(path, mode)
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service.os, "access", _fake_access)
+    monkeypatch.setattr(local_storage_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_storage_setup_probe.os, "access", _fake_access)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -987,17 +1000,19 @@ async def test_test_connection_storage_local_rejects_unwritable_parent(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.LocalStorageConfig(root=str(missing_root))
+        return LocalStorageConfig(root=str(missing_root))
 
-    original_access = setup_service.os.access
+    original_access = local_storage_setup_probe.os.access
 
     def _fake_access(path: object, mode: int) -> bool:
-        if Path(str(path)) == parent and mode == (setup_service.os.W_OK | setup_service.os.X_OK):
+        if Path(str(path)) == parent and mode == (
+            local_storage_setup_probe.os.W_OK | local_storage_setup_probe.os.X_OK
+        ):
             return False
         return original_access(path, mode)
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service.os, "access", _fake_access)
+    monkeypatch.setattr(local_storage_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_storage_setup_probe.os, "access", _fake_access)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",
@@ -1027,10 +1042,10 @@ async def test_test_connection_storage_local_rejects_missing_parent_chain(
         **runtime_context: object,
     ) -> object:
         _ = (plugin_type, backend, config, runtime_context)
-        return setup_service.LocalStorageConfig(root="/nonexistent/root/dir")
+        return LocalStorageConfig(root="/nonexistent/root/dir")
 
-    monkeypatch.setattr(setup_service, "validate_plugin", _fake_validate_plugin)
-    monkeypatch.setattr(setup_service, "_nearest_existing_parent", lambda _path: None)
+    monkeypatch.setattr(local_storage_setup_probe, "validate_plugin", _fake_validate_plugin)
+    monkeypatch.setattr(local_storage_setup_probe, "nearest_existing_parent", lambda _path: None)
     monkeypatch.setattr(
         setup_service,
         "get_plugin_names",


### PR DESCRIPTION
## Summary
- move built-in setup probe implementations out of `setup.py` into backend-adjacent setup-only modules
- add a small builtin setup-probe loader so the separate registry still auto-discovers built-in probes
- update setup service tests to patch the new probe ownership points and cover builtin loader registration

## Testing
- TEST_DB_DSN=postgresql://homesec:homesec@localhost:55442/homesec_setup_probe_ci make check