### PR TITLE
test: isolate parallel postgres test runs

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,8 +11,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from alembic import context
-from sqlalchemy import text
-from sqlalchemy import pool
+from sqlalchemy import pool, text
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -21,13 +20,14 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from sqlalchemy import MetaData  # noqa: E402
+
 from homesec.postgres_support import (  # noqa: E402
     build_async_engine_kwargs,
     resolve_test_db_schema,
     schema_ddl_identifier,
 )
-from homesec.telemetry.db.log_table import metadata as telemetry_metadata  # noqa: E402
 from homesec.state.postgres import Base as StateBase  # noqa: E402
+from homesec.telemetry.db.log_table import metadata as telemetry_metadata  # noqa: E402
 
 # Combine all metadata into one for alembic
 target_metadata = MetaData()

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -23,6 +23,7 @@ from sqlalchemy import MetaData  # noqa: E402
 
 from homesec.postgres_support import (  # noqa: E402
     build_async_engine_kwargs,
+    normalize_async_dsn,
     resolve_test_db_schema,
     schema_ddl_identifier,
 )
@@ -46,7 +47,7 @@ def _get_url() -> str:
     url = os.getenv("DB_DSN") or os.getenv("DATABASE_URL") or config.get_main_option("sqlalchemy.url")
     if not url:
         raise RuntimeError("Missing DB_DSN (or DATABASE_URL) for alembic migration.")
-    return url
+    return normalize_async_dsn(url)
 
 
 def run_migrations_offline() -> None:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -23,6 +23,7 @@ from sqlalchemy import MetaData  # noqa: E402
 
 from homesec.postgres_support import (  # noqa: E402
     build_async_engine_kwargs,
+    is_test_db_schema_enabled,
     normalize_async_dsn,
     resolve_test_db_schema,
     schema_ddl_identifier,
@@ -78,7 +79,7 @@ def do_run_migrations(connection, schema: str | None) -> None:
 async def run_migrations_online() -> None:
     configuration = config.get_section(config.config_ini_section, {})
     configuration["sqlalchemy.url"] = _get_url()
-    schema = resolve_test_db_schema()
+    schema = resolve_test_db_schema() if is_test_db_schema_enabled() else None
     engine_kwargs = build_async_engine_kwargs(schema=schema)
 
     connectable = async_engine_from_config(

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -89,12 +89,13 @@ async def run_migrations_online() -> None:
         **engine_kwargs,
     )
 
-    async with connectable.begin() as connection:
-        if schema is not None:
+    if schema is not None:
+        async with connectable.begin() as connection:
             await connection.execute(
                 text(f"CREATE SCHEMA IF NOT EXISTS {schema_ddl_identifier(schema)}")
             )
-            await connection.execute(text(f"SET search_path TO {schema_ddl_identifier(schema)}"))
+
+    async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations, schema)
 
     await connectable.dispose()

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from alembic import context
+from sqlalchemy import text
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
@@ -20,6 +21,11 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from sqlalchemy import MetaData  # noqa: E402
+from homesec.postgres_support import (  # noqa: E402
+    build_async_engine_kwargs,
+    resolve_test_db_schema,
+    schema_ddl_identifier,
+)
 from homesec.telemetry.db.log_table import metadata as telemetry_metadata  # noqa: E402
 from homesec.state.postgres import Base as StateBase  # noqa: E402
 
@@ -56,8 +62,13 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def do_run_migrations(connection) -> None:
-    context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+def do_run_migrations(connection, schema: str | None) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        version_table_schema=schema,
+    )
 
     with context.begin_transaction():
         context.run_migrations()
@@ -66,11 +77,23 @@ def do_run_migrations(connection) -> None:
 async def run_migrations_online() -> None:
     configuration = config.get_section(config.config_ini_section, {})
     configuration["sqlalchemy.url"] = _get_url()
+    schema = resolve_test_db_schema()
+    engine_kwargs = build_async_engine_kwargs(schema=schema)
 
-    connectable = async_engine_from_config(configuration, prefix="sqlalchemy.", poolclass=pool.NullPool)
+    connectable = async_engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        **engine_kwargs,
+    )
 
-    async with connectable.connect() as connection:
-        await connection.run_sync(do_run_migrations)
+    async with connectable.begin() as connection:
+        if schema is not None:
+            await connection.execute(
+                text(f"CREATE SCHEMA IF NOT EXISTS {schema_ddl_identifier(schema)}")
+            )
+            await connection.execute(text(f"SET search_path TO {schema_ddl_identifier(schema)}"))
+        await connection.run_sync(do_run_migrations, schema)
 
     await connectable.dispose()
 

--- a/src/homesec/postgres_support.py
+++ b/src/homesec/postgres_support.py
@@ -11,6 +11,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 TEST_DB_SCHEMA_ENV = "HOMESEC_TEST_DB_SCHEMA"
+TEST_DB_SCHEMA_ENABLE_ENV = "HOMESEC_ENABLE_TEST_DB_SCHEMA"
 _SCHEMA_PATTERN = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
 
 
@@ -33,6 +34,12 @@ def resolve_test_db_schema(env: Mapping[str, str] | None = None) -> str | None:
     return validate_schema_name(configured)
 
 
+def is_test_db_schema_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether test-only schema scoping is explicitly enabled."""
+    configured = (os.environ if env is None else env).get(TEST_DB_SCHEMA_ENABLE_ENV, "")
+    return configured.lower() in {"1", "true", "yes", "on"}
+
+
 def validate_schema_name(schema: str) -> str:
     """Validate a Postgres schema identifier used for test isolation."""
     if not _SCHEMA_PATTERN.fullmatch(schema):
@@ -47,9 +54,9 @@ def build_async_engine_kwargs(
     schema: str | None = None,
     engine_kwargs: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build SQLAlchemy engine kwargs with an optional schema search path."""
+    """Build SQLAlchemy engine kwargs with an optional explicit schema search path."""
     kwargs = dict(engine_kwargs or {})
-    target_schema = resolve_test_db_schema() if schema is None else validate_schema_name(schema)
+    target_schema = None if schema is None else validate_schema_name(schema)
     if target_schema is None:
         return kwargs
 
@@ -72,7 +79,7 @@ def create_scoped_async_engine(
     schema: str | None = None,
     **engine_kwargs: Any,
 ) -> AsyncEngine:
