### PR TITLE
feat: add preview runtime control plumbing

### DIFF
--- a/src/homesec/app.py
+++ b/src/homesec/app.py
@@ -24,6 +24,9 @@ from homesec.runtime.controller import RuntimeController
 from homesec.runtime.errors import RuntimeReloadConfigError
 from homesec.runtime.manager import RuntimeManager
 from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    CameraPreviewStopResult,
     ManagedRuntime,
     RuntimeCameraStatus,
     RuntimeReloadRequest,
@@ -343,6 +346,21 @@ class Application:
     async def wait_for_runtime_reload(self) -> RuntimeReloadResult | None:
         """Wait for the in-flight runtime reload (if any)."""
         return await self._require_runtime_manager().wait_for_reload()
+
+    async def get_camera_preview_status(self, camera_name: str) -> CameraPreviewStatus:
+        """Return preview status for a runtime camera."""
+        return await self._require_runtime_manager().get_preview_status(camera_name)
+
+    async def ensure_camera_preview_active(
+        self,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        """Ensure preview is active or attachable for a runtime camera."""
+        return await self._require_runtime_manager().ensure_preview_active(camera_name)
+
+    async def force_stop_camera_preview(self, camera_name: str) -> CameraPreviewStopResult:
+        """Force-stop preview for a runtime camera."""
+        return await self._require_runtime_manager().force_stop_preview(camera_name)
 
     def _require_config(self) -> Config:
         if self._config is None:

--- a/src/homesec/runtime/controller.py
+++ b/src/homesec/runtime/controller.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from homesec.models.config import Config
-    from homesec.runtime.models import ManagedRuntime
+    from homesec.runtime.models import (
+        CameraPreviewStartRefusal,
+        CameraPreviewStatus,
+        CameraPreviewStopResult,
+        ManagedRuntime,
+    )
 
 
 class RuntimeController(Protocol):
@@ -26,4 +31,28 @@ class RuntimeController(Protocol):
 
     async def shutdown_all(self) -> None:
         """Best-effort cleanup for any active or in-flight runtimes."""
+        ...
+
+    async def get_preview_status(
+        self,
+        runtime: ManagedRuntime,
+        camera_name: str,
+    ) -> CameraPreviewStatus:
+        """Return the current preview status for a camera."""
+        ...
+
+    async def ensure_preview_active(
+        self,
+        runtime: ManagedRuntime,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        """Ensure preview is attachable for a camera."""
+        ...
+
+    async def force_stop_preview(
+        self,
+        runtime: ManagedRuntime,
+        camera_name: str,
+    ) -> CameraPreviewStopResult:
+        """Force-stop preview for a camera."""
         ...

--- a/src/homesec/runtime/errors.py
+++ b/src/homesec/runtime/errors.py
@@ -24,3 +24,31 @@ class RuntimeReloadConfigError(RuntimeError):
         super().__init__(message)
         self.status_code = status_code
         self.error_code = error_code
+
+
+class RuntimePreviewError(RuntimeError):
+    """Base runtime preview error with a stable machine-readable code."""
+
+    def __init__(self, message: str, *, error_code: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
+class PreviewCameraNotFoundError(RuntimePreviewError):
+    """Raised when preview control targets an unknown camera."""
+
+    def __init__(self, camera_name: str) -> None:
+        super().__init__(
+            f"Camera '{camera_name}' not found in the active runtime",
+            error_code="PREVIEW_CAMERA_NOT_FOUND",
+        )
+
+
+class PreviewRuntimeUnavailableError(RuntimePreviewError):
+    """Raised when the runtime cannot accept preview control commands."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+            error_code="PREVIEW_RUNTIME_UNAVAILABLE",
+        )

--- a/src/homesec/runtime/manager.py
+++ b/src/homesec/runtime/manager.py
@@ -10,8 +10,11 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from homesec.runtime.controller import RuntimeController
-from homesec.runtime.errors import sanitize_runtime_error
+from homesec.runtime.errors import PreviewRuntimeUnavailableError, sanitize_runtime_error
 from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    CameraPreviewStopResult,
     ManagedRuntime,
     RuntimeReloadRequest,
     RuntimeReloadResult,
@@ -141,6 +144,30 @@ class RuntimeManager:
         status.reload_in_progress = self._reload_task is not None and not self._reload_task.done()
         return status
 
+    async def get_preview_status(self, camera_name: str) -> CameraPreviewStatus:
+        """Return preview status for a camera in the active runtime."""
+        return await self._controller.get_preview_status(
+            self._require_active_runtime(),
+            camera_name,
+        )
+
+    async def ensure_preview_active(
+        self,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        """Ensure preview is active or attachable for a camera."""
+        return await self._controller.ensure_preview_active(
+            self._require_active_runtime(),
+            camera_name,
+        )
+
+    async def force_stop_preview(self, camera_name: str) -> CameraPreviewStopResult:
+        """Force-stop preview for a camera in the active runtime."""
+        return await self._controller.force_stop_preview(
+            self._require_active_runtime(),
+            camera_name,
+        )
+
     async def shutdown(self) -> None:
         """Shutdown reload task (if any) and active runtime."""
         if self._reload_task is not None and not self._reload_task.done():
@@ -262,6 +289,12 @@ class RuntimeManager:
             await self._controller.shutdown_all()
         except Exception as exc:
             logger.error("%s failed: %s", context, exc, exc_info=exc)
+
+    def _require_active_runtime(self) -> ManagedRuntime:
+        runtime = self._active_runtime
+        if runtime is None:
+            raise PreviewRuntimeUnavailableError("Runtime is not active")
+        return runtime
 
     def _rollback_to_previous_runtime(
         self,

--- a/src/homesec/runtime/models.py
+++ b/src/homesec/runtime/models.py
@@ -33,6 +33,25 @@ class RuntimeState(StrEnum):
     FAILED = "failed"
 
 
+class PreviewState(StrEnum):
+    """Camera-scoped preview lifecycle state."""
+
+    IDLE = "idle"
+    STARTING = "starting"
+    READY = "ready"
+    DEGRADED = "degraded"
+    STOPPING = "stopping"
+    ERROR = "error"
+
+
+class PreviewRefusalReason(StrEnum):
+    """Machine-readable preview start refusal reason."""
+
+    RECORDING_PRIORITY = "recording_priority"
+    SESSION_BUDGET_EXHAUSTED = "session_budget_exhausted"
+    PREVIEW_TEMPORARILY_UNAVAILABLE = "preview_temporarily_unavailable"
+
+
 @dataclass(slots=True)
 class RuntimeBundle:
     """Restartable runtime unit managed by RuntimeManager."""
@@ -56,6 +75,37 @@ class RuntimeCameraStatus:
 
     healthy: bool
     last_heartbeat: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPreviewStatus:
+    """Runtime-owned preview status for a single camera."""
+
+    camera_name: str
+    enabled: bool
+    state: PreviewState
+    viewer_count: int | None = None
+    degraded_reason: str | None = None
+    last_error: str | None = None
+    idle_shutdown_at: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPreviewStartRefusal:
+    """Machine-readable refusal when preview cannot be attached or started."""
+
+    camera_name: str
+    reason: PreviewRefusalReason
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPreviewStopResult:
+    """Runtime acknowledgement for a force-stop preview request."""
+
+    camera_name: str
+    accepted: bool
+    state: PreviewState
 
 
 @dataclass(slots=True)
@@ -93,3 +143,18 @@ def config_signature(config: Config) -> str:
     payload = config.model_dump(mode="json")
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()[:12]
+
+
+def preview_error_status(
+    camera_name: str,
+    *,
+    enabled: bool,
+    message: str,
+) -> CameraPreviewStatus:
+    """Return an error preview status with bounded user-facing detail."""
+    return CameraPreviewStatus(
+        camera_name=camera_name,
+        enabled=enabled,
+        state=PreviewState.ERROR,
+        last_error=message,
+    )

--- a/src/homesec/runtime/subprocess_controller.py
+++ b/src/homesec/runtime/subprocess_controller.py
@@ -277,7 +277,6 @@ class SubprocessRuntimeController(RuntimeController):
             )
         except Exception as exc:
             message = sanitize_runtime_error(exc)
-            handle.last_error = message
             enabled = self._preview_enabled(handle, camera_name)
             if not enabled:
                 return CameraPreviewStatus(
@@ -332,7 +331,6 @@ class SubprocessRuntimeController(RuntimeController):
             )
         except Exception as exc:
             message = sanitize_runtime_error(exc)
-            handle.last_error = message
             return CameraPreviewStartRefusal(
                 camera_name=camera_name,
                 reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
@@ -376,7 +374,6 @@ class SubprocessRuntimeController(RuntimeController):
             )
         except Exception as exc:
             message = sanitize_runtime_error(exc)
-            handle.last_error = message
             raise PreviewRuntimeUnavailableError(message) from exc
 
         if result.stop_result is None:

--- a/src/homesec/runtime/subprocess_controller.py
+++ b/src/homesec/runtime/subprocess_controller.py
@@ -18,9 +18,31 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from homesec.runtime.controller import RuntimeController
-from homesec.runtime.errors import sanitize_runtime_error
-from homesec.runtime.models import ManagedRuntime, RuntimeCameraStatus, config_signature
-from homesec.runtime.subprocess_protocol import WorkerEvent, WorkerEventType
+from homesec.runtime.errors import (
+    PreviewCameraNotFoundError,
+    PreviewRuntimeUnavailableError,
+    sanitize_runtime_error,
+)
+from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    CameraPreviewStopResult,
+    ManagedRuntime,
+    PreviewRefusalReason,
+    PreviewState,
+    RuntimeCameraStatus,
+    config_signature,
+    preview_error_status,
+)
+from homesec.runtime.subprocess_protocol import (
+    WorkerCommand,
+    WorkerCommandErrorCode,
+    WorkerCommandResult,
+    WorkerCommandType,
+    WorkerEvent,
+    WorkerEventType,
+    WorkerPreviewStatusPayload,
+)
 
 if TYPE_CHECKING:
     from homesec.models.config import Config
@@ -78,6 +100,7 @@ class SubprocessRuntimeHandle:
     correlation_id: str
     temp_dir: Path = field(repr=False)
     control_socket_path: Path = field(repr=False)
+    command_socket_path: Path = field(repr=False)
     config_json_path: Path = field(repr=False)
     event_queue: asyncio.Queue[WorkerEvent] = field(default_factory=asyncio.Queue, repr=False)
     transport: asyncio.DatagramTransport | None = field(default=None, repr=False)
@@ -89,6 +112,7 @@ class SubprocessRuntimeHandle:
     last_heartbeat_at: datetime | None = None
     last_error: str | None = None
     camera_statuses: dict[str, RuntimeCameraStatus] = field(default_factory=dict)
+    camera_preview_statuses: dict[str, CameraPreviewStatus] = field(default_factory=dict)
 
     @property
     def is_running(self) -> bool:
@@ -113,6 +137,7 @@ class SubprocessRuntimeController(RuntimeController):
     kill_timeout_s: float = 5.0
     worker_heartbeat_interval_s: float = 2.0
     heartbeat_stale_s: float = 10.0
+    command_timeout_s: float = 5.0
     worker_module: str = "homesec.runtime.worker"
     worker_extra_args: tuple[str, ...] = ()
     _active_runtime: SubprocessRuntimeHandle | None = field(default=None, init=False, repr=False)
@@ -129,6 +154,7 @@ class SubprocessRuntimeController(RuntimeController):
 
         config_json_path = temp_dir / "runtime_config.json"
         control_socket_path = temp_dir / "events.sock"
+        command_socket_path = temp_dir / "commands.sock"
         correlation_id = uuid.uuid4().hex
         queue: asyncio.Queue[WorkerEvent] = asyncio.Queue()
         transport: asyncio.DatagramTransport | None = None
@@ -162,6 +188,7 @@ class SubprocessRuntimeController(RuntimeController):
             correlation_id=correlation_id,
             temp_dir=temp_dir,
             control_socket_path=control_socket_path,
+            command_socket_path=command_socket_path,
             config_json_path=config_json_path,
             event_queue=queue,
             transport=transport,
@@ -230,6 +257,143 @@ class SubprocessRuntimeController(RuntimeController):
             summary = "; ".join(errors)
             raise RuntimeError(f"Runtime shutdown_all completed with errors: {summary[:512]}")
 
+    async def get_preview_status(
+        self,
+        runtime: ManagedRuntime,
+        camera_name: str,
+    ) -> CameraPreviewStatus:
+        handle = self._require_handle(runtime)
+        if not self._camera_exists(handle, camera_name):
+            raise PreviewCameraNotFoundError(camera_name)
+
+        if not handle.heartbeat_is_fresh(max_age_s=self.heartbeat_stale_s):
+            return self._stale_preview_status(handle, camera_name)
+
+        try:
+            result = await self._send_command(
+                handle,
+                WorkerCommandType.PREVIEW_STATUS,
+                camera_name,
+            )
+        except Exception as exc:
+            message = sanitize_runtime_error(exc)
+            handle.last_error = message
+            enabled = self._preview_enabled(handle, camera_name)
+            if not enabled:
+                return CameraPreviewStatus(
+                    camera_name=camera_name,
+                    enabled=False,
+                    state=PreviewState.IDLE,
+                )
+            return preview_error_status(
+                camera_name,
+                enabled=enabled,
+                message=message,
+            )
+
+        if result.status is None:
+            enabled = self._preview_enabled(handle, camera_name)
+            if not enabled:
+                return CameraPreviewStatus(
+                    camera_name=camera_name,
+                    enabled=False,
+                    state=PreviewState.IDLE,
+                )
+            return preview_error_status(
+                camera_name,
+                enabled=enabled,
+                message="Runtime worker returned no preview status",
+            )
+        status = self._runtime_preview_status(camera_name, result.status)
+        handle.camera_preview_statuses[camera_name] = status
+        return status
+
+    async def ensure_preview_active(
+        self,
+        runtime: ManagedRuntime,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        handle = self._require_handle(runtime)
+        if not self._camera_exists(handle, camera_name):
+            raise PreviewCameraNotFoundError(camera_name)
+
+        if not handle.heartbeat_is_fresh(max_age_s=self.heartbeat_stale_s):
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message=self._runtime_unavailable_message(handle),
+            )
+
+        try:
+            result = await self._send_command(
+                handle,
+                WorkerCommandType.PREVIEW_ENSURE_ACTIVE,
+                camera_name,
+            )
+        except Exception as exc:
+            message = sanitize_runtime_error(exc)
+            handle.last_error = message
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message=message,
+            )
+
+        if result.refusal is not None:
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=result.refusal.reason,
+                message=result.refusal.message,
+            )
+        if result.status is None:
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message="Runtime worker returned no preview status",
+            )
+
+        status = self._runtime_preview_status(camera_name, result.status)
+        handle.camera_preview_statuses[camera_name] = status
+        return status
+
+    async def force_stop_preview(
+        self,
+        runtime: ManagedRuntime,
+        camera_name: str,
+    ) -> CameraPreviewStopResult:
+        handle = self._require_handle(runtime)
+        if not self._camera_exists(handle, camera_name):
+            raise PreviewCameraNotFoundError(camera_name)
+
+        if not handle.heartbeat_is_fresh(max_age_s=self.heartbeat_stale_s):
+            raise PreviewRuntimeUnavailableError(self._runtime_unavailable_message(handle))
+
+        try:
+            result = await self._send_command(
+                handle,
+                WorkerCommandType.PREVIEW_FORCE_STOP,
+                camera_name,
+            )
+        except Exception as exc:
+            message = sanitize_runtime_error(exc)
+            handle.last_error = message
+            raise PreviewRuntimeUnavailableError(message) from exc
+
+        if result.stop_result is None:
+            raise PreviewRuntimeUnavailableError("Runtime worker returned no preview stop result")
+
+        preview_status = CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=self._preview_enabled(handle, camera_name),
+            state=result.stop_result.state,
+        )
+        handle.camera_preview_statuses[camera_name] = preview_status
+        return CameraPreviewStopResult(
+            camera_name=camera_name,
+            accepted=result.stop_result.accepted,
+            state=result.stop_result.state,
+        )
+
     @staticmethod
     def _ensure_posix_support() -> None:
         if os.name != "posix":
@@ -250,6 +414,7 @@ class SubprocessRuntimeController(RuntimeController):
         self._drain_queue(handle.event_queue)
         handle.last_error = None
         handle.camera_statuses = {}
+        handle.camera_preview_statuses = {}
         handle.last_heartbeat_at = None
 
         args = [
@@ -262,6 +427,8 @@ class SubprocessRuntimeController(RuntimeController):
             str(handle.config_json_path),
             "--control-socket-path",
             str(handle.control_socket_path),
+            "--command-socket-path",
+            str(handle.command_socket_path),
             "--correlation-id",
             handle.correlation_id,
             "--heartbeat-interval-s",
@@ -354,6 +521,7 @@ class SubprocessRuntimeController(RuntimeController):
         handle.worker_pid = event.pid
         if event.event in {WorkerEventType.STARTED, WorkerEventType.HEARTBEAT}:
             handle.last_heartbeat_at = event.sent_at
+        if event.cameras:
             handle.camera_statuses = {
                 camera: RuntimeCameraStatus(
                     healthy=status.healthy,
@@ -361,9 +529,135 @@ class SubprocessRuntimeController(RuntimeController):
                 )
                 for camera, status in event.cameras.items()
             }
-            return
+        if event.previews:
+            handle.camera_preview_statuses = {
+                camera: self._runtime_preview_status(camera, status)
+                for camera, status in event.previews.items()
+            }
         if event.event == WorkerEventType.ERROR:
             handle.last_error = event.message or "runtime worker reported an error"
+
+    async def _send_command(
+        self,
+        handle: SubprocessRuntimeHandle,
+        command_type: WorkerCommandType,
+        camera_name: str,
+    ) -> WorkerCommandResult:
+        command = WorkerCommand(
+            command=command_type,
+            command_id=uuid.uuid4().hex,
+            generation=handle.generation,
+            correlation_id=handle.correlation_id,
+            camera_name=camera_name,
+        )
+
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(str(handle.command_socket_path)),
+                timeout=self.command_timeout_s,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to connect to runtime worker preview command socket"
+            ) from exc
+
+        try:
+            writer.write(command.model_dump_json().encode("utf-8") + b"\n")
+            await asyncio.wait_for(writer.drain(), timeout=self.command_timeout_s)
+            raw_response = await asyncio.wait_for(
+                reader.readline(),
+                timeout=self.command_timeout_s,
+            )
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        if not raw_response:
+            raise RuntimeError("Runtime worker closed preview command stream without a response")
+
+        try:
+            result = WorkerCommandResult.model_validate_json(raw_response.decode("utf-8"))
+        except Exception as exc:
+            raise RuntimeError(
+                "Runtime worker returned an invalid preview command response"
+            ) from exc
+
+        if result.generation != command.generation:
+            raise RuntimeError("Runtime worker returned preview response for the wrong generation")
+        if result.correlation_id != command.correlation_id:
+            raise RuntimeError(
+                "Runtime worker returned preview response for the wrong correlation id"
+            )
+        if result.command_id != command.command_id:
+            raise RuntimeError("Runtime worker returned preview response for the wrong command")
+        if result.command != command.command:
+            raise RuntimeError(
+                "Runtime worker returned preview response for the wrong command type"
+            )
+        if result.camera_name != command.camera_name:
+            raise RuntimeError("Runtime worker returned preview response for the wrong camera")
+        if result.error_code == WorkerCommandErrorCode.CAMERA_NOT_FOUND:
+            raise PreviewCameraNotFoundError(camera_name)
+        if result.error_code is not None:
+            raise RuntimeError(
+                result.error_message or f"Runtime preview command failed: {result.error_code}"
+            )
+        return result
+
+    @staticmethod
+    def _runtime_preview_status(
+        camera_name: str,
+        payload: WorkerPreviewStatusPayload,
+    ) -> CameraPreviewStatus:
+        return CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=payload.enabled,
+            state=payload.state,
+            viewer_count=payload.viewer_count,
+            degraded_reason=payload.degraded_reason,
+            last_error=payload.last_error,
+            idle_shutdown_at=payload.idle_shutdown_at,
+        )
+
+    @staticmethod
+    def _camera_exists(handle: SubprocessRuntimeHandle, camera_name: str) -> bool:
+        return any(camera.name == camera_name for camera in handle.config.cameras)
+
+    def _preview_enabled(self, handle: SubprocessRuntimeHandle, camera_name: str) -> bool:
+        cached = handle.camera_preview_statuses.get(camera_name)
+        if cached is not None:
+            return cached.enabled
+
+        camera = next((item for item in handle.config.cameras if item.name == camera_name), None)
+        if camera is None:
+            raise PreviewCameraNotFoundError(camera_name)
+        return handle.config.preview.enabled and camera.enabled and camera.source.backend == "rtsp"
+
+    def _stale_preview_status(
+        self,
+        handle: SubprocessRuntimeHandle,
+        camera_name: str,
+    ) -> CameraPreviewStatus:
+        enabled = self._preview_enabled(handle, camera_name)
+        if not enabled:
+            return CameraPreviewStatus(
+                camera_name=camera_name,
+                enabled=False,
+                state=PreviewState.IDLE,
+            )
+        return preview_error_status(
+            camera_name,
+            enabled=enabled,
+            message=self._runtime_unavailable_message(handle),
+        )
+
+    @staticmethod
+    def _runtime_unavailable_message(handle: SubprocessRuntimeHandle) -> str:
+        if handle.last_error is not None:
+            return handle.last_error
+        if handle.worker_exit_code is not None:
+            return f"runtime worker exited with code {handle.worker_exit_code}"
+        return "runtime worker heartbeat timed out"
 
     async def _stop_handle(
         self,
@@ -424,6 +718,8 @@ class SubprocessRuntimeController(RuntimeController):
 
         if handle.control_socket_path.exists():
             handle.control_socket_path.unlink(missing_ok=True)
+        if handle.command_socket_path.exists():
+            handle.command_socket_path.unlink(missing_ok=True)
         if handle.config_json_path.exists():
             handle.config_json_path.unlink(missing_ok=True)
         shutil.rmtree(handle.temp_dir, ignore_errors=True)

--- a/src/homesec/runtime/subprocess_protocol.py
+++ b/src/homesec/runtime/subprocess_protocol.py
@@ -7,6 +7,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from homesec.runtime.models import PreviewRefusalReason, PreviewState
+
 
 class WorkerEventType(StrEnum):
     """Worker-to-parent event type."""
@@ -24,6 +26,17 @@ class WorkerCameraStatusPayload(BaseModel):
     last_heartbeat: float | None = None
 
 
+class WorkerPreviewStatusPayload(BaseModel):
+    """Serialized preview status emitted by worker."""
+
+    enabled: bool
+    state: PreviewState
+    viewer_count: int | None = None
+    degraded_reason: str | None = None
+    last_error: str | None = None
+    idle_shutdown_at: float | None = None
+
+
 class WorkerEvent(BaseModel):
     """Structured event emitted by runtime worker process."""
 
@@ -33,4 +46,58 @@ class WorkerEvent(BaseModel):
     pid: int
     sent_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     cameras: dict[str, WorkerCameraStatusPayload] = Field(default_factory=dict)
+    previews: dict[str, WorkerPreviewStatusPayload] = Field(default_factory=dict)
     message: str | None = None
+
+
+class WorkerCommandType(StrEnum):
+    """Parent-to-worker control command type."""
+
+    PREVIEW_STATUS = "preview_status"
+    PREVIEW_ENSURE_ACTIVE = "preview_ensure_active"
+    PREVIEW_FORCE_STOP = "preview_force_stop"
+
+
+class WorkerCommandErrorCode(StrEnum):
+    """Machine-readable worker command failure code."""
+
+    CAMERA_NOT_FOUND = "camera_not_found"
+
+
+class WorkerPreviewRefusalPayload(BaseModel):
+    """Serialized preview start refusal."""
+
+    reason: PreviewRefusalReason
+    message: str
+
+
+class WorkerPreviewStopPayload(BaseModel):
+    """Serialized preview stop acknowledgement."""
+
+    accepted: bool
+    state: PreviewState
+
+
+class WorkerCommand(BaseModel):
+    """Structured preview control command sent to the runtime worker."""
+
+    command: WorkerCommandType
+    command_id: str
+    generation: int
+    correlation_id: str
+    camera_name: str
+
+
+class WorkerCommandResult(BaseModel):
+    """Structured response to a preview control command."""
+
+    command: WorkerCommandType
+    command_id: str
+    generation: int
+    correlation_id: str
+    camera_name: str
+    status: WorkerPreviewStatusPayload | None = None
+    refusal: WorkerPreviewRefusalPayload | None = None
+    stop_result: WorkerPreviewStopPayload | None = None
+    error_code: WorkerCommandErrorCode | None = None
+    error_message: str | None = None

--- a/src/homesec/runtime/test_worker_harness.py
+++ b/src/homesec/runtime/test_worker_harness.py
@@ -215,7 +215,6 @@ class _HarnessService:
             correlation_id=self._correlation_id,
             pid=os.getpid(),
             cameras=self._camera_payloads(),
-            previews=dict(self._preview_statuses),
             message=message,
         )
         self._emitter.send(payload)

--- a/src/homesec/runtime/test_worker_harness.py
+++ b/src/homesec/runtime/test_worker_harness.py
@@ -12,10 +12,18 @@ import sys
 from pathlib import Path
 
 from homesec.models.config import Config
+from homesec.runtime.models import PreviewRefusalReason, PreviewState
 from homesec.runtime.subprocess_protocol import (
     WorkerCameraStatusPayload,
+    WorkerCommand,
+    WorkerCommandErrorCode,
+    WorkerCommandResult,
+    WorkerCommandType,
     WorkerEvent,
     WorkerEventType,
+    WorkerPreviewRefusalPayload,
+    WorkerPreviewStatusPayload,
+    WorkerPreviewStopPayload,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,6 +57,7 @@ class _HarnessService:
         generation: int,
         correlation_id: str,
         heartbeat_interval_s: float,
+        command_socket_path: Path,
         scenario: str,
         emitter: _HarnessEventEmitter,
     ) -> None:
@@ -56,8 +65,19 @@ class _HarnessService:
         self._generation = generation
         self._correlation_id = correlation_id
         self._heartbeat_interval_s = heartbeat_interval_s
+        self._command_socket_path = command_socket_path
         self._scenario = scenario
         self._emitter = emitter
+        self._command_server: asyncio.Server | None = None
+        self._preview_statuses = {
+            camera.name: WorkerPreviewStatusPayload(
+                enabled=(
+                    config.preview.enabled and camera.enabled and camera.source.backend == "rtsp"
+                ),
+                state=PreviewState.IDLE,
+            )
+            for camera in config.cameras
+        }
 
     async def run(self, stop_event: asyncio.Event) -> None:
         if self._scenario == _STARTUP_FAIL_SCENARIO:
@@ -67,6 +87,11 @@ class _HarnessService:
             )
             raise RuntimeError("runtime harness startup failure")
 
+        self._command_socket_path.unlink(missing_ok=True)
+        self._command_server = await asyncio.start_unix_server(
+            self._handle_command_connection,
+            path=str(self._command_socket_path),
+        )
         self._emit_event(WorkerEventType.STARTED)
         heartbeat_task = asyncio.create_task(self._heartbeat_loop(stop_event))
         try:
@@ -77,6 +102,12 @@ class _HarnessService:
                 await heartbeat_task
             except asyncio.CancelledError:
                 pass
+            command_server = self._command_server
+            self._command_server = None
+            if command_server is not None:
+                command_server.close()
+                await command_server.wait_closed()
+            self._command_socket_path.unlink(missing_ok=True)
             self._emit_event(WorkerEventType.STOPPED)
 
     def emit_error(self, exc: Exception) -> None:
@@ -93,6 +124,90 @@ class _HarnessService:
             except asyncio.TimeoutError:
                 self._emit_event(WorkerEventType.HEARTBEAT)
 
+    async def _handle_command_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            raw_command = await reader.readline()
+            if not raw_command:
+                return
+            command = WorkerCommand.model_validate_json(raw_command.decode("utf-8"))
+            result = self._handle_command(command)
+            writer.write(result.model_dump_json().encode("utf-8") + b"\n")
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    def _handle_command(self, command: WorkerCommand) -> WorkerCommandResult:
+        if command.camera_name not in self._preview_statuses:
+            return WorkerCommandResult(
+                command=command.command,
+                command_id=command.command_id,
+                generation=self._generation,
+                correlation_id=self._correlation_id,
+                camera_name=command.camera_name,
+                error_code=WorkerCommandErrorCode.CAMERA_NOT_FOUND,
+                error_message=f"Camera '{command.camera_name}' not found",
+            )
+
+        preview_status = self._preview_statuses[command.camera_name]
+        if command.command == WorkerCommandType.PREVIEW_STATUS:
+            return WorkerCommandResult(
+                command=command.command,
+                command_id=command.command_id,
+                generation=self._generation,
+                correlation_id=self._correlation_id,
+                camera_name=command.camera_name,
+                status=preview_status,
+            )
+        if command.command == WorkerCommandType.PREVIEW_ENSURE_ACTIVE:
+            if not preview_status.enabled:
+                return WorkerCommandResult(
+                    command=command.command,
+                    command_id=command.command_id,
+                    generation=self._generation,
+                    correlation_id=self._correlation_id,
+                    camera_name=command.camera_name,
+                    refusal=WorkerPreviewRefusalPayload(
+                        reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                        message="Preview is not enabled for this camera",
+                    ),
+                )
+            ready_status = WorkerPreviewStatusPayload(
+                enabled=True,
+                state=PreviewState.READY,
+                viewer_count=0,
+            )
+            self._preview_statuses[command.camera_name] = ready_status
+            return WorkerCommandResult(
+                command=command.command,
+                command_id=command.command_id,
+                generation=self._generation,
+                correlation_id=self._correlation_id,
+                camera_name=command.camera_name,
+                status=ready_status,
+            )
+        stopping_status = WorkerPreviewStatusPayload(
+            enabled=preview_status.enabled,
+            state=PreviewState.STOPPING,
+            viewer_count=preview_status.viewer_count,
+        )
+        self._preview_statuses[command.camera_name] = stopping_status
+        return WorkerCommandResult(
+            command=command.command,
+            command_id=command.command_id,
+            generation=self._generation,
+            correlation_id=self._correlation_id,
+            camera_name=command.camera_name,
+            stop_result=WorkerPreviewStopPayload(
+                accepted=True,
+                state=PreviewState.STOPPING,
+            ),
+        )
+
     def _emit_event(self, event: WorkerEventType, *, message: str | None = None) -> None:
         payload = WorkerEvent(
             event=event,
@@ -100,6 +215,7 @@ class _HarnessService:
             correlation_id=self._correlation_id,
             pid=os.getpid(),
             cameras=self._camera_payloads(),
+            previews=dict(self._preview_statuses),
             message=message,
         )
         self._emitter.send(payload)
@@ -119,6 +235,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--generation", type=int, required=True)
     parser.add_argument("--config-json-path", type=Path, required=True)
     parser.add_argument("--control-socket-path", type=Path, required=True)
+    parser.add_argument("--command-socket-path", type=Path, required=True)
     parser.add_argument("--correlation-id", type=str, required=True)
     parser.add_argument("--heartbeat-interval-s", type=float, default=0.05)
     parser.add_argument(
@@ -137,6 +254,7 @@ async def _run_harness(args: argparse.Namespace) -> None:
         generation=args.generation,
         correlation_id=args.correlation_id,
         heartbeat_interval_s=args.heartbeat_interval_s,
+        command_socket_path=args.command_socket_path,
         scenario=args.harness_scenario,
         emitter=emitter,
     )

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -421,7 +421,6 @@ class _RuntimeWorkerService:
             correlation_id=self._correlation_id,
             pid=os.getpid(),
             cameras=self._collect_camera_statuses(),
-            previews=self._collect_preview_statuses(),
             message=message,
         )
         self._emitter.send(event)

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -47,10 +47,6 @@ from homesec.runtime.subprocess_protocol import (
     WorkerPreviewStatusPayload,
     WorkerPreviewStopPayload,
 )
-from homesec.sources.rtsp.live_publisher import (
-    LivePublisherStartRefusal,
-    LivePublisherStatus,
-)
 
 if TYPE_CHECKING:
     from homesec.interfaces import (
@@ -67,12 +63,31 @@ logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
+class _PreviewStatusLike(Protocol):
+    """Structural preview-status payload exposed by a source plugin."""
+
+    state: object
+    viewer_count: int | None
+    degraded_reason: str | None
+    last_error: str | None
+    idle_shutdown_at: float | None
+
+
+@runtime_checkable
+class _PreviewRefusalLike(Protocol):
+    """Structural preview-start refusal payload exposed by a source plugin."""
+
+    reason: object
+    message: str
+
+
+@runtime_checkable
 class _PreviewCapableSource(Protocol):
     """Structural protocol for camera sources that expose preview controls."""
 
-    def preview_status(self) -> LivePublisherStatus: ...
+    def preview_status(self) -> _PreviewStatusLike: ...
 
-    def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal: ...
+    def ensure_preview_active(self) -> _PreviewStatusLike | _PreviewRefusalLike: ...
 
     def stop_preview(self) -> None: ...
 
@@ -473,16 +488,22 @@ class _RuntimeWorkerService:
                 state=PreviewState.IDLE,
             )
 
-        preview_status = source.preview_status()
-        return CameraPreviewStatus(
-            camera_name=camera_name,
-            enabled=True,
-            state=PreviewState(preview_status.state.value),
-            viewer_count=preview_status.viewer_count,
-            degraded_reason=preview_status.degraded_reason,
-            last_error=preview_status.last_error,
-            idle_shutdown_at=preview_status.idle_shutdown_at,
-        )
+        try:
+            preview_status = source.preview_status()
+            return self._camera_preview_status_from_source(camera_name, preview_status)
+        except Exception as exc:
+            logger.warning(
+                "Preview status lookup failed for camera=%s: %s",
+                camera_name,
+                exc,
+                exc_info=True,
+            )
+            return CameraPreviewStatus(
+                camera_name=camera_name,
+                enabled=True,
+                state=PreviewState.ERROR,
+                last_error="Preview status unavailable",
+            )
 
     def _ensure_preview_active(
         self,
@@ -502,27 +523,45 @@ class _RuntimeWorkerService:
                 message="Preview source is not available",
             )
 
-        result = source.ensure_preview_active()
-        if isinstance(result, LivePublisherStartRefusal):
+        try:
+            result = source.ensure_preview_active()
+            if isinstance(result, _PreviewRefusalLike):
+                return CameraPreviewStartRefusal(
+                    camera_name=camera_name,
+                    reason=self._preview_refusal_reason_from_source(result.reason),
+                    message=result.message,
+                )
+            return self._camera_preview_status_from_source(camera_name, result)
+        except Exception as exc:
+            logger.warning(
+                "Preview activation failed for camera=%s: %s",
+                camera_name,
+                exc,
+                exc_info=True,
+            )
             return CameraPreviewStartRefusal(
                 camera_name=camera_name,
-                reason=PreviewRefusalReason(result.reason.value),
-                message=result.message,
+                reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message="Preview activation failed",
             )
-        return CameraPreviewStatus(
-            camera_name=camera_name,
-            enabled=True,
-            state=PreviewState(result.state.value),
-            viewer_count=result.viewer_count,
-            degraded_reason=result.degraded_reason,
-            last_error=result.last_error,
-            idle_shutdown_at=result.idle_shutdown_at,
-        )
 
     def _force_stop_preview(self, camera_name: str) -> CameraPreviewStopResult:
         source = self._source_for_camera(camera_name)
         if source is not None and self._preview_enabled(camera_name, source):
-            source.stop_preview()
+            try:
+                source.stop_preview()
+            except Exception as exc:
+                logger.warning(
+                    "Preview stop failed for camera=%s: %s",
+                    camera_name,
+                    exc,
+                    exc_info=True,
+                )
+                return CameraPreviewStopResult(
+                    camera_name=camera_name,
+                    accepted=False,
+                    state=PreviewState.ERROR,
+                )
         return CameraPreviewStopResult(
             camera_name=camera_name,
             accepted=True,
@@ -549,6 +588,40 @@ class _RuntimeWorkerService:
         if source is not None:
             return True
         return camera.source.backend == "rtsp"
+
+    @staticmethod
+    def _camera_preview_status_from_source(
+        camera_name: str,
+        preview_status: _PreviewStatusLike,
+    ) -> CameraPreviewStatus:
+        return CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=True,
+            state=_preview_state_from_source(preview_status.state),
+            viewer_count=preview_status.viewer_count,
+            degraded_reason=preview_status.degraded_reason,
+            last_error=preview_status.last_error,
+            idle_shutdown_at=preview_status.idle_shutdown_at,
+        )
+
+    @staticmethod
+    def _preview_refusal_reason_from_source(reason: object) -> PreviewRefusalReason:
+        raw_reason = getattr(reason, "value", reason)
+        if not isinstance(raw_reason, str):
+            raise TypeError(
+                "Preview refusal reason must be a string-compatible enum, "
+                f"got {type(reason).__name__}"
+            )
+        return PreviewRefusalReason(raw_reason)
+
+
+def _preview_state_from_source(state: object) -> PreviewState:
+    raw_state = getattr(state, "value", state)
+    if not isinstance(raw_state, str):
+        raise TypeError(
+            f"Preview state must be a string-compatible enum, got {type(state).__name__}"
+        )
+    return PreviewState(raw_state)
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -10,7 +10,7 @@ import signal
 import socket
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from homesec.config import resolve_env_var
 from homesec.interfaces import Notifier
@@ -27,11 +27,29 @@ from homesec.runtime.bootstrap import (
     build_runtime_persistence_stack,
 )
 from homesec.runtime.errors import sanitize_runtime_error
-from homesec.runtime.models import RuntimeBundle
+from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    CameraPreviewStopResult,
+    PreviewRefusalReason,
+    PreviewState,
+    RuntimeBundle,
+)
 from homesec.runtime.subprocess_protocol import (
     WorkerCameraStatusPayload,
+    WorkerCommand,
+    WorkerCommandErrorCode,
+    WorkerCommandResult,
+    WorkerCommandType,
     WorkerEvent,
     WorkerEventType,
+    WorkerPreviewRefusalPayload,
+    WorkerPreviewStatusPayload,
+    WorkerPreviewStopPayload,
+)
+from homesec.sources.rtsp.live_publisher import (
+    LivePublisherStartRefusal,
+    LivePublisherStatus,
 )
 
 if TYPE_CHECKING:
@@ -46,6 +64,17 @@ if TYPE_CHECKING:
     from homesec.repository import ClipRepository
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class _PreviewCapableSource(Protocol):
+    """Structural protocol for camera sources that expose preview controls."""
+
+    def preview_status(self) -> LivePublisherStatus: ...
+
+    def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal: ...
+
+    def stop_preview(self) -> None: ...
 
 
 class _NoopNotifier(Notifier):
@@ -87,12 +116,14 @@ class _RuntimeWorkerService:
         generation: int,
         correlation_id: str,
         heartbeat_interval_s: float,
+        command_socket_path: Path,
         emitter: _WorkerEventEmitter,
     ) -> None:
         self._config = config
         self._generation = generation
         self._correlation_id = correlation_id
         self._heartbeat_interval_s = heartbeat_interval_s
+        self._command_socket_path = command_socket_path
         self._emitter = emitter
 
         self._storage: StorageBackend | None = None
@@ -101,6 +132,8 @@ class _RuntimeWorkerService:
         self._repository: ClipRepository | None = None
         self._assembler: RuntimeAssembler | None = None
         self._runtime_bundle: RuntimeBundle | None = None
+        self._command_server: asyncio.Server | None = None
+        self._camera_configs = {camera.name: camera for camera in config.cameras}
 
     async def run_runtime(self, stop_event: asyncio.Event) -> None:
         started = False
@@ -108,6 +141,11 @@ class _RuntimeWorkerService:
 
         try:
             discover_all_plugins()
+            self._command_socket_path.unlink(missing_ok=True)
+            self._command_server = await asyncio.start_unix_server(
+                self._handle_command_connection,
+                path=str(self._command_socket_path),
+            )
 
             persistence = await self._build_runtime_persistence_stack()
             self._storage = persistence.storage
@@ -140,6 +178,13 @@ class _RuntimeWorkerService:
                     await heartbeat_task
                 except asyncio.CancelledError:
                     pass
+
+            command_server = self._command_server
+            self._command_server = None
+            if command_server is not None:
+                command_server.close()
+                await command_server.wait_closed()
+            self._command_socket_path.unlink(missing_ok=True)
 
             await self._shutdown_runtime_stack()
 
@@ -254,6 +299,106 @@ class _RuntimeWorkerService:
 
         return sources, sources_by_camera
 
+    async def _handle_command_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            raw_command = await reader.readline()
+            if not raw_command:
+                return
+
+            try:
+                command = WorkerCommand.model_validate_json(raw_command.decode("utf-8"))
+            except Exception as exc:
+                logger.warning("Dropping invalid runtime preview command: %s", exc, exc_info=True)
+                return
+
+            result = self._handle_command(command)
+            writer.write(result.model_dump_json().encode("utf-8") + b"\n")
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    def _handle_command(self, command: WorkerCommand) -> WorkerCommandResult:
+        if command.generation != self._generation or command.correlation_id != self._correlation_id:
+            return WorkerCommandResult(
+                command=command.command,
+                command_id=command.command_id,
+                generation=self._generation,
+                correlation_id=self._correlation_id,
+                camera_name=command.camera_name,
+                error_message="Runtime worker rejected preview command for another generation",
+            )
+
+        if command.camera_name not in self._camera_configs:
+            return WorkerCommandResult(
+                command=command.command,
+                command_id=command.command_id,
+                generation=self._generation,
+                correlation_id=self._correlation_id,
+                camera_name=command.camera_name,
+                error_code=WorkerCommandErrorCode.CAMERA_NOT_FOUND,
+                error_message=f"Camera '{command.camera_name}' not found",
+            )
+
+        match command.command:
+            case WorkerCommandType.PREVIEW_STATUS:
+                return WorkerCommandResult(
+                    command=command.command,
+                    command_id=command.command_id,
+                    generation=self._generation,
+                    correlation_id=self._correlation_id,
+                    camera_name=command.camera_name,
+                    status=self._preview_status_payload(command.camera_name),
+                )
+            case WorkerCommandType.PREVIEW_ENSURE_ACTIVE:
+                outcome = self._ensure_preview_active(command.camera_name)
+                if isinstance(outcome, CameraPreviewStartRefusal):
+                    return WorkerCommandResult(
+                        command=command.command,
+                        command_id=command.command_id,
+                        generation=self._generation,
+                        correlation_id=self._correlation_id,
+                        camera_name=command.camera_name,
+                        refusal=WorkerPreviewRefusalPayload(
+                            reason=outcome.reason,
+                            message=outcome.message,
+                        ),
+                    )
+                return WorkerCommandResult(
+                    command=command.command,
+                    command_id=command.command_id,
+                    generation=self._generation,
+                    correlation_id=self._correlation_id,
+                    camera_name=command.camera_name,
+                    status=self._preview_status_payload(command.camera_name, outcome),
+                )
+            case WorkerCommandType.PREVIEW_FORCE_STOP:
+                stop_result = self._force_stop_preview(command.camera_name)
+                return WorkerCommandResult(
+                    command=command.command,
+                    command_id=command.command_id,
+                    generation=self._generation,
+                    correlation_id=self._correlation_id,
+                    camera_name=command.camera_name,
+                    stop_result=WorkerPreviewStopPayload(
+                        accepted=stop_result.accepted,
+                        state=stop_result.state,
+                    ),
+                )
+            case _:
+                return WorkerCommandResult(
+                    command=command.command,
+                    command_id=command.command_id,
+                    generation=self._generation,
+                    correlation_id=self._correlation_id,
+                    camera_name=command.camera_name,
+                    error_message=f"Unsupported preview command: {command.command}",
+                )
+
     def _emit_event(self, event_type: WorkerEventType, *, message: str | None = None) -> None:
         event = WorkerEvent(
             event=event_type,
@@ -261,6 +406,7 @@ class _RuntimeWorkerService:
             correlation_id=self._correlation_id,
             pid=os.getpid(),
             cameras=self._collect_camera_statuses(),
+            previews=self._collect_preview_statuses(),
             message=message,
         )
         self._emitter.send(event)
@@ -290,12 +436,127 @@ class _RuntimeWorkerService:
 
         return statuses
 
+    def _collect_preview_statuses(self) -> dict[str, WorkerPreviewStatusPayload]:
+        return {
+            camera.name: self._preview_status_payload(camera.name)
+            for camera in self._config.cameras
+        }
+
+    def _preview_status_payload(
+        self,
+        camera_name: str,
+        status: CameraPreviewStatus | None = None,
+    ) -> WorkerPreviewStatusPayload:
+        preview_status = status or self._preview_status(camera_name)
+        return WorkerPreviewStatusPayload(
+            enabled=preview_status.enabled,
+            state=preview_status.state,
+            viewer_count=preview_status.viewer_count,
+            degraded_reason=preview_status.degraded_reason,
+            last_error=preview_status.last_error,
+            idle_shutdown_at=preview_status.idle_shutdown_at,
+        )
+
+    def _preview_status(self, camera_name: str) -> CameraPreviewStatus:
+        source = self._source_for_camera(camera_name)
+        if not self._preview_enabled(camera_name, source):
+            return CameraPreviewStatus(
+                camera_name=camera_name,
+                enabled=False,
+                state=PreviewState.IDLE,
+            )
+
+        if source is None:
+            return CameraPreviewStatus(
+                camera_name=camera_name,
+                enabled=True,
+                state=PreviewState.IDLE,
+            )
+
+        preview_status = source.preview_status()
+        return CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=True,
+            state=PreviewState(preview_status.state.value),
+            viewer_count=preview_status.viewer_count,
+            degraded_reason=preview_status.degraded_reason,
+            last_error=preview_status.last_error,
+            idle_shutdown_at=preview_status.idle_shutdown_at,
+        )
+
+    def _ensure_preview_active(
+        self,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        source = self._source_for_camera(camera_name)
+        if not self._preview_enabled(camera_name, source):
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message="Preview is not enabled for this camera",
+            )
+        if source is None:
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message="Preview source is not available",
+            )
+
+        result = source.ensure_preview_active()
+        if isinstance(result, LivePublisherStartRefusal):
+            return CameraPreviewStartRefusal(
+                camera_name=camera_name,
+                reason=PreviewRefusalReason(result.reason.value),
+                message=result.message,
+            )
+        return CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=True,
+            state=PreviewState(result.state.value),
+            viewer_count=result.viewer_count,
+            degraded_reason=result.degraded_reason,
+            last_error=result.last_error,
+            idle_shutdown_at=result.idle_shutdown_at,
+        )
+
+    def _force_stop_preview(self, camera_name: str) -> CameraPreviewStopResult:
+        source = self._source_for_camera(camera_name)
+        if source is not None and self._preview_enabled(camera_name, source):
+            source.stop_preview()
+        return CameraPreviewStopResult(
+            camera_name=camera_name,
+            accepted=True,
+            state=PreviewState.STOPPING,
+        )
+
+    def _source_for_camera(self, camera_name: str) -> _PreviewCapableSource | None:
+        bundle = self._runtime_bundle
+        if bundle is None:
+            return None
+        source = bundle.sources_by_camera.get(camera_name)
+        if isinstance(source, _PreviewCapableSource):
+            return source
+        return None
+
+    def _preview_enabled(
+        self,
+        camera_name: str,
+        source: _PreviewCapableSource | None,
+    ) -> bool:
+        camera = self._camera_configs[camera_name]
+        if not self._config.preview.enabled or not camera.enabled:
+            return False
+        if source is not None:
+            return True
+        return camera.source.backend == "rtsp"
+
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="HomeSec runtime worker")
     parser.add_argument("--generation", type=int, required=True)
     parser.add_argument("--config-json-path", type=Path, required=True)
     parser.add_argument("--control-socket-path", type=Path, required=True)
+    parser.add_argument("--command-socket-path", type=Path, required=True)
     parser.add_argument("--correlation-id", type=str, required=True)
     parser.add_argument("--heartbeat-interval-s", type=float, default=2.0)
     return parser.parse_args(argv)
@@ -312,6 +573,7 @@ async def _run_worker(args: argparse.Namespace) -> None:
         generation=args.generation,
         correlation_id=args.correlation_id,
         heartbeat_interval_s=args.heartbeat_interval_s,
+        command_socket_path=args.command_socket_path,
         emitter=emitter,
     )
     stop_event = asyncio.Event()

--- a/tests/homesec/test_app.py
+++ b/tests/homesec/test_app.py
@@ -30,6 +30,11 @@ from homesec.plugins.storage.dropbox import DropboxStorageConfig
 from homesec.runtime.controller import RuntimeController
 from homesec.runtime.errors import RuntimeReloadConfigError
 from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    CameraPreviewStopResult,
+    PreviewRefusalReason,
+    PreviewState,
     RuntimeCameraStatus,
     RuntimeState,
     RuntimeStatusSnapshot,
@@ -112,6 +117,7 @@ class _StubRuntimeController(RuntimeController):
             correlation_id=f"test-{generation}",
             temp_dir=Path("/tmp"),
             control_socket_path=Path("/tmp/homesec-test.sock"),
+            command_socket_path=Path("/tmp/homesec-test-command.sock"),
             config_json_path=Path("/tmp/homesec-test.json"),
         )
         self._handles.append(handle)
@@ -136,6 +142,42 @@ class _StubRuntimeController(RuntimeController):
     async def shutdown_all(self) -> None:
         for handle in self._handles:
             await self.shutdown_runtime(handle)
+
+    async def get_preview_status(
+        self,
+        runtime: SubprocessRuntimeHandle,
+        camera_name: str,
+    ) -> CameraPreviewStatus:
+        _ = runtime
+        return CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=False,
+            state=PreviewState.IDLE,
+        )
+
+    async def ensure_preview_active(
+        self,
+        runtime: SubprocessRuntimeHandle,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        _ = runtime
+        return CameraPreviewStartRefusal(
+            camera_name=camera_name,
+            reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+            message="Preview is not enabled for this camera",
+        )
+
+    async def force_stop_preview(
+        self,
+        runtime: SubprocessRuntimeHandle,
+        camera_name: str,
+    ) -> CameraPreviewStopResult:
+        _ = runtime
+        return CameraPreviewStopResult(
+            camera_name=camera_name,
+            accepted=True,
+            state=PreviewState.STOPPING,
+        )
 
 
 class _StubRuntimeManagerStatus:
@@ -273,6 +315,7 @@ def test_get_runtime_status_preserves_reloading_when_heartbeat_is_stale() -> Non
         correlation_id="test-2",
         temp_dir=Path("/tmp"),
         control_socket_path=Path("/tmp/homesec-test.sock"),
+        command_socket_path=Path("/tmp/homesec-test-command.sock"),
         config_json_path=Path("/tmp/homesec-test.json"),
     )
     runtime.process = cast(asyncio.subprocess.Process, _FakeProcess(pid=1002))
@@ -313,6 +356,7 @@ def test_camera_health_degrades_when_runtime_heartbeat_is_stale() -> None:
         correlation_id="test-2",
         temp_dir=Path("/tmp"),
         control_socket_path=Path("/tmp/homesec-test.sock"),
+        command_socket_path=Path("/tmp/homesec-test-command.sock"),
         config_json_path=Path("/tmp/homesec-test.json"),
     )
     runtime.process = cast(asyncio.subprocess.Process, _FakeProcess(pid=1002))
@@ -437,6 +481,65 @@ async def test_request_runtime_reload_maps_source_config_error_to_400(
     # Then: API-facing error status/code are mapped from ConfigErrorCode
     assert exc_info.value.status_code == 400
     assert exc_info.value.error_code == ConfigErrorCode.FILE_NOT_FOUND.value
+
+
+@pytest.mark.asyncio
+async def test_application_preview_methods_delegate_to_runtime_manager() -> None:
+    """Application preview facade should delegate to runtime manager methods."""
+
+    class _StubRuntimeManager:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str]] = []
+
+        async def get_preview_status(self, camera_name: str) -> CameraPreviewStatus:
+            self.calls.append(("status", camera_name))
+            return CameraPreviewStatus(
+                camera_name=camera_name,
+                enabled=True,
+                state=PreviewState.READY,
+                viewer_count=1,
+            )
+
+        async def ensure_preview_active(
+            self,
+            camera_name: str,
+        ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+            self.calls.append(("ensure", camera_name))
+            return CameraPreviewStatus(
+                camera_name=camera_name,
+                enabled=True,
+                state=PreviewState.READY,
+                viewer_count=1,
+            )
+
+        async def force_stop_preview(self, camera_name: str) -> CameraPreviewStopResult:
+            self.calls.append(("stop", camera_name))
+            return CameraPreviewStopResult(
+                camera_name=camera_name,
+                accepted=True,
+                state=PreviewState.STOPPING,
+            )
+
+    # Given: An application with a runtime manager that records preview calls
+    app = Application(config_path=Path(__file__))
+    manager = _StubRuntimeManager()
+    app._runtime_manager = cast(Any, manager)
+
+    # When: Calling the application preview methods
+    status = await app.get_camera_preview_status("front_door")
+    ensured = await app.ensure_camera_preview_active("front_door")
+    stopped = await app.force_stop_camera_preview("front_door")
+
+    # Then: Preview methods delegate through the runtime manager facade
+    assert status.state == PreviewState.READY
+    assert isinstance(ensured, CameraPreviewStatus)
+    assert ensured.state == PreviewState.READY
+    assert stopped.state == PreviewState.STOPPING
+    assert manager.calls == [
+        ("status", "front_door"),
+        ("ensure", "front_door"),
+        ("stop", "front_door"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -579,6 +682,7 @@ def test_get_runtime_status_uses_worker_exit_code_for_stale_runtime() -> None:
         correlation_id="test-3",
         temp_dir=Path("/tmp"),
         control_socket_path=Path("/tmp/homesec-test.sock"),
+        command_socket_path=Path("/tmp/homesec-test-command.sock"),
         config_json_path=Path("/tmp/homesec-test.json"),
     )
     runtime.process = cast(asyncio.subprocess.Process, _FakeProcess(pid=1003))

--- a/tests/homesec/test_runtime_manager.py
+++ b/tests/homesec/test_runtime_manager.py
@@ -25,8 +25,18 @@ from homesec.plugins.analyzers.openai import OpenAIConfig
 from homesec.plugins.filters.yolo import YoloFilterConfig
 from homesec.plugins.storage.dropbox import DropboxStorageConfig
 from homesec.runtime.controller import RuntimeController
+from homesec.runtime.errors import PreviewRuntimeUnavailableError
 from homesec.runtime.manager import RuntimeManager
-from homesec.runtime.models import RuntimeBundle, RuntimeState, config_signature
+from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    CameraPreviewStopResult,
+    PreviewRefusalReason,
+    PreviewState,
+    RuntimeBundle,
+    RuntimeState,
+    config_signature,
+)
 from homesec.sources.local_folder import LocalFolderSourceConfig
 
 
@@ -95,6 +105,9 @@ class _FakeController(RuntimeController):
         self.build_calls: list[int] = []
         self.start_calls: list[int] = []
         self.shutdown_calls: list[int] = []
+        self.preview_status_calls: list[tuple[int, str]] = []
+        self.preview_ensure_calls: list[tuple[int, str]] = []
+        self.preview_force_stop_calls: list[tuple[int, str]] = []
         self.shutdown_all_calls = 0
         self.running_generations: set[int] = set()
         self.fail_build_generations: set[int] = set()
@@ -102,6 +115,9 @@ class _FakeController(RuntimeController):
         self.fail_shutdown_generations: set[int] = set()
         self.block_start_generations: set[int] = set()
         self.start_gate: asyncio.Event | None = None
+        self.preview_status_result: CameraPreviewStatus | None = None
+        self.preview_ensure_result: CameraPreviewStatus | CameraPreviewStartRefusal | None = None
+        self.preview_force_stop_result: CameraPreviewStopResult | None = None
 
     async def build_candidate(self, config: Config, generation: int) -> RuntimeBundle:
         self.build_calls.append(generation)
@@ -128,6 +144,48 @@ class _FakeController(RuntimeController):
     async def shutdown_all(self) -> None:
         self.shutdown_all_calls += 1
         self.running_generations.clear()
+
+    async def get_preview_status(
+        self,
+        runtime: RuntimeBundle,
+        camera_name: str,
+    ) -> CameraPreviewStatus:
+        self.preview_status_calls.append((runtime.generation, camera_name))
+        if self.preview_status_result is not None:
+            return self.preview_status_result
+        return CameraPreviewStatus(
+            camera_name=camera_name,
+            enabled=False,
+            state=PreviewState.IDLE,
+        )
+
+    async def ensure_preview_active(
+        self,
+        runtime: RuntimeBundle,
+        camera_name: str,
+    ) -> CameraPreviewStatus | CameraPreviewStartRefusal:
+        self.preview_ensure_calls.append((runtime.generation, camera_name))
+        if self.preview_ensure_result is not None:
+            return self.preview_ensure_result
+        return CameraPreviewStartRefusal(
+            camera_name=camera_name,
+            reason=PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+            message="Preview is not enabled for this camera",
+        )
+
+    async def force_stop_preview(
+        self,
+        runtime: RuntimeBundle,
+        camera_name: str,
+    ) -> CameraPreviewStopResult:
+        self.preview_force_stop_calls.append((runtime.generation, camera_name))
+        if self.preview_force_stop_result is not None:
+            return self.preview_force_stop_result
+        return CameraPreviewStopResult(
+            camera_name=camera_name,
+            accepted=True,
+            state=PreviewState.STOPPING,
+        )
 
 
 def _make_config(*, camera_name: str, watch_dir: str) -> Config:
@@ -468,3 +526,63 @@ async def test_runtime_manager_shutdown_cancels_stuck_reload_task() -> None:
     status = manager.get_status()
     assert status.state == RuntimeState.IDLE
     assert status.reload_in_progress is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_manager_delegates_preview_methods_to_active_runtime() -> None:
+    """Preview control should target the currently active runtime generation."""
+    # Given: An active runtime with preview responses configured on the controller
+    controller = _FakeController()
+    controller.preview_status_result = CameraPreviewStatus(
+        camera_name="front",
+        enabled=True,
+        state=PreviewState.READY,
+        viewer_count=2,
+    )
+    controller.preview_ensure_result = CameraPreviewStatus(
+        camera_name="front",
+        enabled=True,
+        state=PreviewState.READY,
+        viewer_count=2,
+    )
+    controller.preview_force_stop_result = CameraPreviewStopResult(
+        camera_name="front",
+        accepted=True,
+        state=PreviewState.STOPPING,
+    )
+    manager = RuntimeManager(controller)
+    config = _make_config(camera_name="front", watch_dir="/tmp/front-preview")
+    await manager.start_initial_runtime(config)
+
+    # When: Querying preview status, ensuring preview, and force-stopping preview
+    status = await manager.get_preview_status("front")
+    ensured = await manager.ensure_preview_active("front")
+    stopped = await manager.force_stop_preview("front")
+
+    # Then: Each preview operation targets the active runtime generation
+    assert status.state == PreviewState.READY
+    assert controller.preview_status_calls == [(1, "front")]
+    assert isinstance(ensured, CameraPreviewStatus)
+    assert ensured.state == PreviewState.READY
+    assert controller.preview_ensure_calls == [(1, "front")]
+    assert stopped.state == PreviewState.STOPPING
+    assert controller.preview_force_stop_calls == [(1, "front")]
+
+
+@pytest.mark.asyncio
+async def test_runtime_manager_preview_methods_require_active_runtime() -> None:
+    """Preview control should fail explicitly before any runtime is active."""
+    # Given: A runtime manager with no active runtime
+    manager = RuntimeManager(_FakeController())
+
+    # When/Then: Preview status requires an active runtime
+    with pytest.raises(PreviewRuntimeUnavailableError, match="Runtime is not active"):
+        await manager.get_preview_status("front")
+
+    # When/Then: Preview ensure requires an active runtime
+    with pytest.raises(PreviewRuntimeUnavailableError, match="Runtime is not active"):
+        await manager.ensure_preview_active("front")
+
+    # When/Then: Preview force-stop requires an active runtime
+    with pytest.raises(PreviewRuntimeUnavailableError, match="Runtime is not active"):
+        await manager.force_stop_preview("front")

--- a/tests/homesec/test_runtime_subprocess_controller.py
+++ b/tests/homesec/test_runtime_subprocess_controller.py
@@ -6,6 +6,7 @@ import asyncio
 import signal
 import tempfile
 import uuid
+from datetime import timedelta
 from pathlib import Path
 from typing import cast
 
@@ -25,7 +26,9 @@ from homesec.models.vlm import VLMConfig
 from homesec.plugins.analyzers.openai import OpenAIConfig
 from homesec.plugins.filters.yolo import YoloFilterConfig
 from homesec.plugins.storage.dropbox import DropboxStorageConfig
+from homesec.runtime.errors import PreviewRuntimeUnavailableError
 from homesec.runtime.manager import RuntimeManager
+from homesec.runtime.models import CameraPreviewStatus, PreviewState
 from homesec.runtime.subprocess_controller import (
     SubprocessRuntimeController,
     SubprocessRuntimeHandle,
@@ -35,14 +38,23 @@ from homesec.runtime.subprocess_protocol import WorkerEvent, WorkerEventType
 from homesec.sources.local_folder import LocalFolderSourceConfig
 
 
-def _make_config(*, watch_dir: str) -> Config:
+def _make_config(
+    *,
+    watch_dir: str,
+    source_backend: str = "local_folder",
+    preview_enabled: bool = False,
+) -> Config:
     return Config(
         cameras=[
             CameraConfig(
                 name="front",
                 source=CameraSourceConfig(
-                    backend="local_folder",
-                    config=LocalFolderSourceConfig(watch_dir=watch_dir, poll_interval=1.0),
+                    backend=source_backend,
+                    config=(
+                        LocalFolderSourceConfig(watch_dir=watch_dir, poll_interval=1.0)
+                        if source_backend == "local_folder"
+                        else {}
+                    ),
                 ),
             )
         ],
@@ -62,6 +74,7 @@ def _make_config(*, watch_dir: str) -> Config:
             trigger_classes=["person"],
         ),
         alert_policy=AlertPolicyConfig(backend="default", config={}),
+        preview={"enabled": preview_enabled},
     )
 
 
@@ -93,6 +106,88 @@ async def test_subprocess_controller_starts_and_stops_test_worker() -> None:
     assert runtime.is_running is False
     assert "front" in runtime.camera_statuses
     assert runtime.camera_statuses["front"].healthy is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.subprocess
+async def test_subprocess_controller_preview_commands_round_trip_to_worker() -> None:
+    """Preview control should round-trip through worker command plumbing."""
+    # Given: A preview-enabled RTSP camera supervised by the harness worker
+    controller = SubprocessRuntimeController(
+        startup_timeout_s=3.0,
+        shutdown_timeout_s=1.0,
+        kill_timeout_s=1.0,
+        worker_heartbeat_interval_s=0.05,
+        heartbeat_stale_s=1.0,
+        worker_module="homesec.runtime.test_worker_harness",
+    )
+    runtime = cast(
+        SubprocessRuntimeHandle,
+        await controller.build_candidate(
+            _make_config(
+                watch_dir="/tmp/preview",
+                source_backend="rtsp",
+                preview_enabled=True,
+            ),
+            1,
+        ),
+    )
+
+    try:
+        await controller.start_runtime(runtime)
+
+        # When: Reading preview status, ensuring preview, and force-stopping preview
+        status = await controller.get_preview_status(runtime, "front")
+        ensured = await controller.ensure_preview_active(runtime, "front")
+        stopped = await controller.force_stop_preview(runtime, "front")
+
+        # Then: The runtime preview contract is returned from the worker
+        assert status.enabled is True
+        assert status.state == PreviewState.IDLE
+        assert isinstance(ensured, CameraPreviewStatus)
+        assert ensured.state == PreviewState.READY
+        assert stopped.accepted is True
+        assert stopped.state == PreviewState.STOPPING
+        assert runtime.camera_preview_statuses["front"].state == PreviewState.STOPPING
+    finally:
+        await controller.shutdown_runtime(runtime)
+
+
+@pytest.mark.asyncio
+@pytest.mark.subprocess
+async def test_subprocess_controller_preview_stop_rejects_stale_worker() -> None:
+    """Force-stop should fail explicitly when the worker heartbeat is stale."""
+    # Given: A running worker whose cached heartbeat has gone stale
+    controller = SubprocessRuntimeController(
+        startup_timeout_s=3.0,
+        shutdown_timeout_s=1.0,
+        kill_timeout_s=1.0,
+        worker_heartbeat_interval_s=5.0,
+        heartbeat_stale_s=0.01,
+        worker_module="homesec.runtime.test_worker_harness",
+    )
+    runtime = cast(
+        SubprocessRuntimeHandle,
+        await controller.build_candidate(
+            _make_config(
+                watch_dir="/tmp/preview-stale",
+                source_backend="rtsp",
+                preview_enabled=True,
+            ),
+            1,
+        ),
+    )
+
+    try:
+        await controller.start_runtime(runtime)
+        assert runtime.last_heartbeat_at is not None
+        runtime.last_heartbeat_at = runtime.last_heartbeat_at - timedelta(seconds=60)
+
+        # When/Then: Force-stop fails because the runtime can no longer accept preview commands
+        with pytest.raises(PreviewRuntimeUnavailableError, match="heartbeat timed out"):
+            await controller.force_stop_preview(runtime, "front")
+    finally:
+        await controller.shutdown_runtime(runtime)
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/test_runtime_subprocess_controller.py
+++ b/tests/homesec/test_runtime_subprocess_controller.py
@@ -6,7 +6,7 @@ import asyncio
 import signal
 import tempfile
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 
@@ -28,7 +28,12 @@ from homesec.plugins.filters.yolo import YoloFilterConfig
 from homesec.plugins.storage.dropbox import DropboxStorageConfig
 from homesec.runtime.errors import PreviewRuntimeUnavailableError
 from homesec.runtime.manager import RuntimeManager
-from homesec.runtime.models import CameraPreviewStatus, PreviewState
+from homesec.runtime.models import (
+    CameraPreviewStartRefusal,
+    CameraPreviewStatus,
+    PreviewRefusalReason,
+    PreviewState,
+)
 from homesec.runtime.subprocess_controller import (
     SubprocessRuntimeController,
     SubprocessRuntimeHandle,
@@ -36,6 +41,12 @@ from homesec.runtime.subprocess_controller import (
 )
 from homesec.runtime.subprocess_protocol import WorkerEvent, WorkerEventType
 from homesec.sources.local_folder import LocalFolderSourceConfig
+
+
+class _FakeProcess:
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+        self.returncode: int | None = None
 
 
 def _make_config(
@@ -188,6 +199,57 @@ async def test_subprocess_controller_preview_stop_rejects_stale_worker() -> None
             await controller.force_stop_preview(runtime, "front")
     finally:
         await controller.shutdown_runtime(runtime)
+
+
+@pytest.mark.asyncio
+async def test_preview_command_failures_do_not_override_runtime_last_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preview command failures should not overwrite runtime-wide worker error state."""
+    # Given: A fresh runtime handle with an existing worker error and a failing preview command
+    controller = SubprocessRuntimeController()
+    runtime = cast(
+        SubprocessRuntimeHandle,
+        await controller.build_candidate(
+            _make_config(
+                watch_dir="/tmp/preview-command-error",
+                source_backend="rtsp",
+                preview_enabled=True,
+            ),
+            1,
+        ),
+    )
+    runtime.process = cast(asyncio.subprocess.Process, _FakeProcess(pid=4242))
+    runtime.last_heartbeat_at = datetime.now(timezone.utc)
+    runtime.last_error = "runtime worker exited with code 137"
+
+    async def _raise_send_command(
+        handle: SubprocessRuntimeHandle,
+        command_type: object,
+        camera_name: str,
+    ) -> object:
+        _ = (handle, command_type, camera_name)
+        raise RuntimeError("preview command failed")
+
+    monkeypatch.setattr(controller, "_send_command", _raise_send_command)
+
+    try:
+        # When: Preview status, ensure, and stop all hit the command failure path
+        status = await controller.get_preview_status(runtime, "front")
+        ensured = await controller.ensure_preview_active(runtime, "front")
+        with pytest.raises(PreviewRuntimeUnavailableError, match="preview command failed"):
+            await controller.force_stop_preview(runtime, "front")
+
+        # Then: Preview failures stay local and preserve the runtime-wide error context
+        assert status.state == PreviewState.ERROR
+        assert status.last_error == "preview command failed"
+        assert isinstance(ensured, CameraPreviewStartRefusal)
+        assert ensured.reason == PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+        assert ensured.message == "preview command failed"
+        assert runtime.last_error == "runtime worker exited with code 137"
+    finally:
+        runtime.process = None
+        await controller._finalize_handle(runtime)
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -251,6 +251,36 @@ def test_runtime_worker_preview_status_command_reports_runtime_preview_state() -
     assert result.status.idle_shutdown_at == 42.0
 
 
+def test_runtime_worker_preview_status_collection_degrades_when_source_raises() -> None:
+    """Preview status collection should fail closed when a source raises."""
+
+    class _PreviewSource:
+        def preview_status(self) -> LivePublisherStatus:
+            raise RuntimeError("publisher crashed")
+
+        def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+            raise AssertionError("status collection should not call ensure_preview_active")
+
+        def stop_preview(self) -> None:
+            raise AssertionError("status collection should not call stop_preview")
+
+    # Given: A preview-enabled RTSP camera whose source raises during status lookup
+    config = _make_config(notifiers=[], source_backend="rtsp", preview_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": _PreviewSource()}),
+    )
+
+    # When: Collecting preview status payloads for worker events
+    payloads = service._collect_preview_statuses()
+
+    # Then: The worker reports preview error state instead of raising
+    assert payloads["front"].enabled is True
+    assert payloads["front"].state == PreviewState.ERROR
+    assert payloads["front"].last_error == "Preview status unavailable"
+
+
 def test_runtime_worker_preview_ensure_command_returns_machine_readable_refusal() -> None:
     """Preview ensure command should preserve refusal semantics as structured data."""
 
@@ -289,6 +319,43 @@ def test_runtime_worker_preview_ensure_command_returns_machine_readable_refusal(
     assert result.refusal is not None
     assert result.refusal.reason == PreviewRefusalReason.RECORDING_PRIORITY
     assert result.refusal.message == "Recording currently owns the session budget"
+
+
+def test_runtime_worker_preview_ensure_command_degrades_when_source_raises() -> None:
+    """Preview ensure command should fail closed when a source raises."""
+
+    class _PreviewSource:
+        def preview_status(self) -> LivePublisherStatus:
+            return LivePublisherStatus(state=LivePublisherState.IDLE)
+
+        def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+            raise RuntimeError("publisher crashed")
+
+        def stop_preview(self) -> None:
+            raise AssertionError("ensure test should not call stop_preview")
+
+    # Given: A preview-enabled RTSP camera whose source raises on preview activation
+    config = _make_config(notifiers=[], source_backend="rtsp", preview_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": _PreviewSource()}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.PREVIEW_ENSURE_ACTIVE,
+        command_id="cmd-ensure-error",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+    )
+
+    # When: Handling a preview ensure command
+    result = service._handle_command(command)
+
+    # Then: The worker returns a temporary-unavailable refusal instead of bubbling the error
+    assert result.refusal is not None
+    assert result.refusal.reason == PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert result.refusal.message == "Preview activation failed"
 
 
 def test_runtime_worker_preview_force_stop_command_returns_stopping_ack() -> None:
@@ -331,3 +398,40 @@ def test_runtime_worker_preview_force_stop_command_returns_stopping_ack() -> Non
     assert result.stop_result.accepted is True
     assert result.stop_result.state == PreviewState.STOPPING
     assert source.stop_calls == 1
+
+
+def test_runtime_worker_preview_force_stop_command_rejects_when_source_raises() -> None:
+    """Preview force-stop should fail closed when a source raises."""
+
+    class _PreviewSource:
+        def preview_status(self) -> LivePublisherStatus:
+            return LivePublisherStatus(state=LivePublisherState.READY)
+
+        def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+            return LivePublisherStatus(state=LivePublisherState.READY)
+
+        def stop_preview(self) -> None:
+            raise RuntimeError("publisher crashed")
+
+    # Given: A preview-enabled RTSP camera whose source raises while stopping preview
+    config = _make_config(notifiers=[], source_backend="rtsp", preview_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": _PreviewSource()}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.PREVIEW_FORCE_STOP,
+        command_id="cmd-stop-error",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+    )
+
+    # When: Handling a preview force-stop command
+    result = service._handle_command(command)
+
+    # Then: The worker returns an explicit rejected stop result
+    assert result.stop_result is not None
+    assert result.stop_result.accepted is False
+    assert result.stop_result.state == PreviewState.ERROR

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -22,6 +24,17 @@ from homesec.models.enums import VLMRunMode
 from homesec.models.filter import FilterConfig
 from homesec.models.vlm import VLMConfig
 from homesec.runtime.bootstrap import RuntimePersistenceStack
+from homesec.runtime.models import PreviewRefusalReason, PreviewState
+from homesec.runtime.subprocess_protocol import (
+    WorkerCommand,
+    WorkerCommandType,
+)
+from homesec.sources.rtsp.live_publisher import (
+    LivePublisherRefusalReason,
+    LivePublisherStartRefusal,
+    LivePublisherState,
+    LivePublisherStatus,
+)
 
 
 class _StubEmitter:
@@ -36,12 +49,14 @@ def _make_config(
     *,
     notifiers: list[NotifierConfig],
     run_mode: VLMRunMode = VLMRunMode.TRIGGER_ONLY,
+    source_backend: str = "local_folder",
+    preview_enabled: bool = False,
 ) -> Config:
     return Config(
         cameras=[
             CameraConfig(
                 name="front",
-                source=CameraSourceConfig(backend="local_folder", config={}),
+                source=CameraSourceConfig(backend=source_backend, config={}),
             )
         ],
         storage=StorageConfig(backend="local", config={}),
@@ -50,6 +65,7 @@ def _make_config(
         filter=FilterConfig(backend="yolo", config={}),
         vlm=VLMConfig(backend="openai", run_mode=run_mode, config={}),
         alert_policy=AlertPolicyConfig(backend="default", config={}),
+        preview={"enabled": preview_enabled},
     )
 
 
@@ -59,6 +75,7 @@ def _make_service(config: Config) -> worker_module._RuntimeWorkerService:
         generation=1,
         correlation_id="test-correlation-id",
         heartbeat_interval_s=1.0,
+        command_socket_path=Path("/tmp/homesec-worker-test.sock"),
         emitter=cast(Any, _StubEmitter()),
     )
 
@@ -187,3 +204,130 @@ async def test_runtime_worker_run_runtime_skips_analyzer_load_when_run_mode_neve
 
     # Then: Worker completes lifecycle without invoking analyzer loader
     assert service._runtime_bundle is None
+
+
+def test_runtime_worker_preview_status_command_reports_runtime_preview_state() -> None:
+    """Preview status command should map source preview status into runtime fields."""
+
+    class _PreviewSource:
+        def preview_status(self) -> LivePublisherStatus:
+            return LivePublisherStatus(
+                state=LivePublisherState.DEGRADED,
+                viewer_count=None,
+                degraded_reason="viewer_count_unavailable",
+                last_error=None,
+                idle_shutdown_at=42.0,
+            )
+
+        def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+            raise AssertionError("status test should not call ensure_preview_active")
+
+        def stop_preview(self) -> None:
+            raise AssertionError("status test should not call stop_preview")
+
+    # Given: A preview-enabled RTSP camera with a preview-capable source in the runtime bundle
+    config = _make_config(notifiers=[], source_backend="rtsp", preview_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": _PreviewSource()}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.PREVIEW_STATUS,
+        command_id="cmd-status",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+    )
+
+    # When: Handling a preview status command
+    result = service._handle_command(command)
+
+    # Then: The worker returns runtime preview status aligned with the contract
+    assert result.status is not None
+    assert result.status.enabled is True
+    assert result.status.state == PreviewState.DEGRADED
+    assert result.status.degraded_reason == "viewer_count_unavailable"
+    assert result.status.idle_shutdown_at == 42.0
+
+
+def test_runtime_worker_preview_ensure_command_returns_machine_readable_refusal() -> None:
+    """Preview ensure command should preserve refusal semantics as structured data."""
+
+    class _PreviewSource:
+        def preview_status(self) -> LivePublisherStatus:
+            return LivePublisherStatus(state=LivePublisherState.IDLE)
+
+        def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+            return LivePublisherStartRefusal(
+                reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                message="Recording currently owns the session budget",
+            )
+
+        def stop_preview(self) -> None:
+            raise AssertionError("ensure test should not call stop_preview")
+
+    # Given: A preview-enabled RTSP camera whose source refuses preview startup
+    config = _make_config(notifiers=[], source_backend="rtsp", preview_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": _PreviewSource()}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.PREVIEW_ENSURE_ACTIVE,
+        command_id="cmd-ensure",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+    )
+
+    # When: Handling a preview ensure command
+    result = service._handle_command(command)
+
+    # Then: The worker returns a machine-readable refusal reason and message
+    assert result.refusal is not None
+    assert result.refusal.reason == PreviewRefusalReason.RECORDING_PRIORITY
+    assert result.refusal.message == "Recording currently owns the session budget"
+
+
+def test_runtime_worker_preview_force_stop_command_returns_stopping_ack() -> None:
+    """Preview force-stop command should return the async stopping acknowledgement."""
+
+    class _PreviewSource:
+        def __init__(self) -> None:
+            self.stop_calls = 0
+
+        def preview_status(self) -> LivePublisherStatus:
+            return LivePublisherStatus(state=LivePublisherState.READY)
+
+        def ensure_preview_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+            return LivePublisherStatus(state=LivePublisherState.READY)
+
+        def stop_preview(self) -> None:
+            self.stop_calls += 1
+
+    # Given: A preview-enabled RTSP camera with a preview-capable source
+    config = _make_config(notifiers=[], source_backend="rtsp", preview_enabled=True)
+    service = _make_service(config)
+    source = _PreviewSource()
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": source}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.PREVIEW_FORCE_STOP,
+        command_id="cmd-stop",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+    )
+
+    # When: Handling a preview force-stop command
+    result = service._handle_command(command)
+
+    # Then: The worker requests source shutdown and returns a stopping acknowledgement
+    assert result.stop_result is not None
+    assert result.stop_result.accepted is True
+    assert result.stop_result.state == PreviewState.STOPPING
+    assert source.stop_calls == 1

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -51,14 +51,17 @@ def _make_config(
     run_mode: VLMRunMode = VLMRunMode.TRIGGER_ONLY,
     source_backend: str = "local_folder",
     preview_enabled: bool = False,
+    camera_names: list[str] | None = None,
 ) -> Config:
+    cameras = [
+        CameraConfig(
+            name=name,
+            source=CameraSourceConfig(backend=source_backend, config={}),
+        )
+        for name in (camera_names or ["front"])
+    ]
     return Config(
-        cameras=[
-            CameraConfig(
-                name="front",
-                source=CameraSourceConfig(backend=source_backend, config={}),
-            )
-        ],
+        cameras=cameras,
         storage=StorageConfig(backend="local", config={}),
         state_store=StateStoreConfig(dsn="postgresql://user:pass@localhost/homesec"),
         notifiers=notifiers,
@@ -69,14 +72,18 @@ def _make_config(
     )
 
 
-def _make_service(config: Config) -> worker_module._RuntimeWorkerService:
+def _make_service(
+    config: Config,
+    *,
+    emitter: object | None = None,
+) -> worker_module._RuntimeWorkerService:
     return worker_module._RuntimeWorkerService(
         config=config,
         generation=1,
         correlation_id="test-correlation-id",
         heartbeat_interval_s=1.0,
         command_socket_path=Path("/tmp/homesec-worker-test.sock"),
-        emitter=cast(Any, _StubEmitter()),
+        emitter=cast(Any, emitter or _StubEmitter()),
     )
 
 
@@ -279,6 +286,38 @@ def test_runtime_worker_preview_status_collection_degrades_when_source_raises() 
     assert payloads["front"].enabled is True
     assert payloads["front"].state == PreviewState.ERROR
     assert payloads["front"].last_error == "Preview status unavailable"
+
+
+def test_runtime_worker_event_payload_stays_under_unix_datagram_limit() -> None:
+    """Heartbeat events should stay within the conservative Unix datagram size budget."""
+
+    class _CapturingEmitter:
+        def __init__(self) -> None:
+            self.payload: object | None = None
+
+        def send(self, event: object) -> None:
+            self.payload = event
+
+        def close(self) -> None:
+            return None
+
+    # Given: A preview-enabled worker with enough cameras to stress the heartbeat payload
+    config = _make_config(
+        notifiers=[],
+        source_backend="rtsp",
+        preview_enabled=True,
+        camera_names=[f"camera_{index}" for index in range(8)],
+    )
+    emitter = _CapturingEmitter()
+    service = _make_service(config, emitter=emitter)
+
+    # When: Emitting a heartbeat event
+    service._emit_event(worker_module.WorkerEventType.HEARTBEAT)
+
+    # Then: The serialized datagram fits within the 2048-byte macOS AF_UNIX limit
+    event = cast(worker_module.WorkerEvent, emitter.payload)
+    assert event.previews == {}
+    assert len(event.model_dump_json().encode("utf-8")) <= 2048
 
 
 def test_runtime_worker_preview_ensure_command_returns_machine_readable_refusal() -> None:


### PR DESCRIPTION
## Summary

- add runtime preview models and app/manager/controller methods for camera-scoped preview status, ensure-active, and force-stop
- extend the subprocess worker protocol with preview status reporting plus request/response preview control commands
- cover the new runtime plumbing with worker, controller, manager, and app tests

## Why

The preview control-plane contract needs runtime-owned camera preview control and machine-readable status/refusal plumbing before the final API handlers can be added.

## Impact

- future preview routes can call a narrow runtime surface instead of reaching into RTSP source internals
- preview status now travels with runtime state, and preview start refusals remain structured across the subprocess boundary
- force-stop is modeled as a runtime acknowledgement without embedding HTTP concerns

## Validation

- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec uv run pytest tests/homesec/test_runtime_manager.py tests/homesec/test_app.py tests/homesec/test_runtime_subprocess_controller.py tests/homesec/test_runtime_worker.py`
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make typecheck`
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check`
