### PR TITLE
refactor: extract rtsp live publisher seam

### DIFF
--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -331,6 +331,7 @@ class RTSPSource(ThreadedClipSource):
         )
         self._owns_frame_pipeline = frame_pipeline is None
         self._live_publisher: LivePublisher = live_publisher or NoopLivePublisher()
+        self._live_publisher_shutdown = False
         self._owns_recorder = recorder is None
 
         self._frame_pipeline: FramePipeline = frame_pipeline or FfmpegFramePipeline(
@@ -417,6 +418,13 @@ class RTSPSource(ThreadedClipSource):
             self._live_publisher.note_viewer_activity(viewer_id=viewer_id)
         except Exception as exc:
             logger.warning("Preview viewer activity update failed: %s", exc, exc_info=True)
+
+    def stop(self, timeout: float | None = None) -> None:
+        """Stop the source and release preview resources even if start never ran."""
+        if self._thread is None:
+            self._shutdown_live_publisher_once()
+            return
+        super().stop(timeout)
 
     def _touch_heartbeat(self) -> None:
         self.last_successful_frame = self._clock.now()
@@ -1310,10 +1318,17 @@ class RTSPSource(ThreadedClipSource):
             self._stop_frame_pipeline()
         except Exception:
             logger.exception("Error stopping frame pipeline")
+        self._shutdown_live_publisher_once()
+
+    def _shutdown_live_publisher_once(self) -> None:
+        if self._live_publisher_shutdown:
+            return
         try:
             self._live_publisher.shutdown()
         except Exception:
             logger.exception("Error stopping live publisher")
+        finally:
+            self._live_publisher_shutdown = True
 
     def _finalize_clip(
         self,

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -390,7 +390,7 @@ class RTSPSource(ThreadedClipSource):
             logger.warning("Preview status lookup failed: %s", exc, exc_info=True)
             return LivePublisherStatus(
                 state=LivePublisherState.ERROR,
-                last_error=str(exc),
+                last_error="Preview publisher status unavailable",
             )
 
     def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
@@ -401,7 +401,7 @@ class RTSPSource(ThreadedClipSource):
             logger.warning("Preview activation failed: %s", exc, exc_info=True)
             return LivePublisherStartRefusal(
                 reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                message=f"Preview publisher activation failed: {exc}",
+                message="Preview publisher activation failed",
             )
 
     def stop_preview(self) -> None:

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -30,7 +30,9 @@ from homesec.sources.rtsp.frame_pipeline import FfmpegFramePipeline, FramePipeli
 from homesec.sources.rtsp.hardware import HardwareAccelConfig, HardwareAccelDetector
 from homesec.sources.rtsp.live_publisher import (
     LivePublisher,
+    LivePublisherRefusalReason,
     LivePublisherStartRefusal,
+    LivePublisherState,
     LivePublisherStatus,
     NoopLivePublisher,
 )
@@ -382,19 +384,39 @@ class RTSPSource(ThreadedClipSource):
 
     def preview_status(self) -> LivePublisherStatus:
         """Return the current preview publisher status for this camera."""
-        return self._live_publisher.status()
+        try:
+            return self._live_publisher.status()
+        except Exception as exc:
+            logger.warning("Preview status lookup failed: %s", exc, exc_info=True)
+            return LivePublisherStatus(
+                state=LivePublisherState.ERROR,
+                last_error=str(exc),
+            )
 
     def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
         """Ensure the preview publisher is active for this camera."""
-        return self._live_publisher.ensure_active()
+        try:
+            return self._live_publisher.ensure_active()
+        except Exception as exc:
+            logger.warning("Preview activation failed: %s", exc, exc_info=True)
+            return LivePublisherStartRefusal(
+                reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message=f"Preview publisher activation failed: {exc}",
+            )
 
     def stop_preview(self) -> None:
         """Request preview shutdown for this camera."""
-        self._live_publisher.request_stop()
+        try:
+            self._live_publisher.request_stop()
+        except Exception as exc:
+            logger.warning("Preview stop failed: %s", exc, exc_info=True)
 
     def note_preview_viewer_activity(self, viewer_id: str | None = None) -> None:
         """Record viewer activity for preview idle-timeout decisions."""
-        self._live_publisher.note_viewer_activity(viewer_id=viewer_id)
+        try:
+            self._live_publisher.note_viewer_activity(viewer_id=viewer_id)
+        except Exception as exc:
+            logger.warning("Preview viewer activity update failed: %s", exc, exc_info=True)
 
     def _touch_heartbeat(self) -> None:
         self.last_successful_frame = self._clock.now()
@@ -572,7 +594,10 @@ class RTSPSource(ThreadedClipSource):
         return proc, output_file, start_mono, start_wall
 
     def _sync_live_publisher_recording_state(self) -> None:
-        self._live_publisher.sync_recording_active(self.recording_process is not None)
+        try:
+            self._live_publisher.sync_recording_active(self.recording_process is not None)
+        except Exception as exc:
+            logger.warning("Preview recording-state sync failed: %s", exc, exc_info=True)
 
     def _telemetry_common_fields(self) -> dict[str, object]:
         return {

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -28,6 +28,12 @@ from homesec.sources.rtsp.capabilities import (
 from homesec.sources.rtsp.clock import Clock, SystemClock
 from homesec.sources.rtsp.frame_pipeline import FfmpegFramePipeline, FramePipeline
 from homesec.sources.rtsp.hardware import HardwareAccelConfig, HardwareAccelDetector
+from homesec.sources.rtsp.live_publisher import (
+    LivePublisher,
+    LivePublisherStartRefusal,
+    LivePublisherStatus,
+    NoopLivePublisher,
+)
 from homesec.sources.rtsp.motion import MotionDetector
 from homesec.sources.rtsp.preflight import (
     CameraPreflightDiagnostics,
@@ -228,6 +234,7 @@ class RTSPSource(ThreadedClipSource):
         camera_name: str,
         *,
         frame_pipeline: FramePipeline | None = None,
+        live_publisher: LivePublisher | None = None,
         recorder: Recorder | None = None,
         clock: Clock | None = None,
         timeout_capabilities: RTSPTimeoutCapabilities | None = None,
@@ -321,6 +328,7 @@ class RTSPSource(ThreadedClipSource):
             debug=self.debug_motion,
         )
         self._owns_frame_pipeline = frame_pipeline is None
+        self._live_publisher: LivePublisher = live_publisher or NoopLivePublisher()
         self._owns_recorder = recorder is None
 
         self._frame_pipeline: FramePipeline = frame_pipeline or FfmpegFramePipeline(
@@ -371,6 +379,22 @@ class RTSPSource(ThreadedClipSource):
 
         age = self._clock.now() - self.last_successful_frame
         return age < (self.frame_timeout_s * 3)
+
+    def preview_status(self) -> LivePublisherStatus:
+        """Return the current preview publisher status for this camera."""
+        return self._live_publisher.status()
+
+    def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+        """Ensure the preview publisher is active for this camera."""
+        return self._live_publisher.ensure_active()
+
+    def stop_preview(self) -> None:
+        """Request preview shutdown for this camera."""
+        self._live_publisher.request_stop()
+
+    def note_preview_viewer_activity(self, viewer_id: str | None = None) -> None:
+        """Record viewer activity for preview idle-timeout decisions."""
+        self._live_publisher.note_viewer_activity(viewer_id=viewer_id)
 
     def _touch_heartbeat(self) -> None:
         self.last_successful_frame = self._clock.now()
@@ -524,6 +548,7 @@ class RTSPSource(ThreadedClipSource):
         self.recording_start_time = start_mono
         self.recording_start_wall = start_wall
         self._recording_id = output_file.name
+        self._sync_live_publisher_recording_state()
 
     def _clear_recording_state(
         self,
@@ -543,7 +568,11 @@ class RTSPSource(ThreadedClipSource):
         self.recording_start_time = None
         self.recording_start_wall = None
         self._recording_id = None
+        self._sync_live_publisher_recording_state()
         return proc, output_file, start_mono, start_wall
+
+    def _sync_live_publisher_recording_state(self) -> None:
+        self._live_publisher.sync_recording_active(self.recording_process is not None)
 
     def _telemetry_common_fields(self) -> dict[str, object]:
         return {
@@ -1256,6 +1285,10 @@ class RTSPSource(ThreadedClipSource):
             self._stop_frame_pipeline()
         except Exception:
             logger.exception("Error stopping frame pipeline")
+        try:
+            self._live_publisher.shutdown()
+        except Exception:
+            logger.exception("Error stopping live publisher")
 
     def _finalize_clip(
         self,

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class LivePublisherState(StrEnum):
+    IDLE = "idle"
+    STARTING = "starting"
+    READY = "ready"
+    DEGRADED = "degraded"
+    STOPPING = "stopping"
+    ERROR = "error"
+
+
+class LivePublisherRefusalReason(StrEnum):
+    RECORDING_PRIORITY = "recording_priority"
+    SESSION_BUDGET_EXHAUSTED = "session_budget_exhausted"
+    PREVIEW_TEMPORARILY_UNAVAILABLE = "preview_temporarily_unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class LivePublisherStatus:
+    state: LivePublisherState
+    viewer_count: int | None = None
+    degraded_reason: str | None = None
+    last_error: str | None = None
+    idle_shutdown_at: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LivePublisherStartRefusal:
+    reason: LivePublisherRefusalReason
+    message: str
+
+
+class LivePublisher(Protocol):
+    def status(self) -> LivePublisherStatus: ...
+
+    def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal: ...
+
+    def request_stop(self) -> None: ...
+
+    def note_viewer_activity(self, viewer_id: str | None = None) -> None: ...
+
+    def sync_recording_active(self, recording_active: bool) -> None: ...
+
+    def shutdown(self) -> None: ...
+
+
+class NoopLivePublisher(LivePublisher):
+    """Default preview seam used until a real publisher backend is wired in."""
+
+    def __init__(self) -> None:
+        self._status = LivePublisherStatus(state=LivePublisherState.IDLE)
+
+    def status(self) -> LivePublisherStatus:
+        return self._status
+
+    def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+        return LivePublisherStartRefusal(
+            reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+            message="Preview publisher is not configured for this RTSP source",
+        )
+
+    def request_stop(self) -> None:
+        self._status = LivePublisherStatus(state=LivePublisherState.IDLE)
+
+    def note_viewer_activity(self, viewer_id: str | None = None) -> None:
+        _ = viewer_id
+
+    def sync_recording_active(self, recording_active: bool) -> None:
+        _ = recording_active
+
+    def shutdown(self) -> None:
+        self._status = LivePublisherStatus(state=LivePublisherState.IDLE)

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -470,10 +470,10 @@ def test_preview_failures_degrade_without_raising(tmp_path: Path) -> None:
 
     # Then: The source reports preview failure without raising
     assert status.state == LivePublisherState.ERROR
-    assert status.last_error == "status boom"
+    assert status.last_error == "Preview publisher status unavailable"
     assert isinstance(ensure_result, LivePublisherStartRefusal)
     assert ensure_result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
-    assert ensure_result.message == "Preview publisher activation failed: ensure_active boom"
+    assert ensure_result.message == "Preview publisher activation failed"
 
 
 def test_recording_lifecycle_tolerates_live_publisher_sync_failures(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -148,6 +148,37 @@ class FakeLivePublisher:
         self.shutdown_calls += 1
 
 
+class RaisingLivePublisher:
+    def __init__(self, *, methods: set[str]) -> None:
+        self._methods = methods
+
+    def _raise_if_configured(self, method: str) -> None:
+        if method in self._methods:
+            raise RuntimeError(f"{method} boom")
+
+    def status(self) -> LivePublisherStatus:
+        self._raise_if_configured("status")
+        return LivePublisherStatus(state=LivePublisherState.READY)
+
+    def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+        self._raise_if_configured("ensure_active")
+        return LivePublisherStatus(state=LivePublisherState.READY)
+
+    def request_stop(self) -> None:
+        self._raise_if_configured("request_stop")
+
+    def note_viewer_activity(self, viewer_id: str | None = None) -> None:
+        _ = viewer_id
+        self._raise_if_configured("note_viewer_activity")
+
+    def sync_recording_active(self, recording_active: bool) -> None:
+        _ = recording_active
+        self._raise_if_configured("sync_recording_active")
+
+    def shutdown(self) -> None:
+        self._raise_if_configured("shutdown")
+
+
 def _make_config(tmp_path: Path, **overrides: object) -> RTSPSourceConfig:
     data: dict[str, object] = {
         "rtsp_url": "rtsp://host/stream",
@@ -420,6 +451,54 @@ def test_cleanup_shuts_down_live_publisher(tmp_path: Path) -> None:
 
     # Then: The live publisher is shut down
     assert publisher.shutdown_calls == 1
+
+
+def test_preview_failures_degrade_without_raising(tmp_path: Path) -> None:
+    """Preview control APIs should fail closed when the live publisher raises."""
+    # Given: An RTSP source whose live publisher raises for preview methods
+    publisher = RaisingLivePublisher(
+        methods={"status", "ensure_active", "request_stop", "note_viewer_activity"}
+    )
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+
+    # When: Querying and controlling preview
+    status = source.preview_status()
+    ensure_result = source.ensure_preview_active()
+    source.note_preview_viewer_activity("viewer-1")
+    source.stop_preview()
+
+    # Then: The source reports preview failure without raising
+    assert status.state == LivePublisherState.ERROR
+    assert status.last_error == "status boom"
+    assert isinstance(ensure_result, LivePublisherStartRefusal)
+    assert ensure_result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert ensure_result.message == "Preview publisher activation failed: ensure_active boom"
+
+
+def test_recording_lifecycle_tolerates_live_publisher_sync_failures(tmp_path: Path) -> None:
+    """Recording start/stop should still work if preview state sync fails."""
+    # Given: An RTSP source whose live publisher raises during recording-state sync
+    publisher = RaisingLivePublisher(methods={"sync_recording_active"})
+    recorder = FakeRecorder()
+    clock = FakeClock()
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(
+        config,
+        camera_name="cam",
+        recorder=recorder,
+        live_publisher=publisher,
+        clock=clock,
+    )
+
+    # When: Starting and then stopping a recording
+    source.start_recording()
+    source.stop_recording()
+
+    # Then: Recording lifecycle still completes
+    assert len(recorder.started) == 1
+    assert len(recorder.stopped) == 1
+    assert source.recording_process is None
 
 
 def test_reconnect_retries_until_success(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -453,6 +453,21 @@ def test_cleanup_shuts_down_live_publisher(tmp_path: Path) -> None:
     assert publisher.shutdown_calls == 1
 
 
+@pytest.mark.asyncio
+async def test_shutdown_shuts_down_live_publisher_even_before_start(tmp_path: Path) -> None:
+    """RTSP shutdown should release preview resources for unstarted sources."""
+    # Given: An RTSP source with an injected live publisher that has not started
+    publisher = FakeLivePublisher()
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+
+    # When: Shutting down the source before its worker thread starts
+    await source.shutdown()
+
+    # Then: The live publisher is still shut down
+    assert publisher.shutdown_calls == 1
+
+
 def test_preview_failures_degrade_without_raising(tmp_path: Path) -> None:
     """Preview control APIs should fail closed when the live publisher raises."""
     # Given: An RTSP source whose live publisher raises for preview methods

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -14,6 +14,12 @@ import pytest
 from homesec.sources.rtsp.core import RTSPRunState, RTSPSource, RTSPSourceConfig
 from homesec.sources.rtsp.frame_pipeline import FfmpegFramePipeline
 from homesec.sources.rtsp.hardware import HardwareAccelConfig
+from homesec.sources.rtsp.live_publisher import (
+    LivePublisherRefusalReason,
+    LivePublisherStartRefusal,
+    LivePublisherState,
+    LivePublisherStatus,
+)
 from homesec.sources.rtsp.recorder import FfmpegRecorder
 from homesec.sources.rtsp.recording_profile import MotionProfile, build_default_recording_profile
 
@@ -112,6 +118,34 @@ class FakeRecorder:
 
     def is_alive(self, proc: DummyProc) -> bool:
         return proc not in self.dead
+
+
+class FakeLivePublisher:
+    def __init__(self) -> None:
+        self._status = LivePublisherStatus(state=LivePublisherState.IDLE)
+        self.ensure_result: LivePublisherStatus | LivePublisherStartRefusal = self._status
+        self.viewer_activity: list[str | None] = []
+        self.recording_active: list[bool] = []
+        self.stop_calls = 0
+        self.shutdown_calls = 0
+
+    def status(self) -> LivePublisherStatus:
+        return self._status
+
+    def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+        return self.ensure_result
+
+    def request_stop(self) -> None:
+        self.stop_calls += 1
+
+    def note_viewer_activity(self, viewer_id: str | None = None) -> None:
+        self.viewer_activity.append(viewer_id)
+
+    def sync_recording_active(self, recording_active: bool) -> None:
+        self.recording_active.append(recording_active)
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
 
 
 def _make_config(tmp_path: Path, **overrides: object) -> RTSPSourceConfig:
@@ -309,6 +343,83 @@ def test_session_limit_fallback_uses_default_recording_profile(tmp_path: Path) -
     expected_profile = build_default_recording_profile(source.rtsp_url)
     assert outcome.recording_profile == expected_profile
     assert outcome.diagnostics.selected_recording_profile == expected_profile.profile_id()
+
+
+def test_default_preview_seam_refuses_until_backend_is_wired(tmp_path: Path) -> None:
+    """RTSP preview seam should fail closed until a real publisher is configured."""
+    # Given: An RTSP source with the default no-op live publisher seam
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(config, camera_name="cam")
+
+    # When: Requesting preview activation
+    preview_result = source.ensure_preview_active()
+
+    # Then: Preview activation is refused and status remains idle
+    assert isinstance(preview_result, LivePublisherStartRefusal)
+    assert preview_result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert source.preview_status() == LivePublisherStatus(state=LivePublisherState.IDLE)
+
+
+def test_preview_methods_delegate_to_live_publisher(tmp_path: Path) -> None:
+    """RTSPSource should delegate preview lifecycle calls to the live publisher seam."""
+    # Given: An RTSP source with an injected live publisher
+    publisher = FakeLivePublisher()
+    publisher.ensure_result = LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=2,
+        idle_shutdown_at=12.0,
+    )
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+
+    # When: Querying preview status and exercising preview lifecycle calls
+    status_before = source.preview_status()
+    ensure_result = source.ensure_preview_active()
+    source.note_preview_viewer_activity("viewer-1")
+    source.stop_preview()
+
+    # Then: RTSPSource forwards the calls to the live publisher
+    assert status_before == LivePublisherStatus(state=LivePublisherState.IDLE)
+    assert ensure_result == publisher.ensure_result
+    assert publisher.viewer_activity == ["viewer-1"]
+    assert publisher.stop_calls == 1
+
+
+def test_recording_state_changes_are_forwarded_to_live_publisher(tmp_path: Path) -> None:
+    """Preview seam should observe recording-active transitions from RTSPSource."""
+    # Given: An RTSP source with a fake recorder and live publisher
+    publisher = FakeLivePublisher()
+    recorder = FakeRecorder()
+    clock = FakeClock()
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(
+        config,
+        camera_name="cam",
+        recorder=recorder,
+        live_publisher=publisher,
+        clock=clock,
+    )
+
+    # When: Starting and then stopping a recording
+    source.start_recording()
+    source.stop_recording()
+
+    # Then: The live publisher sees the recording transition edges
+    assert publisher.recording_active == [True, False]
+
+
+def test_cleanup_shuts_down_live_publisher(tmp_path: Path) -> None:
+    """RTSP cleanup should shut down the injected live publisher seam."""
+    # Given: An RTSP source with an injected live publisher
+    publisher = FakeLivePublisher()
+    config = _make_config(tmp_path, rtsp_url="rtsp://host/stream")
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+
+    # When: Cleaning up the source
+    source.cleanup()
+
+    # Then: The live publisher is shut down
+    assert publisher.shutdown_calls == 1
 
 
 def test_reconnect_retries_until_success(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a dedicated `LivePublisher` seam under `src/homesec/sources/rtsp` with a no-op default implementation
- expose RTSPSource preview lifecycle delegation methods so later runtime/API work can land on that seam instead of extending `core.py` directly
- forward recording-active transitions and source cleanup into the seam, and add RTSP runtime coverage for the new delegation path

## Why
Preview runtime work needs a bounded child component owned by `RTSPSource` so preview lifecycle can evolve separately from the motion and recording path while keeping `RTSPSource` as the per-camera session owner.

## Validation
- `uv run pytest tests/homesec/rtsp/test_runtime.py`
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check`