-    """Create an async engine scoped to the configured schema when present."""
+    """Create an async engine scoped to the explicit schema when present."""
     return create_async_engine(
         normalize_async_dsn(dsn),
         **build_async_engine_kwargs(schema=schema, engine_kwargs=engine_kwargs),

--- a/src/homesec/postgres_support.py
+++ b/src/homesec/postgres_support.py
@@ -1,0 +1,101 @@
+"""Shared Postgres engine helpers."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+TEST_DB_SCHEMA_ENV = "HOMESEC_TEST_DB_SCHEMA"
+_SCHEMA_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+
+def normalize_async_dsn(dsn: str) -> str:
+    """Normalize Postgres DSNs to the asyncpg SQLAlchemy dialect."""
+    if "+asyncpg" in dsn:
+        return dsn
+    if dsn.startswith("postgresql://"):
+        return dsn.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if dsn.startswith("postgres://"):
+        return dsn.replace("postgres://", "postgresql+asyncpg://", 1)
+    return dsn
+
+
+def resolve_test_db_schema(env: Mapping[str, str] | None = None) -> str | None:
+    """Return the configured test schema, if any."""
+    configured = (os.environ if env is None else env).get(TEST_DB_SCHEMA_ENV)
+    if configured is None or configured == "":
+        return None
+    return validate_schema_name(configured)
+
+
+def validate_schema_name(schema: str) -> str:
+    """Validate a Postgres schema identifier used for test isolation."""
+    if not _SCHEMA_PATTERN.fullmatch(schema):
+        raise ValueError(
+            f"Invalid Postgres schema {schema!r}; expected /{_SCHEMA_PATTERN.pattern}/"
+        )
+    return schema
+
+
+def build_async_engine_kwargs(
+    *,
+    schema: str | None = None,
+    engine_kwargs: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build SQLAlchemy engine kwargs with an optional schema search path."""
+    kwargs = dict(engine_kwargs or {})
+    target_schema = resolve_test_db_schema() if schema is None else validate_schema_name(schema)
+    if target_schema is None:
+        return kwargs
+
+    connect_args = dict(kwargs.get("connect_args", {}))
+    server_settings = dict(connect_args.get("server_settings", {}))
+    server_settings.setdefault("search_path", target_schema)
+    connect_args["server_settings"] = server_settings
+    kwargs["connect_args"] = connect_args
+    return kwargs
+
+
+def create_scoped_async_engine(
+    dsn: str,
+    *,
+    schema: str | None = None,
+    **engine_kwargs: Any,
+) -> AsyncEngine:
+    """Create an async engine scoped to the configured schema when present."""
+    return create_async_engine(
+        normalize_async_dsn(dsn),
+        **build_async_engine_kwargs(schema=schema, engine_kwargs=engine_kwargs),
+    )
+
+
+def schema_ddl_identifier(schema: str) -> str:
+    """Return a quoted schema identifier for DDL statements."""
+    return f'"{validate_schema_name(schema)}"'
+
+
+async def create_schema_if_missing(dsn: str, schema: str) -> None:
+    """Create a schema for an isolated test run if it does not exist."""
+    engine = create_async_engine(normalize_async_dsn(dsn))
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema_ddl_identifier(schema)}"))
+    finally:
+        await engine.dispose()
+
+
+async def drop_schema_cascade(dsn: str, schema: str) -> None:
+    """Drop an isolated test schema and everything inside it."""
+    engine = create_async_engine(normalize_async_dsn(dsn))
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(f"DROP SCHEMA IF EXISTS {schema_ddl_identifier(schema)} CASCADE")
+            )
+    finally:
+        await engine.dispose()

--- a/src/homesec/postgres_support.py
+++ b/src/homesec/postgres_support.py
@@ -1,4 +1,4 @@
-"""Shared Postgres engine helpers."""
+"""Shared Postgres helpers for async engines and test schema isolation."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 TEST_DB_SCHEMA_ENV = "HOMESEC_TEST_DB_SCHEMA"
-_SCHEMA_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+_SCHEMA_PATTERN = re.compile(r"^[a-z_][a-z0-9_]{0,62}$")
 
 
 def normalize_async_dsn(dsn: str) -> str:
@@ -55,7 +55,12 @@ def build_async_engine_kwargs(
 
     connect_args = dict(kwargs.get("connect_args", {}))
     server_settings = dict(connect_args.get("server_settings", {}))
-    server_settings.setdefault("search_path", target_schema)
+    existing_search_path = server_settings.get("search_path")
+    if existing_search_path is not None and existing_search_path != target_schema:
+        raise ValueError(
+            "engine_kwargs.connect_args.server_settings.search_path conflicts with schema"
+        )
+    server_settings["search_path"] = target_schema
     connect_args["server_settings"] = server_settings
     kwargs["connect_args"] = connect_args
     return kwargs

--- a/src/homesec/postgres_support.py
+++ b/src/homesec/postgres_support.py
@@ -1,4 +1,8 @@
-"""Shared Postgres helpers for async engines and test schema isolation."""
+"""Shared Postgres helpers for async engines and test schema isolation.
+
+The separate enable flag exists so production code never honors a stray test
+schema env var unless the test harness opts in explicitly.
+"""
 
 from __future__ import annotations
 

--- a/src/homesec/state/postgres.py
+++ b/src/homesec/state/postgres.py
@@ -25,7 +25,7 @@ from sqlalchemy import cast as sa_cast
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import DBAPIError, OperationalError
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from homesec.interfaces import EventStore, StateStore
@@ -53,6 +53,7 @@ from homesec.models.events import (
 from homesec.models.events import (
     ClipEvent as ClipEventModel,
 )
+from homesec.postgres_support import create_scoped_async_engine, normalize_async_dsn
 
 logger = logging.getLogger(__name__)
 _BATCH_STATE_LOOKUP_SIZE = 1000
@@ -148,13 +149,7 @@ class ClipEvent(Base):
 
 
 def _normalize_async_dsn(dsn: str) -> str:
-    if "+asyncpg" in dsn:
-        return dsn
-    if dsn.startswith("postgresql://"):
-        return dsn.replace("postgresql://", "postgresql+asyncpg://", 1)
-    if dsn.startswith("postgres://"):
-        return dsn.replace("postgres://", "postgresql+asyncpg://", 1)
-    return dsn
+    return normalize_async_dsn(dsn)
 
 
 class PostgresStateStore(StateStore):
@@ -164,13 +159,14 @@ class PostgresStateStore(StateStore):
     instead of raising when DB is unavailable.
     """
 
