### PR TITLE
feat: add preview config models

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -96,6 +96,22 @@ state_store:
   dsn_env: DB_DSN  # e.g., postgresql+asyncpg://user:pass@localhost:5432/homesec
 
 # =============================================================================
+# Preview - Optional live preview served directly by HomeSec (v1 HLS)
+# =============================================================================
+preview:
+  enabled: false
+  backend: hls
+  token_ttl_s: 60
+  idle_timeout_s: 30.0
+  config:
+    segment_duration_ms: 1000
+    live_window_segments: 4
+    storage_dir: /tmp/homesec-preview  # Mount tmpfs here when possible
+    audio_enabled: true
+    audio_codec: auto
+    video_codec: auto
+
+# =============================================================================
 # Notifiers - How to send alerts
 # =============================================================================
 # Optional: set to [] (or disable all entries) to run analysis-only with no external alerts.

--- a/src/homesec/models/config.py
+++ b/src/homesec/models/config.py
@@ -160,18 +160,29 @@ class PreviewConfig(BaseModel):
     )
     config: HLSPreviewConfig = Field(default_factory=HLSPreviewConfig)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_and_validate_backend(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        config = dict(value)
+        backend = config.get("backend", "hls")
+        if isinstance(backend, str):
+            backend = backend.lower()
+            config["backend"] = backend
+
+        if backend != "hls":
+            raise ValueError("preview.backend must be 'hls' in config contract v1")
+
+        return config
+
     @field_validator("backend", mode="before")
     @classmethod
     def _normalize_backend(cls, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower()
         return value
-
-    @model_validator(mode="after")
-    def _validate_backend(self) -> PreviewConfig:
-        if self.backend != "hls":
-            raise ValueError("preview.backend must be 'hls' in config contract v1")
-        return self
 
 
 class FastAPIServerConfig(BaseModel):

--- a/src/homesec/models/config.py
+++ b/src/homesec/models/config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from pathlib import Path
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -107,6 +108,72 @@ class RetryConfig(BaseModel):
     backoff_s: float = Field(default=1.0, ge=0.0)
 
 
+class HLSPreviewConfig(BaseModel):
+    """Backend-specific HLS preview configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    segment_duration_ms: int = Field(
+        default=1000,
+        ge=1,
+        description="HLS segment duration in milliseconds.",
+    )
+    live_window_segments: int = Field(
+        default=4,
+        ge=1,
+        description="Number of segments retained in the live window.",
+    )
+    storage_dir: Path = Field(
+        default=Path("/tmp/homesec-preview"),
+        description="Directory used for live HLS segments and playlists.",
+    )
+    audio_enabled: bool = Field(
+        default=True,
+        description="Include audio in preview output when the source provides it.",
+    )
+    audio_codec: Literal["auto", "copy", "aac"] = Field(
+        default="auto",
+        description="Preview audio handling mode.",
+    )
+    video_codec: Literal["auto", "copy", "h264"] = Field(
+        default="auto",
+        description="Preview video handling mode.",
+    )
+
+
+class PreviewConfig(BaseModel):
+    """Top-level live preview configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = False
+    backend: str = "hls"
+    token_ttl_s: int = Field(
+        default=60,
+        ge=1,
+        description="Lifetime for camera-scoped preview tokens.",
+    )
+    idle_timeout_s: float = Field(
+        default=30.0,
+        ge=0.0,
+        description="How long to keep the preview publisher alive without viewers.",
+    )
+    config: HLSPreviewConfig = Field(default_factory=HLSPreviewConfig)
+
+    @field_validator("backend", mode="before")
+    @classmethod
+    def _normalize_backend(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    @model_validator(mode="after")
+    def _validate_backend(self) -> PreviewConfig:
+        if self.backend != "hls":
+            raise ValueError("preview.backend must be 'hls' in config contract v1")
+        return self
+
+
 class FastAPIServerConfig(BaseModel):
     """Configuration for the FastAPI server."""
 
@@ -186,6 +253,7 @@ class Config(BaseModel):
     concurrency: ConcurrencyConfig = Field(default_factory=ConcurrencyConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)
     server: FastAPIServerConfig = Field(default_factory=FastAPIServerConfig)
+    preview: PreviewConfig = Field(default_factory=PreviewConfig)
     filter: FilterConfig
     vlm: VLMConfig
     alert_policy: AlertPolicyConfig

--- a/tests/homesec/test_config.py
+++ b/tests/homesec/test_config.py
@@ -765,18 +765,13 @@ def test_preview_hls_config_parses_explicit_values() -> None:
 
 def test_preview_rejects_unsupported_backend() -> None:
     """Preview config should reject deferred backends in the v1 contract."""
-    # Given a config payload using the deferred MediaMTX backend
+    # Given a config payload using the deferred MediaMTX backend and its native field
     data = minimal_config()
     data["preview"] = {
         "enabled": True,
         "backend": "mediamtx",
         "config": {
-            "segment_duration_ms": 1000,
-            "live_window_segments": 4,
-            "storage_dir": "/tmp/homesec-preview",
-            "audio_enabled": True,
-            "audio_codec": "auto",
-            "video_codec": "auto",
+            "publish_rtsp_base_url": "rtsp://mediamtx:8554",
         },
     }
 
@@ -784,10 +779,11 @@ def test_preview_rejects_unsupported_backend() -> None:
     with pytest.raises(ConfigError) as exc_info:
         load_config_from_dict(data)
 
-    # Then validation rejects the unsupported backend
+    # Then validation rejects the backend before HLS-only config validation noise
     assert exc_info.value.code is ConfigErrorCode.VALIDATION_FAILED
     assert "preview.backend" in str(exc_info.value) or "preview -> backend" in str(exc_info.value)
     assert "hls" in str(exc_info.value)
+    assert "publish_rtsp_base_url" not in str(exc_info.value)
 
 
 def test_preview_rejects_v2_and_legacy_extra_fields() -> None:

--- a/tests/homesec/test_config.py
+++ b/tests/homesec/test_config.py
@@ -602,6 +602,7 @@ def test_load_example_config() -> None:
     # When loading the config
     config = load_config(example_path)
     # Then expected fields are present
+    assert config.preview.backend == "hls"
     assert config.filter.backend == "yolo"
     assert config.vlm.backend == "openai"
 
@@ -704,3 +705,115 @@ def test_server_config_rejects_legacy_serve_ui_field() -> None:
 
     assert exc_info.value.code == ConfigErrorCode.VALIDATION_FAILED
     assert "serve_ui" in str(exc_info.value)
+
+
+def test_preview_defaults_apply_when_preview_block_is_absent() -> None:
+    """Preview config should default to the accepted v1 HLS contract surface."""
+    # Given a valid config payload without a preview block
+    data = minimal_config()
+
+    # When loading the config
+    config = load_config_from_dict(data)
+
+    # Then preview defaults match the v1 contract
+    assert config.preview.enabled is False
+    assert config.preview.backend == "hls"
+    assert config.preview.token_ttl_s == 60
+    assert config.preview.idle_timeout_s == 30.0
+    assert config.preview.config.segment_duration_ms == 1000
+    assert config.preview.config.live_window_segments == 4
+    assert config.preview.config.storage_dir == Path("/tmp/homesec-preview")
+    assert config.preview.config.audio_enabled is True
+    assert config.preview.config.audio_codec == "auto"
+    assert config.preview.config.video_codec == "auto"
+
+
+def test_preview_hls_config_parses_explicit_values() -> None:
+    """Preview config should parse the accepted HLS override surface."""
+    # Given a config payload with explicit preview overrides
+    data = minimal_config()
+    data["preview"] = {
+        "enabled": True,
+        "backend": "HLS",
+        "token_ttl_s": 120,
+        "idle_timeout_s": 45.0,
+        "config": {
+            "segment_duration_ms": 1500,
+            "live_window_segments": 6,
+            "storage_dir": "/run/homesec-preview",
+            "audio_enabled": False,
+            "audio_codec": "aac",
+            "video_codec": "h264",
+        },
+    }
+
+    # When loading the config
+    config = load_config_from_dict(data)
+
+    # Then preview config is normalized and typed correctly
+    assert config.preview.enabled is True
+    assert config.preview.backend == "hls"
+    assert config.preview.token_ttl_s == 120
+    assert config.preview.idle_timeout_s == 45.0
+    assert config.preview.config.segment_duration_ms == 1500
+    assert config.preview.config.live_window_segments == 6
+    assert config.preview.config.storage_dir == Path("/run/homesec-preview")
+    assert config.preview.config.audio_enabled is False
+    assert config.preview.config.audio_codec == "aac"
+    assert config.preview.config.video_codec == "h264"
+
+
+def test_preview_rejects_unsupported_backend() -> None:
+    """Preview config should reject deferred backends in the v1 contract."""
+    # Given a config payload using the deferred MediaMTX backend
+    data = minimal_config()
+    data["preview"] = {
+        "enabled": True,
+        "backend": "mediamtx",
+        "config": {
+            "segment_duration_ms": 1000,
+            "live_window_segments": 4,
+            "storage_dir": "/tmp/homesec-preview",
+            "audio_enabled": True,
+            "audio_codec": "auto",
+            "video_codec": "auto",
+        },
+    }
+
+    # When loading the config
+    with pytest.raises(ConfigError) as exc_info:
+        load_config_from_dict(data)
+
+    # Then validation rejects the unsupported backend
+    assert exc_info.value.code is ConfigErrorCode.VALIDATION_FAILED
+    assert "preview.backend" in str(exc_info.value) or "preview -> backend" in str(exc_info.value)
+    assert "hls" in str(exc_info.value)
+
+
+def test_preview_rejects_v2_and_legacy_extra_fields() -> None:
+    """Preview config should reject fields outside the accepted v1 contract."""
+    # Given a config payload with deferred and legacy preview keys
+    data = minimal_config()
+    data["preview"] = {
+        "enabled": True,
+        "backend": "hls",
+        "mode": "inline",
+        "config": {
+            "segment_duration_ms": 1000,
+            "live_window_segments": 4,
+            "storage_dir": "/tmp/homesec-preview",
+            "audio_enabled": True,
+            "audio_codec": "auto",
+            "video_codec": "auto",
+            "publish_rtsp_base_url": "rtsp://mediamtx:8554",
+        },
+    }
+
+    # When loading the config
+    with pytest.raises(ConfigError) as exc_info:
+        load_config_from_dict(data)
+
+    # Then validation surfaces the unknown v1-forbidden keys
+    assert exc_info.value.code is ConfigErrorCode.VALIDATION_FAILED
+    assert "mode" in str(exc_info.value)
+    assert "publish_rtsp_base_url" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add the top-level `preview` config surface with an HLS-specific nested model and v1 defaults
- enforce the accepted v1 contract by rejecting unsupported preview backends and extra preview fields
- document the new config block in `config/example.yaml` and cover the parsing/validation paths in config tests

## Validation
- `uv run pytest tests/homesec/test_config.py -q`
- `uv run pytest tests/homesec/test_config_manager.py -q`
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15432/homesec make check`