-    def __init__(self, dsn: str) -> None:
+    def __init__(self, dsn: str, *, schema: str | None = None) -> None:
         """Initialize state store.
 
         Args:
             dsn: Postgres connection string (e.g., "postgresql+asyncpg://user:pass@host/db")
         """
         self._dsn = _normalize_async_dsn(dsn)
+        self._schema = schema
         self._engine: AsyncEngine | None = None
 
     async def initialize(self) -> bool:
@@ -182,8 +178,9 @@ class PostgresStateStore(StateStore):
             True if initialization succeeded, False otherwise
         """
         try:
-            self._engine = create_async_engine(
+            self._engine = create_scoped_async_engine(
                 self._dsn,
+                schema=self._schema,
                 pool_pre_ping=True,
                 pool_size=5,
                 max_overflow=0,

--- a/src/homesec/state/postgres.py
+++ b/src/homesec/state/postgres.py
@@ -149,6 +149,7 @@ class ClipEvent(Base):
 
 
 def _normalize_async_dsn(dsn: str) -> str:
+    """Kept as a shim for tests importing DSN normalization from this module."""
     return normalize_async_dsn(dsn)
 
 

--- a/src/homesec/state/postgres.py
+++ b/src/homesec/state/postgres.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
+import homesec.postgres_support as postgres_support
 from homesec.interfaces import EventStore, StateStore
 from homesec.models.clip import ClipListCursor, ClipListPage, ClipStateData
 from homesec.models.enums import ClipStatus, EventType
@@ -53,7 +54,6 @@ from homesec.models.events import (
 from homesec.models.events import (
     ClipEvent as ClipEventModel,
 )
-from homesec.postgres_support import create_scoped_async_engine, normalize_async_dsn
 
 logger = logging.getLogger(__name__)
 _BATCH_STATE_LOOKUP_SIZE = 1000
@@ -148,11 +148,6 @@ class ClipEvent(Base):
     )
 
 
-def _normalize_async_dsn(dsn: str) -> str:
-    """Kept as a shim for tests importing DSN normalization from this module."""
-    return normalize_async_dsn(dsn)
-
-
 class PostgresStateStore(StateStore):
     """Postgres implementation of StateStore interface.
 
@@ -166,7 +161,7 @@ class PostgresStateStore(StateStore):
         Args:
             dsn: Postgres connection string (e.g., "postgresql+asyncpg://user:pass@host/db")
         """
-        self._dsn = _normalize_async_dsn(dsn)
+        self._dsn = dsn
         self._schema = schema
         self._engine: AsyncEngine | None = None
 
@@ -179,7 +174,7 @@ class PostgresStateStore(StateStore):
             True if initialization succeeded, False otherwise
         """
         try:
-            self._engine = create_scoped_async_engine(
+            self._engine = postgres_support.create_scoped_async_engine(
                 self._dsn,
                 schema=self._schema,
                 pool_pre_ping=True,

--- a/src/homesec/telemetry/db_log_handler.py
+++ b/src/homesec/telemetry/db_log_handler.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from homesec.postgres_support import create_scoped_async_engine
+import homesec.postgres_support as postgres_support
 from homesec.telemetry.db.log_table import logs
 from homesec.telemetry.db.log_table import metadata as db_metadata
 from homesec.telemetry.postgres_settings import PostgresConfig
@@ -202,7 +202,7 @@ class AsyncPostgresJsonLogHandler(logging.Handler):
         backoff = float(self.config.db_log_backoff_initial_s)
         backoff_max = float(self.config.db_log_backoff_max_s)
 
-        engine = create_scoped_async_engine(self.config.db_dsn, pool_pre_ping=True)
+        engine = postgres_support.create_scoped_async_engine(self.config.db_dsn, pool_pre_ping=True)
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 

--- a/src/homesec/telemetry/db_log_handler.py
+++ b/src/homesec/telemetry/db_log_handler.py
@@ -13,8 +13,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import insert
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine
 
+from homesec.postgres_support import create_scoped_async_engine
 from homesec.telemetry.db.log_table import logs
 from homesec.telemetry.db.log_table import metadata as db_metadata
 from homesec.telemetry.postgres_settings import PostgresConfig
@@ -201,7 +202,7 @@ class AsyncPostgresJsonLogHandler(logging.Handler):
         backoff = float(self.config.db_log_backoff_initial_s)
         backoff_max = float(self.config.db_log_backoff_max_s)
 
-        engine = create_async_engine(self.config.db_dsn, pool_pre_ping=True)
+        engine = create_scoped_async_engine(self.config.db_dsn, pool_pre_ping=True)
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 

--- a/tests/homesec/conftest.py
+++ b/tests/homesec/conftest.py
@@ -19,8 +19,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 import homesec.postgres_support as postgres_support
 from homesec.models.clip import Clip
 from homesec.postgres_support import (
-    TEST_DB_SCHEMA_ENABLE_ENV,
-    TEST_DB_SCHEMA_ENV,
     create_schema_if_missing,
     drop_schema_cascade,
     resolve_test_db_schema,
@@ -33,10 +31,7 @@ from tests.homesec.mocks import (
     MockStorage,
     MockVLM,
 )
-
-
-def _default_test_dsn() -> str:
-    return os.getenv("TEST_DB_DSN", "postgresql://homesec:homesec@localhost:5432/homesec")
+from tests.homesec.postgres_test_support import default_test_dsn, reset_store_tables
 
 
 def _generate_test_schema_name() -> str:
@@ -47,31 +42,17 @@ def _generate_test_schema_name() -> str:
 @pytest.fixture(scope="session")
 def isolated_postgres_schema() -> str:
     """Provision a per-run schema so parallel test runs can share one Postgres instance."""
-    dsn = _default_test_dsn()
-    previous_raw = os.environ.get(TEST_DB_SCHEMA_ENV)
-    previous_enabled_raw = os.environ.get(TEST_DB_SCHEMA_ENABLE_ENV)
+    dsn = default_test_dsn()
     configured_schema = resolve_test_db_schema()
     created_by_fixture = configured_schema is None
     schema = _generate_test_schema_name() if created_by_fixture else configured_schema
 
     asyncio.run(create_schema_if_missing(dsn, schema))
-    os.environ[TEST_DB_SCHEMA_ENV] = schema
-    os.environ[TEST_DB_SCHEMA_ENABLE_ENV] = "1"
     try:
         yield schema
     finally:
-        try:
-            if created_by_fixture:
-                asyncio.run(drop_schema_cascade(dsn, schema))
-        finally:
-            if previous_raw is None:
-                os.environ.pop(TEST_DB_SCHEMA_ENV, None)
-            else:
-                os.environ[TEST_DB_SCHEMA_ENV] = previous_raw
-            if previous_enabled_raw is None:
-                os.environ.pop(TEST_DB_SCHEMA_ENABLE_ENV, None)
-            else:
-                os.environ[TEST_DB_SCHEMA_ENABLE_ENV] = previous_enabled_raw
+        if created_by_fixture:
+            asyncio.run(drop_schema_cascade(dsn, schema))
 
 
 @pytest.fixture(autouse=True)
@@ -88,22 +69,21 @@ def scope_postgres_test_schema(
     monkeypatch: pytest.MonkeyPatch, isolated_postgres_schema: str
 ) -> None:
     """Scope in-process Postgres engines to the session's isolated schema."""
+    base_create_scoped_engine = postgres_support.create_scoped_async_engine
 
     def _create_scoped_engine(
         dsn: str, *, schema: str | None = None, **engine_kwargs: Any
     ) -> AsyncEngine:
         target_schema = isolated_postgres_schema if schema is None else schema
-        return postgres_support.create_scoped_async_engine(
+        return base_create_scoped_engine(
             dsn,
             schema=target_schema,
             **engine_kwargs,
         )
 
-    monkeypatch.setattr("homesec.state.postgres.create_scoped_async_engine", _create_scoped_engine)
-    monkeypatch.setattr(
-        "homesec.telemetry.db_log_handler.create_scoped_async_engine",
-        _create_scoped_engine,
-    )
+    # Keep runtime callers going through homesec.postgres_support so this fixture
+    # remains the single in-process test isolation seam.
+    monkeypatch.setattr(postgres_support, "create_scoped_async_engine", _create_scoped_engine)
 
 
 @pytest.fixture
@@ -154,7 +134,7 @@ def sample_clip() -> Clip:
 @pytest.fixture
 def postgres_dsn(scope_postgres_test_schema: None) -> str:
     """Return test Postgres DSN (requires local DB running)."""
-    return _default_test_dsn()
+    return default_test_dsn()
 
 
 @pytest.fixture
@@ -162,14 +142,12 @@ async def clean_test_db(postgres_dsn: str) -> None:
     """Clean up test data after each test."""
     from sqlalchemy import delete
 
-    from homesec.state.postgres import Base, ClipEvent, ClipState, PostgresStateStore
+    from homesec.state.postgres import ClipEvent, ClipState, PostgresStateStore
 
     store = PostgresStateStore(postgres_dsn)
     await store.initialize()
     if store._engine is not None:
-        async with store._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-            await conn.run_sync(Base.metadata.create_all)
+        await reset_store_tables(store)
 
     yield  # Run the test first
 

--- a/tests/homesec/conftest.py
+++ b/tests/homesec/conftest.py
@@ -19,6 +19,7 @@ from homesec.postgres_support import (
     TEST_DB_SCHEMA_ENV,
     create_schema_if_missing,
     drop_schema_cascade,
+    resolve_test_db_schema,
 )
 from homesec.sources.rtsp.capabilities import get_global_rtsp_timeout_capabilities
 from tests.homesec.mocks import (
@@ -43,8 +44,10 @@ def _generate_test_schema_name() -> str:
 def isolated_postgres_schema() -> str:
     """Provision a per-run schema so parallel test runs can share one Postgres instance."""
     dsn = _default_test_dsn()
-    schema = os.getenv(TEST_DB_SCHEMA_ENV, _generate_test_schema_name())
-    previous = os.environ.get(TEST_DB_SCHEMA_ENV)
+    previous_raw = os.environ.get(TEST_DB_SCHEMA_ENV)
+    configured_schema = resolve_test_db_schema()
+    created_by_fixture = configured_schema is None
+    schema = _generate_test_schema_name() if created_by_fixture else configured_schema
 
     asyncio.run(create_schema_if_missing(dsn, schema))
     os.environ[TEST_DB_SCHEMA_ENV] = schema
@@ -52,12 +55,13 @@ def isolated_postgres_schema() -> str:
         yield schema
     finally:
         try:
-            asyncio.run(drop_schema_cascade(dsn, schema))
+            if created_by_fixture:
+                asyncio.run(drop_schema_cascade(dsn, schema))
         finally:
-            if previous is None:
+            if previous_raw is None:
                 os.environ.pop(TEST_DB_SCHEMA_ENV, None)
             else:
-                os.environ[TEST_DB_SCHEMA_ENV] = previous
+                os.environ[TEST_DB_SCHEMA_ENV] = previous_raw
 
 
 @pytest.fixture(autouse=True)

--- a/tests/homesec/conftest.py
+++ b/tests/homesec/conftest.py
@@ -1,6 +1,9 @@
 """Shared pytest fixtures for HomeSec tests."""
 
+import asyncio
+import os
 import sys
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -12,6 +15,11 @@ if str(src_path.resolve()) not in sys.path:
 import pytest
 
 from homesec.models.clip import Clip
+from homesec.postgres_support import (
+    TEST_DB_SCHEMA_ENV,
+    create_schema_if_missing,
+    drop_schema_cascade,
+)
 from homesec.sources.rtsp.capabilities import get_global_rtsp_timeout_capabilities
 from tests.homesec.mocks import (
     MockFilter,
@@ -20,6 +28,36 @@ from tests.homesec.mocks import (
     MockStorage,
     MockVLM,
 )
+
+
+def _default_test_dsn() -> str:
+    return os.getenv("TEST_DB_DSN", "postgresql://homesec:homesec@localhost:5432/homesec")
+
+
+def _generate_test_schema_name() -> str:
+    token = uuid.uuid4().hex[:8]
+    return f"hs_pytest_{os.getpid()}_{token}"
+
+
+@pytest.fixture(scope="session")
+def isolated_postgres_schema() -> str:
+    """Provision a per-run schema so parallel test runs can share one Postgres instance."""
+    dsn = _default_test_dsn()
+    schema = os.getenv(TEST_DB_SCHEMA_ENV, _generate_test_schema_name())
+    previous = os.environ.get(TEST_DB_SCHEMA_ENV)
+
+    asyncio.run(create_schema_if_missing(dsn, schema))
+    os.environ[TEST_DB_SCHEMA_ENV] = schema
+    try:
+        yield schema
+    finally:
+        try:
+            asyncio.run(drop_schema_cascade(dsn, schema))
+        finally:
+            if previous is None:
+                os.environ.pop(TEST_DB_SCHEMA_ENV, None)
+            else:
+                os.environ[TEST_DB_SCHEMA_ENV] = previous
 
 
 @pytest.fixture(autouse=True)
@@ -77,11 +115,10 @@ def sample_clip() -> Clip:
 
 
 @pytest.fixture
-def postgres_dsn() -> str:
+def postgres_dsn(isolated_postgres_schema: str) -> str:
     """Return test Postgres DSN (requires local DB running)."""
-    import os
-
-    return os.getenv("TEST_DB_DSN", "postgresql://homesec:homesec@localhost:5432/homesec")
+    _ = isolated_postgres_schema
+    return _default_test_dsn()
 
 
 @pytest.fixture

--- a/tests/homesec/conftest.py
+++ b/tests/homesec/conftest.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 # Add src to sys.path for imports
 src_path = Path(__file__).parent.parent.parent / "src"
@@ -14,8 +15,10 @@ if str(src_path.resolve()) not in sys.path:
 
 import pytest
 
+import homesec.postgres_support as postgres_support
 from homesec.models.clip import Clip
 from homesec.postgres_support import (
+    TEST_DB_SCHEMA_ENABLE_ENV,
     TEST_DB_SCHEMA_ENV,
     create_schema_if_missing,
     drop_schema_cascade,
@@ -45,12 +48,14 @@ def isolated_postgres_schema() -> str:
     """Provision a per-run schema so parallel test runs can share one Postgres instance."""
     dsn = _default_test_dsn()
     previous_raw = os.environ.get(TEST_DB_SCHEMA_ENV)
+    previous_enabled_raw = os.environ.get(TEST_DB_SCHEMA_ENABLE_ENV)
     configured_schema = resolve_test_db_schema()
     created_by_fixture = configured_schema is None
     schema = _generate_test_schema_name() if created_by_fixture else configured_schema
 
     asyncio.run(create_schema_if_missing(dsn, schema))
     os.environ[TEST_DB_SCHEMA_ENV] = schema
+    os.environ[TEST_DB_SCHEMA_ENABLE_ENV] = "1"
     try:
         yield schema
     finally:
@@ -62,6 +67,10 @@ def isolated_postgres_schema() -> str:
                 os.environ.pop(TEST_DB_SCHEMA_ENV, None)
             else:
                 os.environ[TEST_DB_SCHEMA_ENV] = previous_raw
+            if previous_enabled_raw is None:
+                os.environ.pop(TEST_DB_SCHEMA_ENABLE_ENV, None)
+            else:
+                os.environ[TEST_DB_SCHEMA_ENABLE_ENV] = previous_enabled_raw
 
 
 @pytest.fixture(autouse=True)
@@ -71,6 +80,27 @@ def reset_rtsp_timeout_capabilities() -> None:
     capabilities.reset()
     yield
     capabilities.reset()
+
+
+@pytest.fixture
+def scope_postgres_test_schema(
+    monkeypatch: pytest.MonkeyPatch, isolated_postgres_schema: str
+) -> None:
+    """Scope in-process Postgres engines to the session's isolated schema."""
+
+    def _create_scoped_engine(dsn: str, *, schema: str | None = None, **engine_kwargs: Any):
+        target_schema = isolated_postgres_schema if schema is None else schema
+        return postgres_support.create_scoped_async_engine(
+            dsn,
+            schema=target_schema,
+            **engine_kwargs,
+        )
+
+    monkeypatch.setattr("homesec.state.postgres.create_scoped_async_engine", _create_scoped_engine)
+    monkeypatch.setattr(
+        "homesec.telemetry.db_log_handler.create_scoped_async_engine",
+        _create_scoped_engine,
+    )
 
 
 @pytest.fixture
@@ -119,7 +149,7 @@ def sample_clip() -> Clip:
 
 
 @pytest.fixture
-def postgres_dsn(isolated_postgres_schema: str) -> str:
+def postgres_dsn(scope_postgres_test_schema: None, isolated_postgres_schema: str) -> str:
     """Return test Postgres DSN (requires local DB running)."""
     _ = isolated_postgres_schema
     return _default_test_dsn()

--- a/tests/homesec/conftest.py
+++ b/tests/homesec/conftest.py
@@ -14,6 +14,7 @@ if str(src_path.resolve()) not in sys.path:
     sys.path.insert(0, str(src_path.resolve()))
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 import homesec.postgres_support as postgres_support
 from homesec.models.clip import Clip
@@ -88,7 +89,9 @@ def scope_postgres_test_schema(
 ) -> None:
     """Scope in-process Postgres engines to the session's isolated schema."""
 
-    def _create_scoped_engine(dsn: str, *, schema: str | None = None, **engine_kwargs: Any):
+    def _create_scoped_engine(
+        dsn: str, *, schema: str | None = None, **engine_kwargs: Any
+    ) -> AsyncEngine:
         target_schema = isolated_postgres_schema if schema is None else schema
         return postgres_support.create_scoped_async_engine(
             dsn,
@@ -149,9 +152,8 @@ def sample_clip() -> Clip:
 
 
 @pytest.fixture
-def postgres_dsn(scope_postgres_test_schema: None, isolated_postgres_schema: str) -> str:
+def postgres_dsn(scope_postgres_test_schema: None) -> str:
     """Return test Postgres DSN (requires local DB running)."""
-    _ = isolated_postgres_schema
     return _default_test_dsn()
 
 

--- a/tests/homesec/postgres_test_support.py
+++ b/tests/homesec/postgres_test_support.py
@@ -1,0 +1,22 @@
+"""Shared Postgres helpers for tests."""
+
+from __future__ import annotations
+
+import os
+
+from homesec.state.postgres import Base, PostgresStateStore
+
+DEFAULT_TEST_DSN = "postgresql://homesec:homesec@localhost:5432/homesec"
+
+
+def default_test_dsn() -> str:
+    """Return the Docker-backed Postgres DSN used by server-facing tests."""
+    return os.getenv("TEST_DB_DSN", DEFAULT_TEST_DSN)
+
+
+async def reset_store_tables(store: PostgresStateStore) -> None:
+    """Drop and recreate Postgres state tables for a clean test schema."""
+    assert store._engine is not None
+    async with store._engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)

--- a/tests/homesec/test_alembic_env.py
+++ b/tests/homesec/test_alembic_env.py
@@ -11,7 +11,12 @@ from pathlib import Path
 import pytest
 from sqlalchemy import text
 
-from homesec.postgres_support import create_scoped_async_engine, drop_schema_cascade
+from homesec.postgres_support import (
+    TEST_DB_SCHEMA_ENABLE_ENV,
+    TEST_DB_SCHEMA_ENV,
+    create_scoped_async_engine,
+    drop_schema_cascade,
+)
 
 
 def _plain_postgres_dsn(dsn: str) -> str:
@@ -29,7 +34,8 @@ async def test_alembic_upgrade_accepts_plain_postgres_dsn(postgres_dsn: str) -> 
     schema = f"hs_alembic_{uuid.uuid4().hex[:8]}"
     env = os.environ.copy()
     env["DB_DSN"] = _plain_postgres_dsn(postgres_dsn)
-    env["HOMESEC_TEST_DB_SCHEMA"] = schema
+    env[TEST_DB_SCHEMA_ENV] = schema
+    env[TEST_DB_SCHEMA_ENABLE_ENV] = "1"
 
     try:
         # When: Running alembic upgrade head in that schema

--- a/tests/homesec/test_alembic_env.py
+++ b/tests/homesec/test_alembic_env.py
@@ -1,0 +1,56 @@
+"""Tests for Alembic environment configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from homesec.postgres_support import create_scoped_async_engine, drop_schema_cascade
+
+
+def _plain_postgres_dsn(dsn: str) -> str:
+    """Convert an asyncpg SQLAlchemy DSN into the plain Postgres form."""
+    if dsn.startswith("postgresql+asyncpg://"):
+        return dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    return dsn
+
+
+@pytest.mark.asyncio
+async def test_alembic_upgrade_accepts_plain_postgres_dsn(postgres_dsn: str) -> None:
+    """Alembic should accept the repo's documented plain Postgres DSN form."""
+    # Given: A unique isolated schema and a plain Postgres DSN
+    repo_root = Path(__file__).resolve().parents[2]
+    schema = f"hs_alembic_{uuid.uuid4().hex[:8]}"
+    env = os.environ.copy()
+    env["DB_DSN"] = _plain_postgres_dsn(postgres_dsn)
+    env["HOMESEC_TEST_DB_SCHEMA"] = schema
+
+    try:
+        # When: Running alembic upgrade head in that schema
+        result = subprocess.run(
+            [sys.executable, "-m", "alembic", "-c", "alembic.ini", "upgrade", "head"],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        # Then: Migration succeeds and creates the alembic version table in that schema
+        assert result.returncode == 0, result.stderr
+
+        engine = create_scoped_async_engine(postgres_dsn, schema=schema)
+        try:
+            async with engine.connect() as conn:
+                version = await conn.scalar(text("SELECT version_num FROM alembic_version"))
+            assert version is not None
+        finally:
+            await engine.dispose()
+    finally:
+        await drop_schema_cascade(postgres_dsn, schema)

--- a/tests/homesec/test_postgres_support.py
+++ b/tests/homesec/test_postgres_support.py
@@ -1,0 +1,76 @@
+"""Tests for Postgres helper utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from homesec.postgres_support import (
+    build_async_engine_kwargs,
+    resolve_test_db_schema,
+    validate_schema_name,
+)
+
+
+def test_validate_schema_name_accepts_lowercase_max_length() -> None:
+    """validate_schema_name should accept valid lowercase identifiers up to 63 chars."""
+    # Given: A valid 63-character lowercase schema name
+    schema = "a" * 63
+
+    # When: Validating the schema name
+    validated = validate_schema_name(schema)
+
+    # Then: The original schema name is returned unchanged
+    assert validated == schema
+
+
+@pytest.mark.parametrize(
+    "invalid_schema",
+    [
+        "",
+        "1schema",
+        "has-dash",
+        'has"quote',
+        "Uppercase",
+        "a" * 64,
+    ],
+)
+def test_validate_schema_name_rejects_invalid_values(invalid_schema: str) -> None:
+    """validate_schema_name should reject invalid test schema identifiers."""
+    # Given: An invalid schema identifier candidate
+
+    # When/Then: Validation fails with ValueError
+    with pytest.raises(ValueError, match="Invalid Postgres schema"):
+        validate_schema_name(invalid_schema)
+
+
+def test_resolve_test_db_schema_returns_none_for_empty_string() -> None:
+    """resolve_test_db_schema should treat an empty env var as unset."""
+    # Given: An environment mapping with an empty test schema override
+    env = {"HOMESEC_TEST_DB_SCHEMA": ""}
+
+    # When: Resolving the configured test schema
+    schema = resolve_test_db_schema(env)
+
+    # Then: No schema override is returned
+    assert schema is None
+
+
+def test_build_async_engine_kwargs_sets_search_path_for_schema() -> None:
+    """build_async_engine_kwargs should set search_path for the requested schema."""
+    # Given: An explicit schema with no caller-specified search_path
+
+    # When: Building engine kwargs
+    kwargs = build_async_engine_kwargs(schema="hs_pytest_abc12345")
+
+    # Then: search_path is set to the requested schema
+    assert kwargs == {"connect_args": {"server_settings": {"search_path": "hs_pytest_abc12345"}}}
+
+
+def test_build_async_engine_kwargs_rejects_conflicting_search_path() -> None:
+    """build_async_engine_kwargs should reject conflicting caller-provided search_path values."""
+    # Given: An explicit schema and conflicting caller-provided server settings
+    engine_kwargs = {"connect_args": {"server_settings": {"search_path": "other_schema"}}}
+
+    # When/Then: Building engine kwargs fails loudly instead of silently ignoring schema
+    with pytest.raises(ValueError, match="search_path conflicts with schema"):
+        build_async_engine_kwargs(schema="hs_pytest_abc12345", engine_kwargs=engine_kwargs)

--- a/tests/homesec/test_postgres_support.py
+++ b/tests/homesec/test_postgres_support.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 from homesec.postgres_support import (
+    TEST_DB_SCHEMA_ENABLE_ENV,
+    TEST_DB_SCHEMA_ENV,
     build_async_engine_kwargs,
     is_test_db_schema_enabled,
     resolve_test_db_schema,
@@ -56,6 +58,17 @@ def test_resolve_test_db_schema_returns_none_for_empty_string() -> None:
     assert schema is None
 
 
+@pytest.mark.parametrize("invalid_schema", ["Uppercase", "1schema", "has-dash"])
+def test_resolve_test_db_schema_rejects_invalid_values(invalid_schema: str) -> None:
+    """resolve_test_db_schema should validate non-empty env values."""
+    # Given: An environment mapping with an invalid schema override
+    env = {TEST_DB_SCHEMA_ENV: invalid_schema}
+
+    # When/Then: Resolving the schema fails with ValueError
+    with pytest.raises(ValueError, match="Invalid Postgres schema"):
+        resolve_test_db_schema(env)
+
+
 def test_build_async_engine_kwargs_ignores_test_env_without_explicit_schema(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -70,22 +83,36 @@ def test_build_async_engine_kwargs_ignores_test_env_without_explicit_schema(
     assert kwargs == {}
 
 
-def test_test_db_schema_enabled_requires_explicit_opt_in() -> None:
-    """is_test_db_schema_enabled should only turn on when the harness opts in."""
-    # Given: Environments with and without the explicit enable flag
-    disabled_env = {"HOMESEC_TEST_DB_SCHEMA": "hs_pytest_abc12345"}
-    enabled_env = {
-        "HOMESEC_TEST_DB_SCHEMA": "hs_pytest_abc12345",
-        "HOMESEC_ENABLE_TEST_DB_SCHEMA": "1",
+@pytest.mark.parametrize("enabled_value", ["1", "true", "TRUE", "yes", "on"])
+def test_test_db_schema_enabled_accepts_truthy_values(enabled_value: str) -> None:
+    """is_test_db_schema_enabled should accept the documented truthy enable values."""
+    # Given: An environment mapping with an explicit enable flag
+    env = {
+        TEST_DB_SCHEMA_ENV: "hs_pytest_abc12345",
+        TEST_DB_SCHEMA_ENABLE_ENV: enabled_value,
     }
 
     # When: Evaluating whether test schema scoping is enabled
-    disabled = is_test_db_schema_enabled(disabled_env)
-    enabled = is_test_db_schema_enabled(enabled_env)
+    enabled = is_test_db_schema_enabled(env)
 
-    # Then: Schema scoping stays off unless the harness explicitly enables it
-    assert disabled is False
+    # Then: The harness opt-in is recognized as enabled
     assert enabled is True
+
+
+@pytest.mark.parametrize("disabled_value", ["", "0", "false", "FALSE", "no", "off"])
+def test_test_db_schema_enabled_rejects_falsy_values(disabled_value: str) -> None:
+    """is_test_db_schema_enabled should stay off for missing or falsy values."""
+    # Given: An environment mapping without a truthy enable flag
+    env = {
+        TEST_DB_SCHEMA_ENV: "hs_pytest_abc12345",
+        TEST_DB_SCHEMA_ENABLE_ENV: disabled_value,
+    }
+
+    # When: Evaluating whether test schema scoping is enabled
+    enabled = is_test_db_schema_enabled(env)
+
+    # Then: Schema scoping remains disabled
+    assert enabled is False
 
 
 def test_build_async_engine_kwargs_sets_search_path_for_schema() -> None:

--- a/tests/homesec/test_postgres_support.py
+++ b/tests/homesec/test_postgres_support.py
@@ -6,6 +6,7 @@ import pytest
 
 from homesec.postgres_support import (
     build_async_engine_kwargs,
+    is_test_db_schema_enabled,
     resolve_test_db_schema,
     validate_schema_name,
 )
@@ -53,6 +54,38 @@ def test_resolve_test_db_schema_returns_none_for_empty_string() -> None:
 
     # Then: No schema override is returned
     assert schema is None
+
+
+def test_build_async_engine_kwargs_ignores_test_env_without_explicit_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """build_async_engine_kwargs should ignore the test env unless schema is passed explicitly."""
+    # Given: A test-schema env var that should remain test-harness-only
+    monkeypatch.setenv("HOMESEC_TEST_DB_SCHEMA", "hs_pytest_abc12345")
+
+    # When: Building engine kwargs without an explicit schema
+    kwargs = build_async_engine_kwargs()
+
+    # Then: No search_path override is added implicitly
+    assert kwargs == {}
+
+
+def test_test_db_schema_enabled_requires_explicit_opt_in() -> None:
+    """is_test_db_schema_enabled should only turn on when the harness opts in."""
+    # Given: Environments with and without the explicit enable flag
+    disabled_env = {"HOMESEC_TEST_DB_SCHEMA": "hs_pytest_abc12345"}
+    enabled_env = {
+        "HOMESEC_TEST_DB_SCHEMA": "hs_pytest_abc12345",
+        "HOMESEC_ENABLE_TEST_DB_SCHEMA": "1",
+    }
+
+    # When: Evaluating whether test schema scoping is enabled
+    disabled = is_test_db_schema_enabled(disabled_env)
+    enabled = is_test_db_schema_enabled(enabled_env)
+
+    # Then: Schema scoping stays off unless the harness explicitly enables it
+    assert disabled is False
+    assert enabled is True
 
 
 def test_build_async_engine_kwargs_sets_search_path_for_schema() -> None:

--- a/tests/homesec/test_state_store.py
+++ b/tests/homesec/test_state_store.py
@@ -1,6 +1,7 @@
 """Tests for PostgresStateStore."""
 
 import os
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -13,6 +14,7 @@ from homesec.models.enums import ClipStatus
 from homesec.models.events import AlertDecisionMadeEvent, NotificationSentEvent
 from homesec.models.filter import FilterResult
 from homesec.models.vlm import AnalysisResult
+from homesec.postgres_support import create_schema_if_missing, drop_schema_cascade
 from homesec.state import PostgresStateStore
 from homesec.state.postgres import Base, ClipState, _normalize_async_dsn
 
@@ -26,11 +28,9 @@ def get_test_dsn() -> str:
 
 
 @pytest.fixture
-async def state_store() -> PostgresStateStore:
+async def state_store(postgres_dsn: str) -> PostgresStateStore:
     """Create and initialize a PostgresStateStore for testing."""
-    dsn = get_test_dsn()
-    assert dsn is not None
-    store = PostgresStateStore(dsn)
+    store = PostgresStateStore(postgres_dsn)
     initialized = await store.initialize()
     assert initialized, "Failed to initialize state store"
     if store._engine is not None:
@@ -118,6 +118,65 @@ async def test_upsert_and_get_roundtrip(state_store: PostgresStateStore) -> None
     assert retrieved is not None
     assert retrieved.camera_name == "front_door"
     assert retrieved.status == "queued_local"
+
+
+@pytest.mark.asyncio
+async def test_state_stores_with_distinct_schemas_do_not_interfere(postgres_dsn: str) -> None:
+    """State stores using separate schemas on one Postgres instance should remain isolated."""
+    # Given: Two state stores pointed at the same database with distinct schemas
+    token = uuid.uuid4().hex[:8]
+    schema_a = f"hs_parallel_a_{token}"
+    schema_b = f"hs_parallel_b_{token}"
+    await create_schema_if_missing(postgres_dsn, schema_a)
+    await create_schema_if_missing(postgres_dsn, schema_b)
+    store_a = PostgresStateStore(postgres_dsn, schema=schema_a)
+    store_b = PostgresStateStore(postgres_dsn, schema=schema_b)
+    assert await store_a.initialize() is True
+    assert await store_b.initialize() is True
+
+    try:
+        assert store_a._engine is not None
+        assert store_b._engine is not None
+        async with store_a._engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+        async with store_b._engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
+        # When: Each schema stores a clip with the same id
+        clip_id = "test_parallel_schema_001"
+        await store_a.upsert(
+            clip_id,
+            ClipStateData(
+                camera_name="front_door",
+                status=ClipStatus.UPLOADED,
+                local_path="/tmp/a.mp4",
+            ),
+        )
+        await store_b.upsert(
+            clip_id,
+            ClipStateData(
+                camera_name="garage",
+                status=ClipStatus.ANALYZED,
+                local_path="/tmp/b.mp4",
+            ),
+        )
+
+        # Then: Each store reads only its own schema-local row
+        state_a = await store_a.get(clip_id)
+        state_b = await store_b.get(clip_id)
+        assert state_a is not None
+        assert state_b is not None
+        assert state_a.camera_name == "front_door"
+        assert state_b.camera_name == "garage"
+        assert state_a.status == ClipStatus.UPLOADED
+        assert state_b.status == ClipStatus.ANALYZED
+    finally:
+        await store_a.shutdown()
+        await store_b.shutdown()
+        await drop_schema_cascade(postgres_dsn, schema_a)
+        await drop_schema_cascade(postgres_dsn, schema_b)
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/test_state_store.py
+++ b/tests/homesec/test_state_store.py
@@ -1,6 +1,5 @@
 """Tests for PostgresStateStore."""
 
-import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -14,17 +13,14 @@ from homesec.models.enums import ClipStatus
 from homesec.models.events import AlertDecisionMadeEvent, NotificationSentEvent
 from homesec.models.filter import FilterResult
 from homesec.models.vlm import AnalysisResult
-from homesec.postgres_support import create_schema_if_missing, drop_schema_cascade
+from homesec.postgres_support import (
+    create_schema_if_missing,
+    drop_schema_cascade,
+    normalize_async_dsn,
+)
 from homesec.state import PostgresStateStore
-from homesec.state.postgres import Base, ClipState, _normalize_async_dsn
-
-# Default DSN for local Docker Postgres (matches docker-compose.postgres.yml)
-DEFAULT_DSN = "postgresql://homesec:homesec@localhost:5432/homesec"
-
-
-def get_test_dsn() -> str:
-    """Get test database DSN from environment or use default."""
-    return os.environ.get("TEST_DB_DSN", DEFAULT_DSN)
+from homesec.state.postgres import ClipState
+from tests.homesec.postgres_test_support import default_test_dsn, reset_store_tables
 
 
 @pytest.fixture
@@ -34,9 +30,7 @@ async def state_store(postgres_dsn: str) -> PostgresStateStore:
     initialized = await store.initialize()
     assert initialized, "Failed to initialize state store"
     if store._engine is not None:
-        async with store._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-            await conn.run_sync(Base.metadata.create_all)
+        await reset_store_tables(store)
     yield store
     # Cleanup: drop test data
     if store._engine is not None:
@@ -93,9 +87,9 @@ def test_normalize_async_dsn() -> None:
     dsn_async = "postgresql+asyncpg://user:pass@localhost/db"
 
     # When normalizing DSNs
-    norm_plain = _normalize_async_dsn(dsn_plain)
-    norm_short = _normalize_async_dsn(dsn_short)
-    norm_async = _normalize_async_dsn(dsn_async)
+    norm_plain = normalize_async_dsn(dsn_plain)
+    norm_short = normalize_async_dsn(dsn_short)
+    norm_async = normalize_async_dsn(dsn_async)
 
     # Then asyncpg is used
     assert norm_plain.startswith("postgresql+asyncpg://")
@@ -135,14 +129,8 @@ async def test_state_stores_with_distinct_schemas_do_not_interfere(postgres_dsn:
     assert await store_b.initialize() is True
 
     try:
-        assert store_a._engine is not None
-        assert store_b._engine is not None
-        async with store_a._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-            await conn.run_sync(Base.metadata.create_all)
-        async with store_b._engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-            await conn.run_sync(Base.metadata.create_all)
+        await reset_store_tables(store_a)
+        await reset_store_tables(store_b)
 
         # When: Each schema stores a clip with the same id
         clip_id = "test_parallel_schema_001"
@@ -913,7 +901,7 @@ async def test_count_alerts_since_ignores_notification_sent_events(
 @pytest.mark.asyncio
 async def test_count_alerts_since_returns_zero_when_uninitialized() -> None:
     # Given: A state store that has not been initialized
-    store = PostgresStateStore(get_test_dsn())
+    store = PostgresStateStore(default_test_dsn())
 
     # When: Counting alerts without a database engine
     count = await store.count_alerts_since(datetime.now(timezone.utc) - timedelta(hours=1))


### PR DESCRIPTION
## Summary
- add shared Postgres schema-scoping helpers for test-only schema isolation and DSN normalization
- scope Alembic migrations and in-process SQLAlchemy engines to a per-run schema so concurrent worktrees can reuse one Postgres instance safely
- harden the harness with explicit test-only env opt-in for Alembic schema scoping, strict schema-name validation, and a single in-process patch seam through `homesec.postgres_support`
- consolidate test-only DSN and table-reset helpers, and add coverage for helper contracts, Alembic schema migration behavior, and cross-schema isolation

## Why
Parallel server-facing tests were sharing one database namespace and using global table reset behavior, so concurrent worktrees or subagents could destroy each other's tables mid-run.

This keeps production behavior unchanged: normal runtime paths stay on the default schema unless a caller passes an explicit schema, and Alembic only honors the test schema env vars when the test harness explicitly enables them.

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:5433/homesec make check`
