### PR TITLE
feat: add RTSP HLS live publisher

### DIFF
--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -37,7 +37,9 @@ _READY_POLL_INTERVAL_S = 0.1
 _DEFAULT_VIEWER_WINDOW_S = 2.0
 _START_FAILURE_MAX_BYTES = 4_000
 _SESSION_LIMIT_HINTS: tuple[str, ...] = (
-    "too many",
+    "too many clients",
+    "too many connections",
+    "too many sessions",
     "max number of clients",
     "maximum number of clients",
     "maximum number of connections",
@@ -355,9 +357,11 @@ class HLSLivePublisher(LivePublisher):
             if not self._is_process_running_locked():
                 return False
             if self._output_ready_locked():
-                return True
+                return self._is_process_running_locked()
             self._clock.sleep(_READY_POLL_INTERVAL_S)
-        return self._output_ready_locked()
+        if not self._output_ready_locked():
+            return False
+        return self._is_process_running_locked()
 
     def _refresh_locked(self, *, now: float) -> None:
         self._expire_viewers_locked(now=now)

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -214,6 +214,15 @@ class HLSLivePublisher(LivePublisher):
                     self._release_queued_start_waiter_locked(queued_start_token)
                     return completed_start_result
 
+                if self._start_in_progress:
+                    next_queued_start_token = self._active_start_token
+                    if queued_start_token != next_queued_start_token:
+                        self._release_queued_start_waiter_locked(queued_start_token)
+                        queued_start_token = next_queued_start_token
+                        self._register_queued_start_waiter_locked(queued_start_token)
+                    self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
+                    continue
+
                 if self._is_process_running_locked():
                     self._release_queued_start_waiter_locked(queued_start_token)
                     self._mark_activity_locked(now=now)
@@ -224,15 +233,6 @@ class HLSLivePublisher(LivePublisher):
                     )
                     self._ensure_maintenance_thread_started_locked()
                     return self._status
-
-                if self._start_in_progress:
-                    next_queued_start_token = self._active_start_token
-                    if queued_start_token != next_queued_start_token:
-                        self._release_queued_start_waiter_locked(queued_start_token)
-                        queued_start_token = next_queued_start_token
-                        self._register_queued_start_waiter_locked(queued_start_token)
-                    self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
-                    continue
 
                 self._release_queued_start_waiter_locked(queued_start_token)
                 queued_start_token = 0

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -168,7 +168,9 @@ class HLSLivePublisher(LivePublisher):
         self._maintenance_stop = Event()
         self._maintenance_thread: Thread | None = None
         self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
-        self._last_stop_status = self._status
+        self._last_cancellation_result: LivePublisherStatus | LivePublisherStartRefusal = (
+            self._status
+        )
         self._start_in_progress = False
         self._active_start_token = 0
         self._cancelled_start_token = 0
@@ -194,14 +196,11 @@ class HLSLivePublisher(LivePublisher):
                 now = self._clock.now()
                 self._refresh_locked(now=now)
                 if queued_start_token and self._start_was_cancelled_locked(queued_start_token):
-                    return self._last_stop_status
+                    return self._last_cancellation_result
                 if self._stop_requested_since_locked(stop_request_token):
-                    return self._last_stop_status
+                    return self._last_cancellation_result
                 if self._recording_active:
-                    return LivePublisherStartRefusal(
-                        reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
-                        message="Preview is unavailable while recording is active for this camera",
-                    )
+                    return self._recording_priority_refusal()
 
                 if self._is_process_running_locked():
                     self._mark_activity_locked(now=now)
@@ -235,7 +234,7 @@ class HLSLivePublisher(LivePublisher):
             self._stop_request_token += 1
             self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
-            self._last_stop_status = self._status
+            self._last_cancellation_result = self._status
 
     def note_viewer_activity(self, viewer_id: str | None = None) -> None:
         with self._lock:
@@ -262,7 +261,9 @@ class HLSLivePublisher(LivePublisher):
                 self._refresh_locked(now=self._clock.now())
                 return
 
+            self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
+            self._last_cancellation_result = self._recording_priority_refusal()
 
     def shutdown(self) -> None:
         maintenance_thread: Thread | None = None
@@ -270,7 +271,7 @@ class HLSLivePublisher(LivePublisher):
             self._stop_request_token += 1
             self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
-            self._last_stop_status = self._status
+            self._last_cancellation_result = self._status
             self._maintenance_stop.set()
             maintenance_thread = self._maintenance_thread
             self._maintenance_thread = None
@@ -300,13 +301,10 @@ class HLSLivePublisher(LivePublisher):
             with self._lock:
                 if self._start_was_cancelled_locked(start_token):
                     self._stop_locked(clear_error=True)
-                    return self._status
+                    return self._last_cancellation_result
 
                 if self._recording_active:
-                    return LivePublisherStartRefusal(
-                        reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
-                        message="Preview is unavailable while recording is active for this camera",
-                    )
+                    return self._recording_priority_refusal()
 
                 if not self._prepare_live_dir_locked():
                     return self._set_error_locked(
@@ -372,14 +370,11 @@ class HLSLivePublisher(LivePublisher):
 
                 if self._start_was_cancelled_locked(start_token):
                     self._stop_locked(clear_error=True)
-                    return self._status
+                    return self._last_cancellation_result
 
                 if self._recording_active:
                     self._stop_locked(clear_error=True)
-                    return LivePublisherStartRefusal(
-                        reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
-                        message="Preview is unavailable while recording is active for this camera",
-                    )
+                    return self._recording_priority_refusal()
 
                 stderr_tail = self._read_stderr_tail_locked()
                 timeout_option_error = (
@@ -826,6 +821,12 @@ class HLSLivePublisher(LivePublisher):
             last_error=last_error,
         )
         return LivePublisherStartRefusal(reason=reason, message=message)
+
+    def _recording_priority_refusal(self) -> LivePublisherStartRefusal:
+        return LivePublisherStartRefusal(
+            reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+            message="Preview is unavailable while recording is active for this camera",
+        )
 
     def _ensure_maintenance_thread_started_locked(self) -> None:
         if not self._background_maintenance:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -171,10 +171,10 @@ class HLSLivePublisher(LivePublisher):
         self._last_cancellation_result: LivePublisherStatus | LivePublisherStartRefusal = (
             self._status
         )
-        self._last_completed_start_token = 0
-        self._last_completed_start_result: LivePublisherStatus | LivePublisherStartRefusal = (
-            self._status
-        )
+        self._completed_start_results: dict[
+            int, LivePublisherStatus | LivePublisherStartRefusal
+        ] = {}
+        self._queued_start_waiters: dict[int, int] = {}
         self._start_in_progress = False
         self._active_start_token = 0
         self._cancelled_start_token = 0
@@ -200,13 +200,22 @@ class HLSLivePublisher(LivePublisher):
                 now = self._clock.now()
                 self._refresh_locked(now=now)
                 if queued_start_token and self._start_was_cancelled_locked(queued_start_token):
+                    self._release_queued_start_waiter_locked(queued_start_token)
                     return self._last_cancellation_result
                 if self._stop_requested_since_locked(stop_request_token):
+                    self._release_queued_start_waiter_locked(queued_start_token)
                     return self._last_cancellation_result
                 if self._recording_active:
+                    self._release_queued_start_waiter_locked(queued_start_token)
                     return self._recording_priority_refusal()
 
+                completed_start_result = self._completed_start_results.get(queued_start_token)
+                if completed_start_result is not None:
+                    self._release_queued_start_waiter_locked(queued_start_token)
+                    return completed_start_result
+
                 if self._is_process_running_locked():
+                    self._release_queued_start_waiter_locked(queued_start_token)
                     self._mark_activity_locked(now=now)
                     self._status = self._build_running_status_locked(
                         now=now,
@@ -216,14 +225,16 @@ class HLSLivePublisher(LivePublisher):
                     self._ensure_maintenance_thread_started_locked()
                     return self._status
 
-                if queued_start_token and self._last_completed_start_token == queued_start_token:
-                    return self._last_completed_start_result
-
                 if self._start_in_progress:
-                    queued_start_token = self._active_start_token
+                    next_queued_start_token = self._active_start_token
+                    if queued_start_token != next_queued_start_token:
+                        self._release_queued_start_waiter_locked(queued_start_token)
+                        queued_start_token = next_queued_start_token
+                        self._register_queued_start_waiter_locked(queued_start_token)
                     self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
                     continue
 
+                self._release_queued_start_waiter_locked(queued_start_token)
                 queued_start_token = 0
                 self._start_in_progress = True
                 self._active_start_token += 1
@@ -237,9 +248,8 @@ class HLSLivePublisher(LivePublisher):
         finally:
             with self._lock:
                 self._start_in_progress = False
-                if start_result is not None:
-                    self._last_completed_start_token = start_token
-                    self._last_completed_start_result = start_result
+                if start_result is not None and self._queued_start_waiters.get(start_token, 0) > 0:
+                    self._completed_start_results[start_token] = start_result
 
     def request_stop(self) -> None:
         with self._lock:
@@ -751,6 +761,23 @@ class HLSLivePublisher(LivePublisher):
     def _cancel_pending_start_locked(self) -> None:
         if self._start_in_progress:
             self._cancelled_start_token = self._active_start_token
+
+    def _register_queued_start_waiter_locked(self, start_token: int) -> None:
+        if start_token <= 0:
+            return
+        self._queued_start_waiters[start_token] = self._queued_start_waiters.get(start_token, 0) + 1
+
+    def _release_queued_start_waiter_locked(self, start_token: int) -> None:
+        if start_token <= 0:
+            return
+        current_waiters = self._queued_start_waiters.get(start_token)
+        if current_waiters is None:
+            return
+        if current_waiters <= 1:
+            self._queued_start_waiters.pop(start_token, None)
+            self._completed_start_results.pop(start_token, None)
+            return
+        self._queued_start_waiters[start_token] = current_waiters - 1
 
     def _start_was_cancelled_locked(self, start_token: int) -> bool:
         return self._cancelled_start_token >= start_token

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -169,6 +169,8 @@ class HLSLivePublisher(LivePublisher):
         self._maintenance_thread: Thread | None = None
         self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
         self._start_in_progress = False
+        self._active_start_token = 0
+        self._cancelled_start_token = 0
         self._process: subprocess.Popen[bytes] | None = None
         self._stderr_handle: TextIO | None = None
         self._recording_active = False
@@ -182,6 +184,7 @@ class HLSLivePublisher(LivePublisher):
             return self._status
 
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+        start_token = 0
         while True:
             with self._lock:
                 now = self._clock.now()
@@ -207,16 +210,19 @@ class HLSLivePublisher(LivePublisher):
                     continue
 
                 self._start_in_progress = True
+                self._active_start_token += 1
+                start_token = self._active_start_token
                 break
 
         try:
-            return self._start(now=now)
+            return self._start(now=now, start_token=start_token)
         finally:
             with self._lock:
                 self._start_in_progress = False
 
     def request_stop(self) -> None:
         with self._lock:
+            self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
 
     def note_viewer_activity(self, viewer_id: str | None = None) -> None:
@@ -249,6 +255,7 @@ class HLSLivePublisher(LivePublisher):
     def shutdown(self) -> None:
         maintenance_thread: Thread | None = None
         with self._lock:
+            self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
             self._maintenance_stop.set()
             maintenance_thread = self._maintenance_thread
@@ -257,7 +264,12 @@ class HLSLivePublisher(LivePublisher):
         if maintenance_thread is not None and maintenance_thread is not current_thread():
             maintenance_thread.join(timeout=2.0)
 
-    def _start(self, *, now: float) -> LivePublisherStatus | LivePublisherStartRefusal:
+    def _start(
+        self,
+        *,
+        now: float,
+        start_token: int,
+    ) -> LivePublisherStatus | LivePublisherStartRefusal:
         codec_plan = self._build_codec_plan()
         timeout_args = self._timeout_capabilities.build_ffmpeg_timeout_args_for_user_flags(
             connect_timeout_s=self._rtsp_connect_timeout_s,
@@ -270,6 +282,10 @@ class HLSLivePublisher(LivePublisher):
 
         for label, timeout_attempt_args in attempts:
             with self._lock:
+                if self._start_was_cancelled_locked(start_token):
+                    self._stop_locked(clear_error=True)
+                    return self._status
+
                 if self._recording_active:
                     return LivePublisherStartRefusal(
                         reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
@@ -333,6 +349,10 @@ class HLSLivePublisher(LivePublisher):
                         state=LivePublisherState.READY,
                         degraded_reason=None,
                     )
+                    return self._status
+
+                if self._start_was_cancelled_locked(start_token):
+                    self._stop_locked(clear_error=True)
                     return self._status
 
                 if self._recording_active:
@@ -668,6 +688,13 @@ class HLSLivePublisher(LivePublisher):
             )
         finally:
             self._stderr_handle = None
+
+    def _cancel_pending_start_locked(self) -> None:
+        if self._start_in_progress:
+            self._cancelled_start_token = self._active_start_token
+
+    def _start_was_cancelled_locked(self, start_token: int) -> bool:
+        return self._cancelled_start_token >= start_token
 
     def _sleep_without_lock_locked(self, seconds: float) -> None:
         self._lock.release()

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -315,6 +315,13 @@ class HLSLivePublisher(LivePublisher):
                 )
                 return self._status
 
+            if self._recording_active:
+                self._stop_locked(clear_error=True)
+                return LivePublisherStartRefusal(
+                    reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                    message="Preview is unavailable while recording is active for this camera",
+                )
+
             stderr_tail = self._read_stderr_tail_locked()
             timeout_option_error = (
                 label == "timeouts" and bool(stderr_tail) and _is_timeout_option_error(stderr_tail)
@@ -358,7 +365,7 @@ class HLSLivePublisher(LivePublisher):
                 return False
             if self._output_ready_locked():
                 return self._is_process_running_locked()
-            self._clock.sleep(_READY_POLL_INTERVAL_S)
+            self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
         if not self._output_ready_locked():
             return False
         return self._is_process_running_locked()
@@ -639,6 +646,13 @@ class HLSLivePublisher(LivePublisher):
             )
         finally:
             self._stderr_handle = None
+
+    def _sleep_without_lock_locked(self, seconds: float) -> None:
+        self._lock.release()
+        try:
+            self._clock.sleep(seconds)
+        finally:
+            self._lock.acquire()
 
     def _mark_activity_locked(self, *, now: float) -> None:
         self._last_activity_at = now

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -292,9 +292,10 @@ class HLSLivePublisher(LivePublisher):
                     )
 
                 if not self._prepare_live_dir_locked():
-                    return LivePublisherStartRefusal(
+                    return self._set_error_locked(
                         reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
                         message="Preview storage directory is unavailable",
+                        last_error="Preview storage directory could not be prepared",
                     )
 
                 cmd = self._build_ffmpeg_cmd(
@@ -655,7 +656,8 @@ class HLSLivePublisher(LivePublisher):
 
     def _prepare_live_dir_locked(self) -> bool:
         try:
-            self._cleanup_live_dir_locked()
+            if not self._cleanup_live_dir_locked():
+                return False
             self._camera_dir.mkdir(parents=True, exist_ok=True)
             return True
         except Exception:
@@ -666,17 +668,19 @@ class HLSLivePublisher(LivePublisher):
             )
             return False
 
-    def _cleanup_live_dir_locked(self) -> None:
+    def _cleanup_live_dir_locked(self) -> bool:
         if not self._camera_dir.exists():
-            return
+            return True
         try:
             shutil.rmtree(self._camera_dir)
+            return True
         except Exception:
             logger.exception(
                 "Failed to clean preview directory: camera=%s dir=%s",
                 self._camera_name,
                 self._camera_dir,
             )
+            return False
 
     def _close_process_handles_locked(self) -> None:
         if self._stderr_handle is None:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -171,6 +171,7 @@ class HLSLivePublisher(LivePublisher):
         self._start_in_progress = False
         self._active_start_token = 0
         self._cancelled_start_token = 0
+        self._stop_request_token = 0
         self._process: subprocess.Popen[bytes] | None = None
         self._stderr_handle: TextIO | None = None
         self._recording_active = False
@@ -185,10 +186,13 @@ class HLSLivePublisher(LivePublisher):
 
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
         start_token = 0
+        stop_request_token = self._stop_request_token
         while True:
             with self._lock:
                 now = self._clock.now()
                 self._refresh_locked(now=now)
+                if self._stop_requested_since_locked(stop_request_token):
+                    return self._status
                 if self._recording_active:
                     return LivePublisherStartRefusal(
                         reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
@@ -222,6 +226,7 @@ class HLSLivePublisher(LivePublisher):
 
     def request_stop(self) -> None:
         with self._lock:
+            self._stop_request_token += 1
             self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
 
@@ -255,6 +260,7 @@ class HLSLivePublisher(LivePublisher):
     def shutdown(self) -> None:
         maintenance_thread: Thread | None = None
         with self._lock:
+            self._stop_request_token += 1
             self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
             self._maintenance_stop.set()
@@ -733,6 +739,9 @@ class HLSLivePublisher(LivePublisher):
 
     def _start_was_cancelled_locked(self, start_token: int) -> bool:
         return self._cancelled_start_token >= start_token
+
+    def _stop_requested_since_locked(self, stop_request_token: int) -> bool:
+        return self._stop_request_token != stop_request_token
 
     def _sleep_without_lock_locked(self, seconds: float) -> None:
         self._lock.release()

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -171,6 +171,10 @@ class HLSLivePublisher(LivePublisher):
         self._last_cancellation_result: LivePublisherStatus | LivePublisherStartRefusal = (
             self._status
         )
+        self._last_completed_start_token = 0
+        self._last_completed_start_result: LivePublisherStatus | LivePublisherStartRefusal = (
+            self._status
+        )
         self._start_in_progress = False
         self._active_start_token = 0
         self._cancelled_start_token = 0
@@ -212,6 +216,9 @@ class HLSLivePublisher(LivePublisher):
                     self._ensure_maintenance_thread_started_locked()
                     return self._status
 
+                if queued_start_token and self._last_completed_start_token == queued_start_token:
+                    return self._last_completed_start_result
+
                 if self._start_in_progress:
                     queued_start_token = self._active_start_token
                     self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
@@ -223,11 +230,16 @@ class HLSLivePublisher(LivePublisher):
                 start_token = self._active_start_token
                 break
 
+        start_result: LivePublisherStatus | LivePublisherStartRefusal | None = None
         try:
-            return self._start(start_token=start_token)
+            start_result = self._start(start_token=start_token)
+            return start_result
         finally:
             with self._lock:
                 self._start_in_progress = False
+                if start_result is not None:
+                    self._last_completed_start_token = start_token
+                    self._last_completed_start_result = start_result
 
     def request_stop(self) -> None:
         with self._lock:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -168,6 +168,7 @@ class HLSLivePublisher(LivePublisher):
         self._maintenance_stop = Event()
         self._maintenance_thread: Thread | None = None
         self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+        self._start_in_progress = False
         self._process: subprocess.Popen[bytes] | None = None
         self._stderr_handle: TextIO | None = None
         self._recording_active = False
@@ -181,26 +182,38 @@ class HLSLivePublisher(LivePublisher):
             return self._status
 
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
-        with self._lock:
-            now = self._clock.now()
-            self._refresh_locked(now=now)
-            if self._recording_active:
-                return LivePublisherStartRefusal(
-                    reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
-                    message="Preview is unavailable while recording is active for this camera",
-                )
+        while True:
+            with self._lock:
+                now = self._clock.now()
+                self._refresh_locked(now=now)
+                if self._recording_active:
+                    return LivePublisherStartRefusal(
+                        reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                        message="Preview is unavailable while recording is active for this camera",
+                    )
 
-            if self._is_process_running_locked():
-                self._mark_activity_locked(now=now)
-                self._status = self._build_running_status_locked(
-                    now=now,
-                    state=LivePublisherState.READY,
-                    degraded_reason=None,
-                )
-                self._ensure_maintenance_thread_started_locked()
-                return self._status
+                if self._is_process_running_locked():
+                    self._mark_activity_locked(now=now)
+                    self._status = self._build_running_status_locked(
+                        now=now,
+                        state=LivePublisherState.READY,
+                        degraded_reason=None,
+                    )
+                    self._ensure_maintenance_thread_started_locked()
+                    return self._status
 
-            return self._start_locked(now=now)
+                if self._start_in_progress:
+                    self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
+                    continue
+
+                self._start_in_progress = True
+                break
+
+        try:
+            return self._start(now=now)
+        finally:
+            with self._lock:
+                self._start_in_progress = False
 
     def request_stop(self) -> None:
         with self._lock:
@@ -244,8 +257,8 @@ class HLSLivePublisher(LivePublisher):
         if maintenance_thread is not None and maintenance_thread is not current_thread():
             maintenance_thread.join(timeout=2.0)
 
-    def _start_locked(self, *, now: float) -> LivePublisherStatus | LivePublisherStartRefusal:
-        codec_plan = self._build_codec_plan_locked()
+    def _start(self, *, now: float) -> LivePublisherStatus | LivePublisherStartRefusal:
+        codec_plan = self._build_codec_plan()
         timeout_args = self._timeout_capabilities.build_ffmpeg_timeout_args_for_user_flags(
             connect_timeout_s=self._rtsp_connect_timeout_s,
             io_timeout_s=self._rtsp_io_timeout_s,
@@ -256,77 +269,86 @@ class HLSLivePublisher(LivePublisher):
         last_refusal: LivePublisherStartRefusal | None = None
 
         for label, timeout_attempt_args in attempts:
-            if not self._prepare_live_dir_locked():
-                return LivePublisherStartRefusal(
-                    reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                    message="Preview storage directory is unavailable",
+            with self._lock:
+                if self._recording_active:
+                    return LivePublisherStartRefusal(
+                        reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                        message="Preview is unavailable while recording is active for this camera",
+                    )
+
+                if not self._prepare_live_dir_locked():
+                    return LivePublisherStartRefusal(
+                        reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                        message="Preview storage directory is unavailable",
+                    )
+
+                cmd = self._build_ffmpeg_cmd(
+                    codec_plan=codec_plan,
+                    timeout_args=timeout_attempt_args,
+                )
+                self._log_ffmpeg_cmd(label=label, cmd=cmd)
+
+                try:
+                    stderr_handle = open(self._stderr_log_path, "w", encoding="utf-8")
+                except Exception as exc:
+                    logger.warning("Failed to open preview stderr log: %s", exc, exc_info=True)
+                    return self._set_error_locked(
+                        reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                        message="Preview stderr log could not be created",
+                        last_error=f"Preview stderr log create failed: {type(exc).__name__}",
+                    )
+
+                try:
+                    process = subprocess.Popen(
+                        cmd,
+                        stdout=subprocess.DEVNULL,
+                        stderr=stderr_handle,
+                        start_new_session=True,
+                    )
+                except Exception as exc:
+                    stderr_handle.close()
+                    logger.warning("Failed to start preview ffmpeg: %s", exc, exc_info=True)
+                    return self._set_error_locked(
+                        reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                        message="Preview ffmpeg could not be started",
+                        last_error=f"Preview ffmpeg start failed: {type(exc).__name__}",
+                    )
+
+                self._process = process
+                self._stderr_handle = stderr_handle
+                self._mark_activity_locked(now=now)
+                self._status = LivePublisherStatus(
+                    state=LivePublisherState.STARTING,
+                    viewer_count=self._viewer_count_locked(now=now),
+                    idle_shutdown_at=now + self._idle_timeout_s,
                 )
 
-            cmd = self._build_ffmpeg_cmd(
-                codec_plan=codec_plan,
-                timeout_args=timeout_attempt_args,
-            )
-            self._log_ffmpeg_cmd(label=label, cmd=cmd)
+                if self._wait_until_ready_locked():
+                    if label == "timeouts":
+                        self._timeout_capabilities.note_ffmpeg_timeout_success()
+                    ready_now = self._clock.now()
+                    self._ensure_maintenance_thread_started_locked()
+                    self._status = self._build_running_status_locked(
+                        now=ready_now,
+                        state=LivePublisherState.READY,
+                        degraded_reason=None,
+                    )
+                    return self._status
 
-            try:
-                stderr_handle = open(self._stderr_log_path, "w", encoding="utf-8")
-            except Exception as exc:
-                logger.warning("Failed to open preview stderr log: %s", exc, exc_info=True)
-                return self._set_error_locked(
-                    reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                    message="Preview stderr log could not be created",
-                    last_error=f"Preview stderr log create failed: {type(exc).__name__}",
+                if self._recording_active:
+                    self._stop_locked(clear_error=True)
+                    return LivePublisherStartRefusal(
+                        reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                        message="Preview is unavailable while recording is active for this camera",
+                    )
+
+                stderr_tail = self._read_stderr_tail_locked()
+                timeout_option_error = (
+                    label == "timeouts"
+                    and bool(stderr_tail)
+                    and _is_timeout_option_error(stderr_tail)
                 )
-
-            try:
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=stderr_handle,
-                    start_new_session=True,
-                )
-            except Exception as exc:
-                stderr_handle.close()
-                logger.warning("Failed to start preview ffmpeg: %s", exc, exc_info=True)
-                return self._set_error_locked(
-                    reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                    message="Preview ffmpeg could not be started",
-                    last_error=f"Preview ffmpeg start failed: {type(exc).__name__}",
-                )
-
-            self._process = process
-            self._stderr_handle = stderr_handle
-            self._mark_activity_locked(now=now)
-            self._status = LivePublisherStatus(
-                state=LivePublisherState.STARTING,
-                viewer_count=self._viewer_count_locked(now=now),
-                idle_shutdown_at=now + self._idle_timeout_s,
-            )
-
-            if self._wait_until_ready_locked():
-                if label == "timeouts":
-                    self._timeout_capabilities.note_ffmpeg_timeout_success()
-                ready_now = self._clock.now()
-                self._ensure_maintenance_thread_started_locked()
-                self._status = self._build_running_status_locked(
-                    now=ready_now,
-                    state=LivePublisherState.READY,
-                    degraded_reason=None,
-                )
-                return self._status
-
-            if self._recording_active:
-                self._stop_locked(clear_error=True)
-                return LivePublisherStartRefusal(
-                    reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
-                    message="Preview is unavailable while recording is active for this camera",
-                )
-
-            stderr_tail = self._read_stderr_tail_locked()
-            timeout_option_error = (
-                label == "timeouts" and bool(stderr_tail) and _is_timeout_option_error(stderr_tail)
-            )
-            self._stop_locked(clear_error=False)
+                self._stop_locked(clear_error=False)
 
             if timeout_option_error:
                 changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
@@ -411,8 +433,8 @@ class HLSLivePublisher(LivePublisher):
             degraded_reason=None,
         )
 
-    def _build_codec_plan_locked(self) -> _CodecPlan:
-        stream_info = self._probe_stream_info_locked()
+    def _build_codec_plan(self) -> _CodecPlan:
+        stream_info = self._probe_stream_info()
         video_args: tuple[str, ...]
         audio_args: tuple[str, ...]
 
@@ -438,7 +460,7 @@ class HLSLivePublisher(LivePublisher):
 
         return _CodecPlan(video_args=video_args, audio_args=audio_args)
 
-    def _probe_stream_info_locked(self) -> ProbeStreamInfo | None:
+    def _probe_stream_info(self) -> ProbeStreamInfo | None:
         needs_probe = self._video_codec == "auto" or (
             self._audio_enabled and self._audio_codec == "auto"
         )

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -186,11 +186,14 @@ class HLSLivePublisher(LivePublisher):
 
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
         start_token = 0
+        queued_start_token = 0
         stop_request_token = self._stop_request_token
         while True:
             with self._lock:
                 now = self._clock.now()
                 self._refresh_locked(now=now)
+                if queued_start_token and self._start_was_cancelled_locked(queued_start_token):
+                    return self._status
                 if self._stop_requested_since_locked(stop_request_token):
                     return self._status
                 if self._recording_active:
@@ -210,9 +213,11 @@ class HLSLivePublisher(LivePublisher):
                     return self._status
 
                 if self._start_in_progress:
+                    queued_start_token = self._active_start_token
                     self._sleep_without_lock_locked(_READY_POLL_INTERVAL_S)
                     continue
 
+                queued_start_token = 0
                 self._start_in_progress = True
                 self._active_start_token += 1
                 start_token = self._active_start_token

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -215,7 +215,7 @@ class HLSLivePublisher(LivePublisher):
                 break
 
         try:
-            return self._start(now=now, start_token=start_token)
+            return self._start(start_token=start_token)
         finally:
             with self._lock:
                 self._start_in_progress = False
@@ -267,7 +267,6 @@ class HLSLivePublisher(LivePublisher):
     def _start(
         self,
         *,
-        now: float,
         start_token: int,
     ) -> LivePublisherStatus | LivePublisherStartRefusal:
         codec_plan = self._build_codec_plan()
@@ -332,17 +331,19 @@ class HLSLivePublisher(LivePublisher):
 
                 self._process = process
                 self._stderr_handle = stderr_handle
-                self._mark_activity_locked(now=now)
+                started_now = self._clock.now()
+                self._mark_activity_locked(now=started_now)
                 self._status = LivePublisherStatus(
                     state=LivePublisherState.STARTING,
-                    viewer_count=self._viewer_count_locked(now=now),
-                    idle_shutdown_at=now + self._idle_timeout_s,
+                    viewer_count=self._viewer_count_locked(now=started_now),
+                    idle_shutdown_at=started_now + self._idle_timeout_s,
                 )
 
                 if self._wait_until_ready_locked():
                     if label == "timeouts":
                         self._timeout_capabilities.note_ffmpeg_timeout_success()
                     ready_now = self._clock.now()
+                    self._mark_activity_locked(now=ready_now)
                     self._ensure_maintenance_thread_started_locked()
                     self._status = self._build_running_status_locked(
                         now=ready_now,

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -211,8 +211,18 @@ class HLSLivePublisher(LivePublisher):
 
                 completed_start_result = self._completed_start_results.get(queued_start_token)
                 if completed_start_result is not None:
-                    self._release_queued_start_waiter_locked(queued_start_token)
-                    return completed_start_result
+                    # A queued caller may observe a completed READY result even if the
+                    # underlying ffmpeg process has already exited. In that case, drop the
+                    # cached READY result and proceed with normal startup logic.
+                    if (
+                        isinstance(completed_start_result, LivePublisherStatus)
+                        and completed_start_result.state is LivePublisherState.READY
+                        and not self._is_process_running_locked()
+                    ):
+                        self._completed_start_results.pop(queued_start_token, None)
+                    else:
+                        self._release_queued_start_waiter_locked(queued_start_token)
+                        return completed_start_result
 
                 if self._start_in_progress:
                     next_queued_start_token = self._active_start_token

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -168,6 +168,7 @@ class HLSLivePublisher(LivePublisher):
         self._maintenance_stop = Event()
         self._maintenance_thread: Thread | None = None
         self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+        self._last_stop_status = self._status
         self._start_in_progress = False
         self._active_start_token = 0
         self._cancelled_start_token = 0
@@ -193,9 +194,9 @@ class HLSLivePublisher(LivePublisher):
                 now = self._clock.now()
                 self._refresh_locked(now=now)
                 if queued_start_token and self._start_was_cancelled_locked(queued_start_token):
-                    return self._status
+                    return self._last_stop_status
                 if self._stop_requested_since_locked(stop_request_token):
-                    return self._status
+                    return self._last_stop_status
                 if self._recording_active:
                     return LivePublisherStartRefusal(
                         reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
@@ -234,6 +235,7 @@ class HLSLivePublisher(LivePublisher):
             self._stop_request_token += 1
             self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
+            self._last_stop_status = self._status
 
     def note_viewer_activity(self, viewer_id: str | None = None) -> None:
         with self._lock:
@@ -268,6 +270,7 @@ class HLSLivePublisher(LivePublisher):
             self._stop_request_token += 1
             self._cancel_pending_start_locked()
             self._stop_locked(clear_error=True)
+            self._last_stop_status = self._status
             self._maintenance_stop.set()
             maintenance_thread = self._maintenance_thread
             self._maintenance_thread = None

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -1,8 +1,50 @@
 from __future__ import annotations
 
+import logging
+import shutil
+import signal
+import subprocess
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Protocol
+from pathlib import Path
+from threading import Event, RLock, Thread, current_thread
+from typing import Literal, Protocol, TextIO
+
+from homesec.sources.rtsp.capabilities import (
+    RTSPTimeoutCapabilities,
+    get_global_rtsp_timeout_capabilities,
+)
+from homesec.sources.rtsp.clock import Clock, SystemClock
+from homesec.sources.rtsp.discovery import (
+    CameraProbeResult,
+    FfprobeStreamDiscovery,
+    ProbeError,
+    ProbeStreamInfo,
+    build_camera_key,
+)
+from homesec.sources.rtsp.recording_profile import is_mp4_audio_copy_compatible
+from homesec.sources.rtsp.utils import (
+    _build_timeout_attempts,
+    _format_cmd,
+    _is_timeout_option_error,
+    _redact_rtsp_url,
+    _signal_process_group,
+)
+
+logger = logging.getLogger(__name__)
+
+_READY_POLL_INTERVAL_S = 0.1
+_DEFAULT_VIEWER_WINDOW_S = 2.0
+_START_FAILURE_MAX_BYTES = 4_000
+_SESSION_LIMIT_HINTS: tuple[str, ...] = (
+    "too many",
+    "max number of clients",
+    "maximum number of clients",
+    "maximum number of connections",
+    "session limit",
+    "max sessions",
+    "maximum sessions",
+)
 
 
 class LivePublisherState(StrEnum):
@@ -49,6 +91,640 @@ class LivePublisher(Protocol):
     def shutdown(self) -> None: ...
 
 
+class StreamDiscovery(Protocol):
+    def probe(
+        self,
+        *,
+        camera_key: str,
+        candidate_urls: list[str],
+    ) -> CameraProbeResult | ProbeError: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _CodecPlan:
+    video_args: tuple[str, ...]
+    audio_args: tuple[str, ...]
+
+
+class HLSLivePublisher(LivePublisher):
+    """Runtime-owned RTSP preview publisher that writes a live HLS window."""
+
+    def __init__(
+        self,
+        *,
+        camera_name: str,
+        rtsp_url: str,
+        storage_dir: Path,
+        segment_duration_ms: int,
+        live_window_segments: int,
+        idle_timeout_s: float,
+        audio_enabled: bool,
+        audio_codec: Literal["auto", "copy", "aac"] = "auto",
+        video_codec: Literal["auto", "copy", "h264"] = "auto",
+        rtsp_connect_timeout_s: float,
+        rtsp_io_timeout_s: float,
+        clock: Clock | None = None,
+        timeout_capabilities: RTSPTimeoutCapabilities | None = None,
+        stream_discovery: StreamDiscovery | None = None,
+        background_maintenance: bool = True,
+        maintenance_interval_s: float | None = None,
+    ) -> None:
+        self._camera_name = camera_name
+        self._camera_slug = _sanitize_camera_name(camera_name)
+        self._camera_key = build_camera_key(camera_name, rtsp_url)
+        self._rtsp_url = rtsp_url
+        self._storage_dir = Path(storage_dir)
+        self._camera_dir = self._storage_dir / "homesec" / self._camera_slug
+        self._playlist_path = self._camera_dir / "playlist.m3u8"
+        self._stderr_log_path = self._camera_dir / "preview_ffmpeg.log"
+        self._segment_filename_pattern = self._camera_dir / "segment_%06d.ts"
+        self._segment_duration_s = max(0.001, float(segment_duration_ms) / 1000.0)
+        self._live_window_segments = int(live_window_segments)
+        self._idle_timeout_s = max(0.0, float(idle_timeout_s))
+        self._audio_enabled = bool(audio_enabled)
+        self._audio_codec = audio_codec
+        self._video_codec = video_codec
+        self._rtsp_connect_timeout_s = float(rtsp_connect_timeout_s)
+        self._rtsp_io_timeout_s = float(rtsp_io_timeout_s)
+        self._clock = clock or SystemClock()
+        self._timeout_capabilities = timeout_capabilities or get_global_rtsp_timeout_capabilities()
+        self._stream_discovery = stream_discovery or FfprobeStreamDiscovery(
+            rtsp_connect_timeout_s=self._rtsp_connect_timeout_s,
+            rtsp_io_timeout_s=self._rtsp_io_timeout_s,
+            timeout_capabilities=self._timeout_capabilities,
+        )
+        self._background_maintenance = background_maintenance
+        self._maintenance_interval_s = (
+            float(maintenance_interval_s)
+            if maintenance_interval_s is not None
+            else min(max(self._segment_duration_s, 0.25), 1.0)
+        )
+        self._viewer_window_s = max(_DEFAULT_VIEWER_WINDOW_S, self._segment_duration_s * 2.0)
+        self._startup_timeout_s = max(3.0, min(10.0, (self._segment_duration_s * 4.0) + 2.0))
+
+        self._lock = RLock()
+        self._maintenance_stop = Event()
+        self._maintenance_thread: Thread | None = None
+        self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+        self._process: subprocess.Popen[bytes] | None = None
+        self._stderr_handle: TextIO | None = None
+        self._recording_active = False
+        self._viewer_activity: dict[str, float] = {}
+        self._anonymous_viewer_last_seen: float | None = None
+        self._last_activity_at: float | None = None
+
+    def status(self) -> LivePublisherStatus:
+        with self._lock:
+            self._refresh_locked(now=self._clock.now())
+            return self._status
+
+    def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
+        with self._lock:
+            now = self._clock.now()
+            self._refresh_locked(now=now)
+            if self._recording_active:
+                return LivePublisherStartRefusal(
+                    reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                    message="Preview is unavailable while recording is active for this camera",
+                )
+
+            if self._is_process_running_locked():
+                self._mark_activity_locked(now=now)
+                self._status = self._build_running_status_locked(
+                    now=now,
+                    state=LivePublisherState.READY,
+                    degraded_reason=None,
+                )
+                self._ensure_maintenance_thread_started_locked()
+                return self._status
+
+            return self._start_locked(now=now)
+
+    def request_stop(self) -> None:
+        with self._lock:
+            self._stop_locked(clear_error=True)
+
+    def note_viewer_activity(self, viewer_id: str | None = None) -> None:
+        with self._lock:
+            now = self._clock.now()
+            self._refresh_locked(now=now)
+            if not self._is_process_running_locked():
+                return
+
+            self._mark_activity_locked(now=now)
+            if viewer_id is None:
+                self._anonymous_viewer_last_seen = now
+            else:
+                self._viewer_activity[viewer_id] = now
+            self._status = self._build_running_status_locked(
+                now=now,
+                state=LivePublisherState.READY,
+                degraded_reason=None,
+            )
+
+    def sync_recording_active(self, recording_active: bool) -> None:
+        with self._lock:
+            self._recording_active = recording_active
+            if not recording_active:
+                self._refresh_locked(now=self._clock.now())
+                return
+
+            self._stop_locked(clear_error=True)
+
+    def shutdown(self) -> None:
+        maintenance_thread: Thread | None = None
+        with self._lock:
+            self._stop_locked(clear_error=True)
+            self._maintenance_stop.set()
+            maintenance_thread = self._maintenance_thread
+            self._maintenance_thread = None
+
+        if maintenance_thread is not None and maintenance_thread is not current_thread():
+            maintenance_thread.join(timeout=2.0)
+
+    def _start_locked(self, *, now: float) -> LivePublisherStatus | LivePublisherStartRefusal:
+        codec_plan = self._build_codec_plan_locked()
+        timeout_args = self._timeout_capabilities.build_ffmpeg_timeout_args_for_user_flags(
+            connect_timeout_s=self._rtsp_connect_timeout_s,
+            io_timeout_s=self._rtsp_io_timeout_s,
+            user_flags=[],
+        )
+
+        attempts = _build_timeout_attempts(timeout_args)
+        last_refusal: LivePublisherStartRefusal | None = None
+
+        for label, timeout_attempt_args in attempts:
+            if not self._prepare_live_dir_locked():
+                return LivePublisherStartRefusal(
+                    reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                    message="Preview storage directory is unavailable",
+                )
+
+            cmd = self._build_ffmpeg_cmd(
+                codec_plan=codec_plan,
+                timeout_args=timeout_attempt_args,
+            )
+            self._log_ffmpeg_cmd(label=label, cmd=cmd)
+
+            try:
+                stderr_handle = open(self._stderr_log_path, "w", encoding="utf-8")
+            except Exception as exc:
+                logger.warning("Failed to open preview stderr log: %s", exc, exc_info=True)
+                return self._set_error_locked(
+                    reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                    message="Preview stderr log could not be created",
+                    last_error=f"Preview stderr log create failed: {type(exc).__name__}",
+                )
+
+            try:
+                process = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=stderr_handle,
+                    start_new_session=True,
+                )
+            except Exception as exc:
+                stderr_handle.close()
+                logger.warning("Failed to start preview ffmpeg: %s", exc, exc_info=True)
+                return self._set_error_locked(
+                    reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                    message="Preview ffmpeg could not be started",
+                    last_error=f"Preview ffmpeg start failed: {type(exc).__name__}",
+                )
+
+            self._process = process
+            self._stderr_handle = stderr_handle
+            self._mark_activity_locked(now=now)
+            self._status = LivePublisherStatus(
+                state=LivePublisherState.STARTING,
+                viewer_count=self._viewer_count_locked(now=now),
+                idle_shutdown_at=now + self._idle_timeout_s,
+            )
+            self._ensure_maintenance_thread_started_locked()
+
+            if self._wait_until_ready_locked():
+                if label == "timeouts":
+                    self._timeout_capabilities.note_ffmpeg_timeout_success()
+                ready_now = self._clock.now()
+                self._status = self._build_running_status_locked(
+                    now=ready_now,
+                    state=LivePublisherState.READY,
+                    degraded_reason=None,
+                )
+                return self._status
+
+            stderr_tail = self._read_stderr_tail_locked()
+            timeout_option_error = (
+                label == "timeouts" and bool(stderr_tail) and _is_timeout_option_error(stderr_tail)
+            )
+            self._stop_locked(clear_error=False)
+
+            if timeout_option_error:
+                changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
+                if changed:
+                    logger.warning(
+                        "Preview ffmpeg timeout options unsupported; retrying without timeout options"
+                    )
+                continue
+
+            refusal_reason = _classify_start_refusal(stderr_tail)
+            message = (
+                "Preview could not start because the camera session budget is exhausted"
+                if refusal_reason is LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+                else "Preview publisher failed to become ready"
+            )
+            last_refusal = self._set_error_locked(
+                reason=refusal_reason,
+                message=message,
+                last_error=stderr_tail or "Preview publisher exited before producing HLS output",
+            )
+            break
+
+        if last_refusal is not None:
+            return last_refusal
+
+        return self._set_error_locked(
+            reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+            message="Preview publisher failed to start",
+            last_error="Preview publisher failed after retrying timeout options",
+        )
+
+    def _wait_until_ready_locked(self) -> bool:
+        deadline = self._clock.now() + self._startup_timeout_s
+        while self._clock.now() < deadline:
+            if not self._is_process_running_locked():
+                return False
+            if self._output_ready_locked():
+                return True
+            self._clock.sleep(_READY_POLL_INTERVAL_S)
+        return self._output_ready_locked()
+
+    def _refresh_locked(self, *, now: float) -> None:
+        self._expire_viewers_locked(now=now)
+
+        if self._process is not None and not self._is_process_running_locked():
+            exit_code = self._process.poll()
+            stderr_tail = self._read_stderr_tail_locked()
+            self._process = None
+            self._close_process_handles_locked()
+            self._cleanup_live_dir_locked()
+            self._viewer_activity.clear()
+            self._anonymous_viewer_last_seen = None
+            self._last_activity_at = None
+            self._status = LivePublisherStatus(
+                state=LivePublisherState.ERROR,
+                viewer_count=0,
+                last_error=stderr_tail or f"Preview ffmpeg exited unexpectedly ({exit_code})",
+            )
+            return
+
+        if not self._is_process_running_locked():
+            if self._status.state not in (LivePublisherState.ERROR,):
+                self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+            return
+
+        viewer_count = self._viewer_count_locked(now=now)
+        if viewer_count == 0 and self._last_activity_at is not None:
+            idle_shutdown_at = self._last_activity_at + self._idle_timeout_s
+            if now >= idle_shutdown_at:
+                logger.info(
+                    "Stopping preview publisher after idle timeout: camera=%s",
+                    self._camera_name,
+                )
+                self._stop_locked(clear_error=True)
+                return
+
+        self._status = self._build_running_status_locked(
+            now=now,
+            state=LivePublisherState.READY,
+            degraded_reason=None,
+        )
+
+    def _build_codec_plan_locked(self) -> _CodecPlan:
+        stream_info = self._probe_stream_info_locked()
+        video_args: tuple[str, ...]
+        audio_args: tuple[str, ...]
+
+        if self._video_codec == "copy":
+            video_args = ("-c:v", "copy")
+        elif self._video_codec == "h264":
+            video_args = _h264_transcode_args(self._segment_duration_s)
+        elif stream_info is not None and (stream_info.video_codec or "").lower() == "h264":
+            video_args = ("-c:v", "copy")
+        else:
+            video_args = _h264_transcode_args(self._segment_duration_s)
+
+        if not self._audio_enabled:
+            audio_args = ("-an",)
+        elif self._audio_codec == "copy":
+            audio_args = ("-map", "0:a:0?", "-c:a", "copy")
+        elif self._audio_codec == "aac":
+            audio_args = ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
+        elif stream_info is not None and is_mp4_audio_copy_compatible(stream_info.audio_codec):
+            audio_args = ("-map", "0:a:0?", "-c:a", "copy")
+        else:
+            audio_args = ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
+
+        return _CodecPlan(video_args=video_args, audio_args=audio_args)
+
+    def _probe_stream_info_locked(self) -> ProbeStreamInfo | None:
+        needs_probe = self._video_codec == "auto" or (
+            self._audio_enabled and self._audio_codec == "auto"
+        )
+        if not needs_probe:
+            return None
+
+        result = self._stream_discovery.probe(
+            camera_key=self._camera_key,
+            candidate_urls=[self._rtsp_url],
+        )
+        match result:
+            case ProbeError() as err:
+                logger.warning(
+                    "Preview stream probe failed for %s: %s",
+                    self._camera_name,
+                    err.message,
+                )
+                return None
+            case CameraProbeResult() as probe_result:
+                for stream in probe_result.streams:
+                    if stream.probe_ok:
+                        return stream
+                return None
+            case _:
+                logger.warning(
+                    "Preview stream probe returned unexpected type for %s: %s",
+                    self._camera_name,
+                    type(result).__name__,
+                )
+                return None
+
+    def _build_ffmpeg_cmd(
+        self,
+        *,
+        codec_plan: _CodecPlan,
+        timeout_args: list[str],
+    ) -> list[str]:
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-nostdin",
+            "-loglevel",
+            "warning",
+            "-rtsp_transport",
+            "tcp",
+            "-rtsp_flags",
+            "prefer_tcp",
+            "-user_agent",
+            "Lavf",
+        ]
+        cmd.extend(timeout_args)
+        cmd.extend(["-fflags", "+genpts+igndts", "-i", self._rtsp_url, "-map", "0:v:0"])
+        cmd.extend(codec_plan.video_args)
+        cmd.extend(codec_plan.audio_args)
+        cmd.extend(
+            [
+                "-muxdelay",
+                "0",
+                "-muxpreload",
+                "0",
+                "-f",
+                "hls",
+                "-hls_time",
+                _format_segment_duration(self._segment_duration_s),
+                "-hls_list_size",
+                str(self._live_window_segments),
+                "-hls_delete_threshold",
+                "1",
+                "-hls_allow_cache",
+                "0",
+                "-hls_flags",
+                "delete_segments+append_list+omit_endlist+program_date_time+temp_file",
+                "-hls_segment_filename",
+                str(self._segment_filename_pattern),
+                "-start_number",
+                "0",
+                "-y",
+                str(self._playlist_path),
+            ]
+        )
+        return cmd
+
+    def _build_running_status_locked(
+        self,
+        *,
+        now: float,
+        state: LivePublisherState,
+        degraded_reason: str | None,
+    ) -> LivePublisherStatus:
+        viewer_count = self._viewer_count_locked(now=now)
+        idle_shutdown_at: float | None = None
+        if viewer_count == 0 and self._last_activity_at is not None:
+            idle_shutdown_at = self._last_activity_at + self._idle_timeout_s
+        return LivePublisherStatus(
+            state=state,
+            viewer_count=viewer_count,
+            degraded_reason=degraded_reason,
+            last_error=None,
+            idle_shutdown_at=idle_shutdown_at,
+        )
+
+    def _output_ready_locked(self) -> bool:
+        if not self._playlist_path.exists():
+            return False
+        try:
+            playlist_text = self._playlist_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            logger.warning("Failed to read preview playlist: %s", exc, exc_info=True)
+            return False
+
+        if not playlist_text.strip():
+            return False
+
+        for line in playlist_text.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                return True
+
+        return any(self._camera_dir.glob("segment_*.ts"))
+
+    def _stop_locked(self, *, clear_error: bool) -> None:
+        if self._process is None and self._stderr_handle is None:
+            if clear_error:
+                self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+            return
+
+        self._status = LivePublisherStatus(state=LivePublisherState.STOPPING, viewer_count=0)
+        process = self._process
+        self._process = None
+        if process is not None:
+            self._terminate_process(process)
+        self._close_process_handles_locked()
+        self._cleanup_live_dir_locked()
+        self._viewer_activity.clear()
+        self._anonymous_viewer_last_seen = None
+        self._last_activity_at = None
+
+        if clear_error:
+            self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+    def _terminate_process(self, process: subprocess.Popen[bytes]) -> None:
+        try:
+            if process.poll() is None:
+                if not _signal_process_group(process.pid, signal.SIGTERM):
+                    process.terminate()
+                process.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Preview process did not terminate, killing: camera=%s pid=%s",
+                self._camera_name,
+                process.pid,
+            )
+            try:
+                if not _signal_process_group(process.pid, signal.SIGKILL):
+                    process.kill()
+                process.wait(timeout=2.0)
+            except Exception:
+                logger.exception(
+                    "Failed to kill preview process: camera=%s pid=%s",
+                    self._camera_name,
+                    process.pid,
+                )
+        except Exception:
+            logger.exception(
+                "Failed while stopping preview process: camera=%s pid=%s",
+                self._camera_name,
+                process.pid,
+            )
+
+    def _prepare_live_dir_locked(self) -> bool:
+        try:
+            self._cleanup_live_dir_locked()
+            self._camera_dir.mkdir(parents=True, exist_ok=True)
+            return True
+        except Exception:
+            logger.exception(
+                "Failed to prepare preview directory: camera=%s dir=%s",
+                self._camera_name,
+                self._camera_dir,
+            )
+            return False
+
+    def _cleanup_live_dir_locked(self) -> None:
+        if not self._camera_dir.exists():
+            return
+        try:
+            shutil.rmtree(self._camera_dir)
+        except Exception:
+            logger.exception(
+                "Failed to clean preview directory: camera=%s dir=%s",
+                self._camera_name,
+                self._camera_dir,
+            )
+
+    def _close_process_handles_locked(self) -> None:
+        if self._stderr_handle is None:
+            return
+        try:
+            self._stderr_handle.close()
+        except Exception:
+            logger.exception(
+                "Failed to close preview stderr log: camera=%s path=%s",
+                self._camera_name,
+                self._stderr_log_path,
+            )
+        finally:
+            self._stderr_handle = None
+
+    def _mark_activity_locked(self, *, now: float) -> None:
+        self._last_activity_at = now
+
+    def _expire_viewers_locked(self, *, now: float) -> None:
+        expired_viewers = [
+            viewer_id
+            for viewer_id, last_seen in self._viewer_activity.items()
+            if (now - last_seen) > self._viewer_window_s
+        ]
+        for viewer_id in expired_viewers:
+            self._viewer_activity.pop(viewer_id, None)
+
+        if (
+            self._anonymous_viewer_last_seen is not None
+            and (now - self._anonymous_viewer_last_seen) > self._viewer_window_s
+        ):
+            self._anonymous_viewer_last_seen = None
+
+    def _viewer_count_locked(self, *, now: float) -> int:
+        self._expire_viewers_locked(now=now)
+        count = len(self._viewer_activity)
+        if self._anonymous_viewer_last_seen is not None:
+            count += 1
+        return count
+
+    def _is_process_running_locked(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def _read_stderr_tail_locked(self) -> str:
+        if not self._stderr_log_path.exists():
+            return ""
+        try:
+            data = self._stderr_log_path.read_bytes()
+        except Exception as exc:
+            logger.warning("Failed to read preview stderr tail: %s", exc, exc_info=True)
+            return ""
+
+        if len(data) > _START_FAILURE_MAX_BYTES:
+            data = data[-_START_FAILURE_MAX_BYTES:]
+        text = data.decode(errors="replace")
+        return text.replace(self._rtsp_url, _redact_rtsp_url(self._rtsp_url)).strip()
+
+    def _log_ffmpeg_cmd(self, *, label: str, cmd: list[str]) -> None:
+        safe_cmd = list(cmd)
+        try:
+            input_idx = safe_cmd.index("-i")
+            safe_cmd[input_idx + 1] = _redact_rtsp_url(str(safe_cmd[input_idx + 1]))
+        except Exception as exc:
+            logger.warning("Failed to redact preview RTSP URL: %s", exc, exc_info=True)
+        logger.debug(
+            "Preview ffmpeg (%s): %s",
+            label,
+            _format_cmd(safe_cmd),
+        )
+
+    def _set_error_locked(
+        self,
+        *,
+        reason: LivePublisherRefusalReason,
+        message: str,
+        last_error: str,
+    ) -> LivePublisherStartRefusal:
+        self._status = LivePublisherStatus(
+            state=LivePublisherState.ERROR,
+            viewer_count=0,
+            last_error=last_error,
+        )
+        return LivePublisherStartRefusal(reason=reason, message=message)
+
+    def _ensure_maintenance_thread_started_locked(self) -> None:
+        if not self._background_maintenance:
+            return
+        thread = self._maintenance_thread
+        if thread is not None and thread.is_alive():
+            return
+        self._maintenance_stop.clear()
+        self._maintenance_thread = Thread(
+            target=self._maintenance_loop,
+            name=f"preview-{self._camera_slug}",
+            daemon=True,
+        )
+        self._maintenance_thread.start()
+
+    def _maintenance_loop(self) -> None:
+        while not self._maintenance_stop.wait(self._maintenance_interval_s):
+            with self._lock:
+                self._refresh_locked(now=self._clock.now())
+
+
 class NoopLivePublisher(LivePublisher):
     """Default preview seam used until a real publisher backend is wired in."""
 
@@ -75,3 +751,50 @@ class NoopLivePublisher(LivePublisher):
 
     def shutdown(self) -> None:
         self._status = LivePublisherStatus(state=LivePublisherState.IDLE)
+
+
+def _format_segment_duration(segment_duration_s: float) -> str:
+    return f"{segment_duration_s:.3f}".rstrip("0").rstrip(".")
+
+
+def _sanitize_camera_name(name: str) -> str:
+    raw = str(name).strip()
+    if not raw:
+        return "camera"
+    out: list[str] = []
+    for ch in raw:
+        if ch.isalnum() or ch in ("-", "_"):
+            out.append(ch)
+        elif ch.isspace():
+            out.append("_")
+        else:
+            out.append("_")
+    cleaned = "".join(out).strip("_")
+    while "__" in cleaned:
+        cleaned = cleaned.replace("__", "_")
+    return cleaned or "camera"
+
+
+def _classify_start_refusal(stderr_tail: str) -> LivePublisherRefusalReason:
+    lowered = stderr_tail.lower()
+    for hint in _SESSION_LIMIT_HINTS:
+        if hint in lowered:
+            return LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    return LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+
+
+def _h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:
+    return (
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-tune",
+        "zerolatency",
+        "-pix_fmt",
+        "yuv420p",
+        "-sc_threshold",
+        "0",
+        "-force_key_frames",
+        f"expr:gte(t,n_forced*{_format_segment_duration(segment_duration_s)})",
+    )

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -282,6 +282,7 @@ class HLSLivePublisher(LivePublisher):
         for label, timeout_attempt_args in attempts:
             attempt_refusal: LivePublisherStartRefusal | None = None
             timeout_option_error = False
+            stop_error: str | None = None
             with self._lock:
                 if self._start_was_cancelled_locked(start_token):
                     self._stop_locked(clear_error=True)
@@ -372,9 +373,12 @@ class HLSLivePublisher(LivePublisher):
                     and label == "timeouts"
                     and (_is_timeout_option_error(stderr_tail))
                 )
-                self._stop_locked(clear_error=False)
+                stop_error = self._stop_locked(clear_error=False)
 
-                if not timeout_option_error:
+                if stop_error is not None:
+                    stderr_tail = f"{stderr_tail}; {stop_error}" if stderr_tail else stop_error
+
+                if not timeout_option_error or stop_error is not None:
                     refusal_reason = _classify_start_refusal(stderr_tail)
                     message = (
                         "Preview could not start because the camera session budget is exhausted"
@@ -388,7 +392,7 @@ class HLSLivePublisher(LivePublisher):
                         or "Preview publisher exited before producing HLS output",
                     )
 
-            if timeout_option_error:
+            if timeout_option_error and stop_error is None:
                 changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
                 if changed:
                     logger.warning(
@@ -613,27 +617,43 @@ class HLSLivePublisher(LivePublisher):
 
         return any(self._camera_dir.glob("segment_*.ts"))
 
-    def _stop_locked(self, *, clear_error: bool) -> None:
-        if self._process is None and self._stderr_handle is None:
+    def _stop_locked(self, *, clear_error: bool) -> str | None:
+        has_live_window = self._camera_dir.exists()
+        if self._process is None and self._stderr_handle is None and not has_live_window:
             if clear_error:
                 self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
-            return
+            return None
 
         self._status = LivePublisherStatus(state=LivePublisherState.STOPPING, viewer_count=0)
+        teardown_errors: list[str] = []
         process = self._process
         self._process = None
         if process is not None:
-            self._terminate_process(process)
+            stop_error = self._terminate_process(process)
+            if stop_error is not None:
+                teardown_errors.append(stop_error)
         self._close_process_handles_locked()
-        self._cleanup_live_dir_locked()
+        if not self._cleanup_live_dir_locked():
+            teardown_errors.append("Preview live output could not be removed")
         self._viewer_activity.clear()
         self._anonymous_viewer_last_seen = None
         self._last_activity_at = None
 
         if clear_error:
-            self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+            if teardown_errors:
+                self._status = LivePublisherStatus(
+                    state=LivePublisherState.ERROR,
+                    viewer_count=0,
+                    last_error="; ".join(teardown_errors),
+                )
+            else:
+                self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
-    def _terminate_process(self, process: subprocess.Popen[bytes]) -> None:
+        if teardown_errors:
+            return "; ".join(teardown_errors)
+        return None
+
+    def _terminate_process(self, process: subprocess.Popen[bytes]) -> str | None:
         try:
             if process.poll() is None:
                 if not _signal_process_group(process.pid, signal.SIGTERM):
@@ -661,6 +681,9 @@ class HLSLivePublisher(LivePublisher):
                 self._camera_name,
                 process.pid,
             )
+        if process.poll() is None:
+            return "Preview ffmpeg could not be stopped cleanly"
+        return None
 
     def _prepare_live_dir_locked(self) -> bool:
         try:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -280,6 +280,8 @@ class HLSLivePublisher(LivePublisher):
         last_refusal: LivePublisherStartRefusal | None = None
 
         for label, timeout_attempt_args in attempts:
+            attempt_refusal: LivePublisherStartRefusal | None = None
+            timeout_option_error = False
             with self._lock:
                 if self._start_was_cancelled_locked(start_token):
                     self._stop_locked(clear_error=True)
@@ -366,11 +368,25 @@ class HLSLivePublisher(LivePublisher):
 
                 stderr_tail = self._read_stderr_tail_locked()
                 timeout_option_error = (
-                    label == "timeouts"
-                    and bool(stderr_tail)
-                    and _is_timeout_option_error(stderr_tail)
+                    bool(stderr_tail)
+                    and label == "timeouts"
+                    and (_is_timeout_option_error(stderr_tail))
                 )
                 self._stop_locked(clear_error=False)
+
+                if not timeout_option_error:
+                    refusal_reason = _classify_start_refusal(stderr_tail)
+                    message = (
+                        "Preview could not start because the camera session budget is exhausted"
+                        if refusal_reason is LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+                        else "Preview publisher failed to become ready"
+                    )
+                    attempt_refusal = self._set_error_locked(
+                        reason=refusal_reason,
+                        message=message,
+                        last_error=stderr_tail
+                        or "Preview publisher exited before producing HLS output",
+                    )
 
             if timeout_option_error:
                 changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
@@ -380,27 +396,19 @@ class HLSLivePublisher(LivePublisher):
                     )
                 continue
 
-            refusal_reason = _classify_start_refusal(stderr_tail)
-            message = (
-                "Preview could not start because the camera session budget is exhausted"
-                if refusal_reason is LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
-                else "Preview publisher failed to become ready"
-            )
-            last_refusal = self._set_error_locked(
-                reason=refusal_reason,
-                message=message,
-                last_error=stderr_tail or "Preview publisher exited before producing HLS output",
-            )
-            break
+            if attempt_refusal is not None:
+                last_refusal = attempt_refusal
+                break
 
         if last_refusal is not None:
             return last_refusal
 
-        return self._set_error_locked(
-            reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-            message="Preview publisher failed to start",
-            last_error="Preview publisher failed after retrying timeout options",
-        )
+        with self._lock:
+            return self._set_error_locked(
+                reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                message="Preview publisher failed to start",
+                last_error="Preview publisher failed after retrying timeout options",
+            )
 
     def _wait_until_ready_locked(self) -> bool:
         deadline = self._clock.now() + self._startup_timeout_s

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -22,7 +22,6 @@ from homesec.sources.rtsp.discovery import (
     ProbeStreamInfo,
     build_camera_key,
 )
-from homesec.sources.rtsp.recording_profile import is_mp4_audio_copy_compatible
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
     _format_cmd,
@@ -36,6 +35,7 @@ logger = logging.getLogger(__name__)
 _READY_POLL_INTERVAL_S = 0.1
 _DEFAULT_VIEWER_WINDOW_S = 2.0
 _START_FAILURE_MAX_BYTES = 4_000
+_HLS_BROWSER_COPY_AUDIO_CODECS: frozenset[str] = frozenset({"aac"})
 _SESSION_LIMIT_HINTS: tuple[str, ...] = (
     "too many clients",
     "too many connections",
@@ -473,7 +473,9 @@ class HLSLivePublisher(LivePublisher):
             audio_args = ("-map", "0:a:0?", "-c:a", "copy")
         elif self._audio_codec == "aac":
             audio_args = ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
-        elif stream_info is not None and is_mp4_audio_copy_compatible(stream_info.audio_codec):
+        elif stream_info is not None and _is_hls_browser_audio_copy_compatible(
+            stream_info.audio_codec
+        ):
             audio_args = ("-map", "0:a:0?", "-c:a", "copy")
         else:
             audio_args = ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
@@ -851,6 +853,12 @@ def _classify_start_refusal(stderr_tail: str) -> LivePublisherRefusalReason:
         if hint in lowered:
             return LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
     return LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+
+
+def _is_hls_browser_audio_copy_compatible(audio_codec: str | None) -> bool:
+    if audio_codec is None:
+        return False
+    return audio_codec.strip().lower() in _HLS_BROWSER_COPY_AUDIO_CODECS
 
 
 def _h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -300,12 +300,12 @@ class HLSLivePublisher(LivePublisher):
                 viewer_count=self._viewer_count_locked(now=now),
                 idle_shutdown_at=now + self._idle_timeout_s,
             )
-            self._ensure_maintenance_thread_started_locked()
 
             if self._wait_until_ready_locked():
                 if label == "timeouts":
                     self._timeout_capabilities.note_ffmpeg_timeout_success()
                 ready_now = self._clock.now()
+                self._ensure_maintenance_thread_started_locked()
                 self._status = self._build_running_status_locked(
                     now=ready_now,
                     state=LivePublisherState.READY,
@@ -723,6 +723,9 @@ class HLSLivePublisher(LivePublisher):
         while not self._maintenance_stop.wait(self._maintenance_interval_s):
             with self._lock:
                 self._refresh_locked(now=self._clock.now())
+                if not self._is_process_running_locked():
+                    self._maintenance_thread = None
+                    return
 
 
 class NoopLivePublisher(LivePublisher):

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -532,6 +532,57 @@ def test_startup_requires_running_process_when_ready_deadline_expires(tmp_path: 
     assert not (tmp_path / "homesec" / "Front_Door_1").exists()
 
 
+def test_request_stop_preempts_slow_startup_without_error(tmp_path: Path) -> None:
+    """Explicit stop should cancel a slow startup instead of surfacing preview failure."""
+
+    # Given: A publisher whose ffmpeg process stays alive but never produces HLS output
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock())
+    publisher._startup_timeout_s = 0.5
+    calls: list[dict[str, object]] = []
+    spawned = Event()
+    start_result: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        _ = proc
+        _ = cmd
+        spawned.set()
+
+    def run_ensure_active() -> None:
+        with patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(
+                calls,
+                make_output=False,
+                on_spawn=on_spawn,
+            ),
+        ):
+            start_result["result"] = publisher.ensure_active()
+
+    ensure_thread = Thread(target=run_ensure_active)
+    ensure_thread.start()
+    assert spawned.wait(timeout=0.2)
+
+    # When: Preview is explicitly stopped while startup is still waiting for HLS readiness
+    publisher.request_stop()
+    ensure_thread.join(timeout=0.3)
+
+    # Then: Startup resolves as an idle cancellation instead of forcing ERROR state
+    assert not ensure_thread.is_alive()
+    result = start_result["result"]
+    assert result == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+    assert proc.terminate_calls == 1
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
 def test_recording_priority_preempts_slow_startup(tmp_path: Path) -> None:
     """Recording activation should preempt a slow preview startup without blocking."""
 
@@ -592,6 +643,46 @@ def test_recording_priority_preempts_slow_startup(tmp_path: Path) -> None:
     proc = calls[0]["proc"]
     assert isinstance(proc, FakeProc)
     assert proc.terminate_calls == 1
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_request_stop_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
+    """Explicit stop should cancel startup before ffmpeg spawn when probing is slow."""
+
+    # Given: A publisher whose codec probe is still in flight
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock(), discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_result: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active() -> None:
+        with patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(calls),
+        ):
+            start_result["result"] = publisher.ensure_active()
+
+    ensure_thread = Thread(target=run_ensure_active)
+    ensure_thread.start()
+    assert discovery.started.wait(timeout=0.2)
+
+    # When: Preview is explicitly stopped before the probe has released
+    publisher.request_stop()
+    discovery.release.set()
+    ensure_thread.join(timeout=0.3)
+
+    # Then: Startup finishes idle without spawning preview ffmpeg
+    assert not ensure_thread.is_alive()
+    result = start_result["result"]
+    assert result == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+    assert calls == []
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -256,6 +256,41 @@ def test_ensure_active_is_idempotent_and_cleans_stale_window(tmp_path: Path) -> 
     assert "delete_segments+append_list+omit_endlist+program_date_time+temp_file" in cmd
 
 
+def test_ensure_active_refuses_when_stale_window_cannot_be_cleaned(tmp_path: Path) -> None:
+    """Startup should fail closed when stale preview output cannot be removed."""
+    # Given: A publisher with stale HLS files that cannot be cleaned before restart
+    publisher = _make_publisher(tmp_path)
+    stale_dir = tmp_path / "homesec" / "Front_Door_1"
+    _write_live_output(
+        playlist_path=stale_dir / "playlist.m3u8",
+        segment_pattern=stale_dir / "segment_%06d.ts",
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activation is attempted while directory cleanup fails
+    with (
+        patch(
+            "homesec.sources.rtsp.live_publisher.shutil.rmtree",
+            side_effect=OSError("device busy"),
+        ),
+        patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(calls, make_output=False),
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: Startup is refused before ffmpeg spawn instead of reusing stale readiness signals
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert calls == []
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.ERROR,
+        viewer_count=0,
+        last_error="Preview storage directory could not be prepared",
+    )
+
+
 def test_auto_codec_prefers_copy_for_h264_and_aac(tmp_path: Path) -> None:
     """auto codec mode should copy browser-safe source codecs."""
     # Given: A publisher whose source probe reports H.264 video and AAC audio

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -56,6 +56,28 @@ class FakeDiscovery:
         )
 
 
+class SlowDiscovery:
+    def __init__(self, stream: ProbeStreamInfo) -> None:
+        self._stream = stream
+        self.started = Event()
+        self.release = Event()
+
+    def probe(
+        self,
+        *,
+        camera_key: str,
+        candidate_urls: list[str],
+    ) -> CameraProbeResult:
+        self.started.set()
+        self.release.wait(timeout=1.0)
+        return CameraProbeResult(
+            camera_key=camera_key,
+            streams=[self._stream],
+            attempted_urls=list(candidate_urls),
+            duration_ms=0,
+        )
+
+
 class FakeProc:
     def __init__(self, *, pid: int, returncode: int | None = None) -> None:
         self.pid = pid
@@ -570,4 +592,56 @@ def test_recording_priority_preempts_slow_startup(tmp_path: Path) -> None:
     proc = calls[0]["proc"]
     assert isinstance(proc, FakeProc)
     assert proc.terminate_calls == 1
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
+    """Recording activation should interrupt startup before ffmpeg spawn when probing is slow."""
+
+    # Given: A publisher whose codec probe is still in flight
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock(), discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_result: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active() -> None:
+        with patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(calls),
+        ):
+            start_result["result"] = publisher.ensure_active()
+
+    ensure_thread = Thread(target=run_ensure_active)
+    ensure_thread.start()
+    assert discovery.started.wait(timeout=0.2)
+
+    sync_completed = Event()
+
+    # When: Recording becomes active before the probe has released
+    def run_sync_recording_active() -> None:
+        publisher.sync_recording_active(True)
+        sync_completed.set()
+
+    sync_thread = Thread(target=run_sync_recording_active)
+    sync_thread.start()
+    sync_thread.join(timeout=0.3)
+
+    discovery.release.set()
+    ensure_thread.join(timeout=0.3)
+
+    # Then: Recording-priority preemption finishes without spawning preview ffmpeg
+    assert sync_completed.is_set()
+    assert not sync_thread.is_alive()
+    assert not ensure_thread.is_alive()
+    result = start_result["result"]
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert calls == []
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1118,6 +1118,74 @@ def test_request_stop_cancels_activation_that_queued_after_stop(tmp_path: Path) 
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
 
+def test_request_stop_keeps_cancelled_queue_from_observing_later_restart(tmp_path: Path) -> None:
+    """Explicit stop should keep stale queued callers from inheriting a later restart."""
+
+    # Given: One queued activation is already waiting when an explicit stop cancels startup
+    class _ThreadClock:
+        def __init__(self) -> None:
+            self.wait_started = Event()
+            self.release_wait = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            _ = seconds
+            self.wait_started.set()
+            self.release_wait.wait(timeout=1.0)
+
+    clock = _ThreadClock()
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=clock, discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        third_thread = Thread(target=run_ensure_active, args=("third",))
+        first_thread.start()
+        assert discovery.started.wait(timeout=0.2)
+        second_thread.start()
+        assert clock.wait_started.wait(timeout=0.2)
+
+        # When: A later restart succeeds before the stale queued caller wakes up
+        publisher.request_stop()
+        discovery.release.set()
+        first_thread.join(timeout=1.0)
+        third_thread.start()
+        third_thread.join(timeout=1.0)
+        clock.release_wait.set()
+        second_thread.join(timeout=1.0)
+
+    # Then: The stale queued activation resolves to the stop result instead of piggybacking on restart
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not third_thread.is_alive()
+    assert start_results["first"] == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert start_results["second"] == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    third_result = start_results["third"]
+    assert isinstance(third_result, LivePublisherStatus)
+    assert third_result.state == LivePublisherState.READY
+    assert third_result.viewer_count == 0
+    assert third_result.idle_shutdown_at is not None
+    assert len(calls) == 1
+    assert publisher.status() == third_result
+
+
 def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     """Recording activation should interrupt startup before ffmpeg spawn when probing is slow."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1236,3 +1236,107 @@ def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> 
     assert result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
     assert calls == []
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_recording_priority_cancels_stale_probe_when_recording_ends_before_release(
+    tmp_path: Path,
+) -> None:
+    """Recording preemption should fence a slow probe even if recording ends before it returns."""
+
+    # Given: A publisher whose codec probe is still in flight
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock(), discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_result: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active() -> None:
+        with patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(calls),
+        ):
+            start_result["result"] = publisher.ensure_active()
+
+    ensure_thread = Thread(target=run_ensure_active)
+    ensure_thread.start()
+    assert discovery.started.wait(timeout=0.2)
+
+    # When: Recording briefly preempts preview before the slow probe returns
+    publisher.sync_recording_active(True)
+    publisher.sync_recording_active(False)
+    discovery.release.set()
+    ensure_thread.join(timeout=0.3)
+
+    # Then: The stale activation stays cancelled and does not restart preview
+    assert not ensure_thread.is_alive()
+    result = start_result["result"]
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert calls == []
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_recording_priority_cancels_waiting_activation_after_recording_window(
+    tmp_path: Path,
+) -> None:
+    """Recording preemption should fence queued activations after recording has ended."""
+
+    # Given: One preview activation probing slowly while a second caller waits behind it
+    class _ThreadClock:
+        def __init__(self) -> None:
+            self.wait_started = Event()
+            self.release_wait = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            _ = seconds
+            self.wait_started.set()
+            self.release_wait.wait(timeout=1.0)
+
+    clock = _ThreadClock()
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=clock, discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        first_thread.start()
+        assert discovery.started.wait(timeout=0.2)
+        second_thread.start()
+        assert clock.wait_started.wait(timeout=0.2)
+
+        # When: Recording briefly preempts preview before the waiting caller can wake
+        publisher.sync_recording_active(True)
+        publisher.sync_recording_active(False)
+        discovery.release.set()
+        first_thread.join(timeout=1.0)
+        clock.release_wait.set()
+        second_thread.join(timeout=1.0)
+
+    # Then: Both stale activation attempts resolve as recording-priority refusals
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    first_result = start_results["first"]
+    second_result = start_results["second"]
+    assert isinstance(first_result, LivePublisherStartRefusal)
+    assert first_result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert isinstance(second_result, LivePublisherStartRefusal)
+    assert second_result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert calls == []
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -402,6 +402,68 @@ def test_request_stop_terminates_process_and_removes_live_window(tmp_path: Path)
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
 
+def test_request_stop_reports_error_when_process_does_not_stop_cleanly(tmp_path: Path) -> None:
+    """Explicit stop should fail closed when ffmpeg teardown does not complete."""
+    # Given: An active preview publisher whose ffmpeg stop path reports failure
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        _ = publisher.ensure_active()
+
+    camera_dir = tmp_path / "homesec" / "Front_Door_1"
+
+    # When: Force-stopping preview while process teardown reports failure
+    with patch.object(
+        publisher,
+        "_terminate_process",
+        return_value="Preview ffmpeg could not be stopped cleanly",
+    ):
+        publisher.request_stop()
+
+    # Then: The publisher surfaces the stop failure instead of reporting a clean idle stop
+    assert not camera_dir.exists()
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.ERROR,
+        viewer_count=0,
+        last_error="Preview ffmpeg could not be stopped cleanly",
+    )
+
+
+def test_request_stop_reports_error_when_live_window_cleanup_fails(tmp_path: Path) -> None:
+    """Explicit stop should fail closed when live HLS cleanup cannot finish."""
+    # Given: An active preview publisher whose live window cannot be removed
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        _ = publisher.ensure_active()
+
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+    camera_dir = tmp_path / "homesec" / "Front_Door_1"
+
+    # When: Force-stopping preview while live-window cleanup fails
+    with patch(
+        "homesec.sources.rtsp.live_publisher.shutil.rmtree",
+        side_effect=OSError("device busy"),
+    ):
+        publisher.request_stop()
+
+    # Then: The publisher preserves an error state instead of claiming preview is idle
+    assert proc.terminate_calls == 1
+    assert camera_dir.exists()
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.ERROR,
+        viewer_count=0,
+        last_error="Preview live output could not be removed",
+    )
+
+
 def test_request_stop_allows_maintenance_thread_to_exit(tmp_path: Path) -> None:
     """Explicit stop should not leave a permanent maintenance thread behind."""
     # Given: An active preview publisher with background maintenance enabled
@@ -517,6 +579,51 @@ def test_start_failure_maps_session_budget_refusal_and_cleans_storage(tmp_path: 
     assert status.last_error is not None
     assert "Too many clients" in status.last_error
     assert not (tmp_path / "homesec" / "Front_Door_1").exists()
+
+
+def test_timeout_retry_aborts_when_failed_start_teardown_cannot_clean_up(tmp_path: Path) -> None:
+    """Timeout-option fallback should stop retrying when failed-start cleanup leaves stale state."""
+    # Given: A publisher whose failed start cannot fully clean its live window
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+    cleanup_calls = 0
+    original_cleanup = publisher._cleanup_live_dir_locked
+
+    def cleanup_with_failed_stop() -> bool:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        if cleanup_calls == 2:
+            return False
+        return original_cleanup()
+
+    # When: Activating preview with ffmpeg rejecting timeout options
+    with (
+        patch.object(
+            publisher,
+            "_cleanup_live_dir_locked",
+            side_effect=cleanup_with_failed_stop,
+        ),
+        patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(
+                calls,
+                make_output=False,
+                returncode=1,
+                stderr_text="Unrecognized option 'rw_timeout'.\n",
+            ),
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: Startup fails closed instead of retrying a second ffmpeg launch
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert len(calls) == 1
+    status = publisher.status()
+    assert status.state == LivePublisherState.ERROR
+    assert status.last_error is not None
+    assert "rw_timeout" in status.last_error
+    assert "Preview live output could not be removed" in status.last_error
 
 
 def test_non_session_limit_failure_does_not_map_generic_too_many_text(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -16,14 +16,22 @@ from homesec.sources.rtsp.live_publisher import (
 
 
 class FakeClock:
-    def __init__(self, start: float = 0.0) -> None:
+    def __init__(
+        self,
+        start: float = 0.0,
+        *,
+        on_sleep: Callable[[float], None] | None = None,
+    ) -> None:
         self._now = float(start)
+        self._on_sleep = on_sleep
 
     def now(self) -> float:
         return self._now
 
     def sleep(self, seconds: float) -> None:
         self._now += float(seconds)
+        if self._on_sleep is not None:
+            self._on_sleep(self._now)
 
 
 class FakeDiscovery:
@@ -74,6 +82,15 @@ class _Writable(Protocol):
     def write(self, text: str) -> object: ...
 
     def flush(self) -> None: ...
+
+
+def _write_live_output(*, playlist_path: Path, segment_pattern: Path) -> None:
+    playlist_path.parent.mkdir(parents=True, exist_ok=True)
+    playlist_path.write_text(
+        "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:1.0,\nsegment_000000.ts\n",
+        encoding="utf-8",
+    )
+    Path(str(segment_pattern).replace("%06d", "000000")).write_bytes(b"segment")
 
 
 def _probe_stream(
@@ -131,6 +148,7 @@ def _fake_popen_factory(
     make_output: bool = True,
     returncode: int | None = None,
     stderr_text: str = "",
+    on_spawn: Callable[[FakeProc, list[str]], None] | None = None,
 ) -> Callable[..., FakeProc]:
     next_pid = 1000
 
@@ -156,6 +174,9 @@ def _fake_popen_factory(
             }
         )
 
+        if on_spawn is not None:
+            on_spawn(proc, list(cmd))
+
         if stderr_text and hasattr(stderr, "write") and hasattr(stderr, "flush"):
             stderr_handle = cast(_Writable, stderr)
             stderr_handle.write(stderr_text)
@@ -164,12 +185,10 @@ def _fake_popen_factory(
         if make_output:
             playlist_path = Path(cmd[-1])
             segment_pattern = Path(cmd[cmd.index("-hls_segment_filename") + 1])
-            playlist_path.parent.mkdir(parents=True, exist_ok=True)
-            playlist_path.write_text(
-                "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:1.0,\nsegment_000000.ts\n",
-                encoding="utf-8",
+            _write_live_output(
+                playlist_path=playlist_path,
+                segment_pattern=segment_pattern,
             )
-            Path(str(segment_pattern).replace("%06d", "000000")).write_bytes(b"segment")
 
         return proc
 
@@ -409,4 +428,81 @@ def test_start_failure_maps_session_budget_refusal_and_cleans_storage(tmp_path: 
     assert status.state == LivePublisherState.ERROR
     assert status.last_error is not None
     assert "Too many clients" in status.last_error
+    assert not (tmp_path / "homesec" / "Front_Door_1").exists()
+
+
+def test_non_session_limit_failure_does_not_map_generic_too_many_text(tmp_path: Path) -> None:
+    """Non-session ffmpeg errors should not be misclassified as session-budget refusals."""
+    # Given: A publisher whose ffmpeg start fails with a non-session "too many" error
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            make_output=False,
+            returncode=1,
+            stderr_text="Too many packets buffered for output stream 0:1.\n",
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The refusal stays generic instead of claiming the camera session budget is exhausted
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert publisher.status().state == LivePublisherState.ERROR
+
+
+def test_startup_requires_running_process_when_ready_deadline_expires(tmp_path: Path) -> None:
+    """Startup should refuse readiness when ffmpeg exits before the deadline check completes."""
+    # Given: A publisher whose ffmpeg produces HLS files but exits at the startup deadline
+    calls: list[dict[str, object]] = []
+    spawn: dict[str, FakeProc | Path] = {}
+
+    def on_sleep(now: float) -> None:
+        proc = spawn.get("proc")
+        playlist_path = spawn.get("playlist_path")
+        segment_pattern = spawn.get("segment_pattern")
+        if (
+            now < 6.0
+            or not isinstance(proc, FakeProc)
+            or not isinstance(playlist_path, Path)
+            or not isinstance(segment_pattern, Path)
+            or proc.returncode is not None
+        ):
+            return
+
+        _write_live_output(
+            playlist_path=playlist_path,
+            segment_pattern=segment_pattern,
+        )
+        proc.returncode = 1
+
+    clock = FakeClock(on_sleep=on_sleep)
+    publisher = _make_publisher(tmp_path, clock=clock)
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        spawn["proc"] = proc
+        spawn["playlist_path"] = Path(cmd[-1])
+        spawn["segment_pattern"] = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            make_output=False,
+            on_spawn=on_spawn,
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: Startup fails closed instead of reporting READY for a dead ffmpeg process
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    status = publisher.status()
+    assert status.state == LivePublisherState.ERROR
+    assert status.last_error == "Preview publisher exited before producing HLS output"
     assert not (tmp_path / "homesec" / "Front_Door_1").exists()

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -102,6 +102,8 @@ def _make_publisher(
     idle_timeout_s: float = 5.0,
     audio_codec: Literal["auto", "copy", "aac"] = "auto",
     video_codec: Literal["auto", "copy", "h264"] = "auto",
+    background_maintenance: bool = False,
+    maintenance_interval_s: float | None = None,
 ) -> HLSLivePublisher:
     return HLSLivePublisher(
         camera_name="Front Door #1",
@@ -118,7 +120,8 @@ def _make_publisher(
         clock=clock or FakeClock(),
         stream_discovery=discovery
         or FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="aac")),
-        background_maintenance=False,
+        background_maintenance=background_maintenance,
+        maintenance_interval_s=maintenance_interval_s,
     )
 
 
@@ -290,6 +293,34 @@ def test_request_stop_terminates_process_and_removes_live_window(tmp_path: Path)
     assert proc.terminate_calls == 1
     assert not camera_dir.exists()
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_request_stop_allows_maintenance_thread_to_exit(tmp_path: Path) -> None:
+    """Explicit stop should not leave a permanent maintenance thread behind."""
+    # Given: An active preview publisher with background maintenance enabled
+    publisher = _make_publisher(
+        tmp_path,
+        background_maintenance=True,
+        maintenance_interval_s=0.01,
+    )
+    calls: list[dict[str, object]] = []
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        _ = publisher.ensure_active()
+
+    maintenance_thread = publisher._maintenance_thread
+    assert maintenance_thread is not None
+    assert maintenance_thread.is_alive()
+
+    # When: Force-stopping preview
+    publisher.request_stop()
+    maintenance_thread.join(timeout=0.5)
+
+    # Then: The maintenance thread exits once the publisher is idle
+    assert not maintenance_thread.is_alive()
+    assert publisher._maintenance_thread is None
 
 
 def test_idle_shutdown_stops_preview_after_viewers_go_inactive(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -775,6 +775,89 @@ def test_recording_priority_preempts_slow_startup(tmp_path: Path) -> None:
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
 
+def test_request_stop_clears_racing_start_failure_error(tmp_path: Path) -> None:
+    """Explicit stop should win over a concurrent startup-failure error transition."""
+
+    # Given: A publisher timing out during startup while error reporting is delayed
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock())
+    publisher._startup_timeout_s = 0.2
+    calls: list[dict[str, object]] = []
+    spawned = Event()
+    error_transition_started = Event()
+    allow_error_transition = Event()
+
+    original_set_error_locked = publisher._set_error_locked
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        _ = proc
+        _ = cmd
+        spawned.set()
+
+    def delayed_set_error_locked(
+        *,
+        reason: LivePublisherRefusalReason,
+        message: str,
+        last_error: str,
+    ) -> LivePublisherStartRefusal:
+        error_transition_started.set()
+        allow_error_transition.wait(timeout=1.0)
+        return original_set_error_locked(
+            reason=reason,
+            message=message,
+            last_error=last_error,
+        )
+
+    def run_ensure_active() -> None:
+        with (
+            patch(
+                "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+                side_effect=_fake_popen_factory(
+                    calls,
+                    make_output=False,
+                    on_spawn=on_spawn,
+                ),
+            ),
+            patch.object(
+                publisher,
+                "_set_error_locked",
+                side_effect=delayed_set_error_locked,
+            ),
+        ):
+            _ = publisher.ensure_active()
+
+    ensure_thread = Thread(target=run_ensure_active)
+    ensure_thread.start()
+    assert spawned.wait(timeout=0.2)
+    assert error_transition_started.wait(timeout=1.0)
+
+    stop_completed = Event()
+
+    # When: Explicit stop races the startup-failure error transition
+    def run_request_stop() -> None:
+        publisher.request_stop()
+        stop_completed.set()
+
+    stop_thread = Thread(target=run_request_stop)
+    stop_thread.start()
+    time.sleep(0.05)
+    allow_error_transition.set()
+    ensure_thread.join(timeout=1.0)
+    stop_thread.join(timeout=1.0)
+
+    # Then: The later stop request leaves the publisher idle instead of ERROR
+    assert stop_completed.is_set()
+    assert not ensure_thread.is_alive()
+    assert not stop_thread.is_alive()
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
 def test_request_stop_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     """Explicit stop should cancel startup before ffmpeg spawn when probing is slow."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1005,6 +1005,62 @@ def test_request_stop_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
 
+def test_request_stop_cancels_waiting_activation_queue(tmp_path: Path) -> None:
+    """Explicit stop should prevent queued activation callers from immediately restarting preview."""
+
+    # Given: One preview activation probing slowly while a second caller waits behind it
+    class _ThreadClock:
+        def __init__(self) -> None:
+            self.wait_started = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            self.wait_started.set()
+            time.sleep(seconds)
+
+    clock = _ThreadClock()
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=clock, discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        first_thread.start()
+        assert discovery.started.wait(timeout=0.2)
+        second_thread.start()
+        assert clock.wait_started.wait(timeout=0.2)
+
+        # When: Preview is explicitly stopped while a second caller is queued behind startup
+        publisher.request_stop()
+        discovery.release.set()
+        first_thread.join(timeout=1.0)
+        second_thread.join(timeout=1.0)
+
+    # Then: Both in-flight activation calls resolve idle and no new ffmpeg process is spawned
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert start_results["first"] == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert start_results["second"] == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert calls == []
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
 def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     """Recording activation should interrupt startup before ffmpeg spawn when probing is slow."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1243,6 +1243,94 @@ def test_waiting_activation_inherits_failed_start_result(tmp_path: Path) -> None
     assert publisher.status().state == LivePublisherState.ERROR
 
 
+def test_waiting_activation_keeps_failed_result_after_later_restart(tmp_path: Path) -> None:
+    """Queued activation callers should not inherit a later restart after their start already failed."""
+
+    # Given: One preview activation probing slowly while a second caller waits behind it
+    class _ThreadClock:
+        def __init__(self) -> None:
+            self.wait_started = Event()
+            self.release_wait = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            _ = seconds
+            self.wait_started.set()
+            self.release_wait.wait(timeout=1.0)
+
+    clock = _ThreadClock()
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=clock, discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+    failed_start = _fake_popen_factory(
+        calls,
+        make_output=False,
+        returncode=1,
+        stderr_text="Too many clients already connected.\n",
+    )
+    successful_restart = _fake_popen_factory(calls)
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **kwargs: object,
+    ) -> FakeProc:
+        factory = failed_start if len(calls) == 0 else successful_restart
+        return factory(
+            cmd,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=start_new_session,
+            **kwargs,
+        )
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=fake_popen,
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        third_thread = Thread(target=run_ensure_active, args=("third",))
+        first_thread.start()
+        assert discovery.started.wait(timeout=0.2)
+        second_thread.start()
+        assert clock.wait_started.wait(timeout=0.2)
+
+        # When: The original start fails and a later caller restarts preview before the waiter wakes
+        discovery.release.set()
+        first_thread.join(timeout=1.0)
+        third_thread.start()
+        third_thread.join(timeout=1.0)
+        clock.release_wait.set()
+        second_thread.join(timeout=1.0)
+
+    # Then: The waiting caller still receives the failed start instead of inheriting the restart
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not third_thread.is_alive()
+    first_result = start_results["first"]
+    second_result = start_results["second"]
+    third_result = start_results["third"]
+    assert isinstance(first_result, LivePublisherStartRefusal)
+    assert first_result.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert second_result == first_result
+    assert isinstance(third_result, LivePublisherStatus)
+    assert third_result.state == LivePublisherState.READY
+    assert third_result.viewer_count == 0
+    assert third_result.idle_shutdown_at is not None
+    assert len(calls) == 2
+    assert publisher.status() == third_result
+
+
 def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     """Recording activation should interrupt startup before ffmpeg spawn when probing is slow."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -174,7 +174,8 @@ def _fake_popen_factory(
     stderr_text: str = "",
     on_spawn: Callable[[FakeProc, list[str]], None] | None = None,
 ) -> Callable[..., FakeProc]:
-    next_pid = 1000
+    # Use an implausibly high PID so test cleanup never risks signaling a real process group.
+    next_pid = 900_000_000
 
     def fake_popen(
         cmd: list[str],
@@ -766,6 +767,58 @@ def test_slow_startup_arms_idle_timeout_from_ready_time(tmp_path: Path) -> None:
         viewer_count=0,
     )
     assert proc.terminate_calls == 1
+
+
+def test_waiting_activation_does_not_return_ready_until_start_completes(tmp_path: Path) -> None:
+    """Concurrent callers should queue behind startup (even after spawn) and share its result."""
+
+    # Given: A publisher whose ffmpeg spawns but never produces HLS output
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock())
+    publisher._startup_timeout_s = 0.3
+    calls: list[dict[str, object]] = []
+    spawned = Event()
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        _ = proc
+        _ = cmd
+        spawned.set()
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    # When: A second caller arrives while the first startup is still waiting for readiness
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            make_output=False,
+            on_spawn=on_spawn,
+        ),
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        first_thread.start()
+        assert spawned.wait(timeout=0.5)
+        second_thread.start()
+        first_thread.join(timeout=1.0)
+        second_thread.join(timeout=1.0)
+
+    # Then: Both callers share the eventual failed start instead of returning READY early
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert len(calls) == 1
+    first_result = start_results["first"]
+    second_result = start_results["second"]
+    assert isinstance(first_result, LivePublisherStartRefusal)
+    assert second_result == first_result
 
 
 def test_request_stop_preempts_slow_startup_without_error(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1061,6 +1061,63 @@ def test_request_stop_cancels_waiting_activation_queue(tmp_path: Path) -> None:
     assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
 
 
+def test_request_stop_cancels_activation_that_queued_after_stop(tmp_path: Path) -> None:
+    """Explicit stop should fence callers that queue behind a start already being cancelled."""
+
+    # Given: One preview activation probing slowly while a later caller arrives after stop
+    class _ThreadClock:
+        def __init__(self) -> None:
+            self.wait_started = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            self.wait_started.set()
+            time.sleep(seconds)
+
+    clock = _ThreadClock()
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=clock, discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        first_thread.start()
+        assert discovery.started.wait(timeout=0.2)
+
+        # When: Preview is explicitly stopped before a second caller queues behind startup
+        publisher.request_stop()
+        second_thread.start()
+        assert clock.wait_started.wait(timeout=0.2)
+
+        discovery.release.set()
+        first_thread.join(timeout=1.0)
+        second_thread.join(timeout=1.0)
+
+    # Then: The late-queued activation also resolves idle and does not restart ffmpeg
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert start_results["first"] == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert start_results["second"] == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert calls == []
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
 def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     """Recording activation should interrupt startup before ffmpeg spawn when probing is slow."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal, Protocol, cast
+from unittest.mock import patch
+
+from homesec.sources.rtsp.discovery import CameraProbeResult, ProbeStreamInfo
+from homesec.sources.rtsp.live_publisher import (
+    HLSLivePublisher,
+    LivePublisherRefusalReason,
+    LivePublisherStartRefusal,
+    LivePublisherState,
+    LivePublisherStatus,
+)
+
+
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = float(start)
+
+    def now(self) -> float:
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        self._now += float(seconds)
+
+
+class FakeDiscovery:
+    def __init__(self, stream: ProbeStreamInfo | None) -> None:
+        self._stream = stream
+        self.calls = 0
+
+    def probe(
+        self,
+        *,
+        camera_key: str,
+        candidate_urls: list[str],
+    ) -> CameraProbeResult:
+        self.calls += 1
+        return CameraProbeResult(
+            camera_key=camera_key,
+            streams=[] if self._stream is None else [self._stream],
+            attempted_urls=list(candidate_urls),
+            duration_ms=0,
+        )
+
+
+class FakeProc:
+    def __init__(self, *, pid: int, returncode: int | None = None) -> None:
+        self.pid = pid
+        self.returncode = returncode
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_timeouts: list[float | None] = []
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        self.returncode = 0
+
+    def wait(self, timeout: float | None = None) -> int | None:
+        self.wait_timeouts.append(timeout)
+        return self.returncode
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+
+class _Writable(Protocol):
+    def write(self, text: str) -> object: ...
+
+    def flush(self) -> None: ...
+
+
+def _probe_stream(
+    *,
+    video_codec: str,
+    audio_codec: str | None,
+) -> ProbeStreamInfo:
+    return ProbeStreamInfo(
+        url="rtsp://host/main",
+        video_codec=video_codec,
+        audio_codec=audio_codec,
+        width=1920,
+        height=1080,
+        fps=15.0,
+        fps_raw="15/1",
+        probe_ok=True,
+        error=None,
+    )
+
+
+def _make_publisher(
+    tmp_path: Path,
+    *,
+    clock: FakeClock | None = None,
+    discovery: FakeDiscovery | None = None,
+    idle_timeout_s: float = 5.0,
+    audio_codec: Literal["auto", "copy", "aac"] = "auto",
+    video_codec: Literal["auto", "copy", "h264"] = "auto",
+) -> HLSLivePublisher:
+    return HLSLivePublisher(
+        camera_name="Front Door #1",
+        rtsp_url="rtsp://host/main",
+        storage_dir=tmp_path,
+        segment_duration_ms=1000,
+        live_window_segments=4,
+        idle_timeout_s=idle_timeout_s,
+        audio_enabled=True,
+        audio_codec=audio_codec,
+        video_codec=video_codec,
+        rtsp_connect_timeout_s=1.0,
+        rtsp_io_timeout_s=1.0,
+        clock=clock or FakeClock(),
+        stream_discovery=discovery
+        or FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="aac")),
+        background_maintenance=False,
+    )
+
+
+def _fake_popen_factory(
+    calls: list[dict[str, object]],
+    *,
+    make_output: bool = True,
+    returncode: int | None = None,
+    stderr_text: str = "",
+) -> Callable[..., FakeProc]:
+    next_pid = 1000
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **_: object,
+    ) -> FakeProc:
+        nonlocal next_pid
+        proc = FakeProc(pid=next_pid, returncode=returncode)
+        next_pid += 1
+
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+                "proc": proc,
+            }
+        )
+
+        if stderr_text and hasattr(stderr, "write") and hasattr(stderr, "flush"):
+            stderr_handle = cast(_Writable, stderr)
+            stderr_handle.write(stderr_text)
+            stderr_handle.flush()
+
+        if make_output:
+            playlist_path = Path(cmd[-1])
+            segment_pattern = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+            playlist_path.parent.mkdir(parents=True, exist_ok=True)
+            playlist_path.write_text(
+                "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:1.0,\nsegment_000000.ts\n",
+                encoding="utf-8",
+            )
+            Path(str(segment_pattern).replace("%06d", "000000")).write_bytes(b"segment")
+
+        return proc
+
+    return fake_popen
+
+
+def test_ensure_active_is_idempotent_and_cleans_stale_window(tmp_path: Path) -> None:
+    """ensure_active should start once and replace stale playlist state."""
+    # Given: A publisher with stale preview files from a prior session
+    clock = FakeClock()
+    publisher = _make_publisher(tmp_path, clock=clock)
+    stale_dir = tmp_path / "homesec" / "Front_Door_1"
+    stale_dir.mkdir(parents=True, exist_ok=True)
+    stale_file = stale_dir / "old.ts"
+    stale_file.write_text("stale", encoding="utf-8")
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview twice
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first = publisher.ensure_active()
+        second = publisher.ensure_active()
+
+    # Then: ffmpeg starts once and the live window is recreated in the camera-scoped path
+    assert first == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=clock.now() + 5.0,
+    )
+    assert second == first
+    assert len(calls) == 1
+    assert calls[0]["start_new_session"] is True
+    assert not stale_file.exists()
+    assert (stale_dir / "playlist.m3u8").exists()
+    assert (stale_dir / "segment_000000.ts").exists()
+    cmd = cast(list[str], calls[0]["cmd"])
+    assert "-f" in cmd
+    assert "hls" in cmd
+    assert "delete_segments+append_list+omit_endlist+program_date_time+temp_file" in cmd
+
+
+def test_auto_codec_prefers_copy_for_h264_and_aac(tmp_path: Path) -> None:
+    """auto codec mode should copy browser-safe source codecs."""
+    # Given: A publisher whose source probe reports H.264 video and AAC audio
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="aac")),
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The HLS ffmpeg path copy-remuxes both tracks
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "copy"
+    assert cmd[cmd.index("-c:a") + 1] == "copy"
+    assert "libx264" not in cmd
+
+
+def test_auto_codec_transcodes_non_browser_safe_source(tmp_path: Path) -> None:
+    """auto codec mode should transcode unsupported source codecs to browser-safe outputs."""
+    # Given: A publisher whose source probe reports H.265 video and PCMA audio
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="hevc", audio_codec="pcm_alaw")),
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The HLS ffmpeg path transcodes to H.264 video and AAC audio
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "libx264"
+    assert cmd[cmd.index("-c:a") + 1] == "aac"
+    assert cmd[cmd.index("-b:a") + 1] == "128k"
+
+
+def test_request_stop_terminates_process_and_removes_live_window(tmp_path: Path) -> None:
+    """Explicit stop should terminate ffmpeg and remove playlist and segments."""
+    # Given: An active preview publisher
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        _ = publisher.ensure_active()
+
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+    camera_dir = tmp_path / "homesec" / "Front_Door_1"
+
+    # When: Force-stopping preview
+    publisher.request_stop()
+
+    # Then: ffmpeg is terminated and the live files are cleaned up
+    assert proc.terminate_calls == 1
+    assert not camera_dir.exists()
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_idle_shutdown_stops_preview_after_viewers_go_inactive(tmp_path: Path) -> None:
+    """Idle timeout should stop the publisher after recent viewers disappear."""
+    # Given: An active preview publisher with one recent viewer
+    clock = FakeClock()
+    publisher = _make_publisher(tmp_path, clock=clock, idle_timeout_s=5.0)
+    calls: list[dict[str, object]] = []
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        _ = publisher.ensure_active()
+    publisher.note_viewer_activity("viewer-1")
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+
+    # When: The viewer ages out of the recent-consumer window but idle timeout has not fired yet
+    clock.sleep(2.1)
+    status_before_timeout = publisher.status()
+
+    # Then: Preview is still ready with no active viewers and a pending idle shutdown time
+    assert status_before_timeout.state == LivePublisherState.READY
+    assert status_before_timeout.viewer_count == 0
+    assert status_before_timeout.idle_shutdown_at == 5.0
+
+    # When: Advancing beyond the idle timeout
+    clock.sleep(3.0)
+    status_after_timeout = publisher.status()
+
+    # Then: Preview stops and the live window is removed
+    assert status_after_timeout == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert proc.terminate_calls == 1
+    assert not (tmp_path / "homesec" / "Front_Door_1").exists()
+
+
+def test_recording_priority_sheds_active_preview_and_refuses_restart(tmp_path: Path) -> None:
+    """Recording-active sync should stop preview and refuse new activation."""
+    # Given: An active preview publisher
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        _ = publisher.ensure_active()
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+
+    # When: Recording becomes active and preview is requested again
+    publisher.sync_recording_active(True)
+    restart_result = publisher.ensure_active()
+
+    # Then: The existing preview is stopped and future starts are refused
+    assert proc.terminate_calls == 1
+    assert isinstance(restart_result, LivePublisherStartRefusal)
+    assert restart_result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+
+
+def test_start_failure_maps_session_budget_refusal_and_cleans_storage(tmp_path: Path) -> None:
+    """Immediate ffmpeg failure with session-limit hints should return a session-budget refusal."""
+    # Given: A publisher whose ffmpeg start fails with a session-limit error
+    publisher = _make_publisher(tmp_path)
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            make_output=False,
+            returncode=1,
+            stderr_text="Too many clients already connected.\n",
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The publisher surfaces a session-budget refusal and removes partial live output
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    status = publisher.status()
+    assert status.state == LivePublisherState.ERROR
+    assert status.last_error is not None
+    assert "Too many clients" in status.last_error
+    assert not (tmp_path / "homesec" / "Front_Door_1").exists()

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from pathlib import Path
-from threading import Event, Thread
+from threading import Event, Thread, current_thread
 from typing import Literal, Protocol, cast
 from unittest.mock import patch
 
@@ -819,6 +819,121 @@ def test_waiting_activation_does_not_return_ready_until_start_completes(tmp_path
     second_result = start_results["second"]
     assert isinstance(first_result, LivePublisherStartRefusal)
     assert second_result == first_result
+
+
+def test_waiting_activation_restarts_when_process_exits_before_waiter_wakes(tmp_path: Path) -> None:
+    """Queued activation callers should not return a stale READY after ffmpeg has already exited."""
+
+    # Given: A publisher whose first startup is slow enough for a second caller to queue behind it
+    class _ControlledClock:
+        def __init__(self) -> None:
+            self.waiter_sleep_started = Event()
+            self.waiter_sleep_release = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            if current_thread().name == "waiter":
+                self.waiter_sleep_started.set()
+                self.waiter_sleep_release.wait()
+                return
+            time.sleep(seconds)
+
+    clock = _ControlledClock()
+    publisher = _make_publisher(tmp_path, clock=clock)
+    publisher._startup_timeout_s = 1.0
+
+    calls: list[dict[str, object]] = []
+    spawned = Event()
+    first_proc: FakeProc | None = None
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        _ = cmd
+        nonlocal first_proc
+        if first_proc is None:
+            first_proc = proc
+            spawned.set()
+
+    first_spawn = _fake_popen_factory(
+        calls,
+        make_output=False,
+        on_spawn=on_spawn,
+    )
+    second_spawn = _fake_popen_factory(calls)
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **kwargs: object,
+    ) -> FakeProc:
+        factory = first_spawn if len(calls) == 0 else second_spawn
+        return factory(
+            cmd,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=start_new_session,
+            **kwargs,
+        )
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=fake_popen,
+    ):
+        starter_thread = Thread(
+            target=run_ensure_active,
+            args=("starter",),
+            name="starter",
+            daemon=True,
+        )
+        waiter_thread = Thread(
+            target=run_ensure_active,
+            args=("waiter",),
+            name="waiter",
+            daemon=True,
+        )
+        try:
+            starter_thread.start()
+            assert spawned.wait(timeout=0.5)
+            waiter_thread.start()
+            assert clock.waiter_sleep_started.wait(timeout=0.5)
+
+            camera_dir = tmp_path / "homesec" / "Front_Door_1"
+            _write_live_output(
+                playlist_path=camera_dir / "playlist.m3u8",
+                segment_pattern=camera_dir / "segment_%06d.ts",
+            )
+
+            starter_thread.join(timeout=1.0)
+            assert not starter_thread.is_alive()
+            starter_result = start_results["starter"]
+            assert isinstance(starter_result, LivePublisherStatus)
+            assert starter_result.state == LivePublisherState.READY
+            assert starter_result.viewer_count == 0
+
+            # When: The underlying process exits before the queued waiter observes the completed start
+            assert isinstance(first_proc, FakeProc)
+            first_proc.returncode = 1
+            clock.waiter_sleep_release.set()
+            waiter_thread.join(timeout=1.0)
+        finally:
+            clock.waiter_sleep_release.set()
+            starter_thread.join(timeout=1.0)
+            waiter_thread.join(timeout=1.0)
+
+    # Then: The queued waiter restarts preview instead of returning a stale READY result
+    assert not waiter_thread.is_alive()
+    assert len(calls) == 2
+    waiter_result = start_results["waiter"]
+    assert isinstance(waiter_result, LivePublisherStatus)
+    assert waiter_result.state == LivePublisherState.READY
 
 
 def test_request_stop_preempts_slow_startup_without_error(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -561,6 +561,71 @@ def test_startup_requires_running_process_when_ready_deadline_expires(tmp_path: 
     assert not (tmp_path / "homesec" / "Front_Door_1").exists()
 
 
+def test_slow_startup_arms_idle_timeout_from_ready_time(tmp_path: Path) -> None:
+    """Slow startup should not age out the idle window before preview becomes ready."""
+    # Given: A publisher whose HLS output does not appear until the readiness deadline
+    calls: list[dict[str, object]] = []
+    spawn: dict[str, FakeProc | Path] = {}
+
+    def on_sleep(now: float) -> None:
+        playlist_path = spawn.get("playlist_path")
+        segment_pattern = spawn.get("segment_pattern")
+        if (
+            now < 6.0
+            or not isinstance(playlist_path, Path)
+            or not isinstance(segment_pattern, Path)
+            or playlist_path.exists()
+        ):
+            return
+
+        _write_live_output(
+            playlist_path=playlist_path,
+            segment_pattern=segment_pattern,
+        )
+
+    clock = FakeClock(on_sleep=on_sleep)
+    publisher = _make_publisher(tmp_path, clock=clock, idle_timeout_s=5.0)
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        spawn["proc"] = proc
+        spawn["playlist_path"] = Path(cmd[-1])
+        spawn["segment_pattern"] = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+
+    # When: Activating preview after a slow HLS startup
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            make_output=False,
+            on_spawn=on_spawn,
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The idle timeout starts from readiness instead of expiring during startup
+    assert result.state == LivePublisherState.READY
+    assert result.viewer_count == 0
+    assert result.idle_shutdown_at == clock.now() + 5.0
+
+    status_while_ready = publisher.status()
+    assert status_while_ready.state == LivePublisherState.READY
+    assert status_while_ready.viewer_count == 0
+    assert status_while_ready.idle_shutdown_at == result.idle_shutdown_at
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+    assert proc.terminate_calls == 0
+
+    clock.sleep(4.9)
+    assert publisher.status() == status_while_ready
+
+    clock.sleep(0.2)
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+    )
+    assert proc.terminate_calls == 1
+
+
 def test_request_stop_preempts_slow_startup_without_error(tmp_path: Path) -> None:
     """Explicit stop should cancel a slow startup instead of surfacing preview failure."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1186,6 +1186,63 @@ def test_request_stop_keeps_cancelled_queue_from_observing_later_restart(tmp_pat
     assert publisher.status() == third_result
 
 
+def test_waiting_activation_inherits_failed_start_result(tmp_path: Path) -> None:
+    """Queued activation callers should share the failed start they were waiting on."""
+
+    # Given: One preview activation probing slowly while a second caller waits behind it
+    class _ThreadClock:
+        def __init__(self) -> None:
+            self.wait_started = Event()
+
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            self.wait_started.set()
+            time.sleep(seconds)
+
+    clock = _ThreadClock()
+    discovery = SlowDiscovery(_probe_stream(video_codec="h264", audio_codec="aac"))
+    publisher = _make_publisher(tmp_path, clock=clock, discovery=discovery)
+    calls: list[dict[str, object]] = []
+    start_results: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def run_ensure_active(name: str) -> None:
+        start_results[name] = publisher.ensure_active()
+
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            make_output=False,
+            returncode=1,
+            stderr_text="Too many clients already connected.\n",
+        ),
+    ):
+        first_thread = Thread(target=run_ensure_active, args=("first",))
+        second_thread = Thread(target=run_ensure_active, args=("second",))
+        first_thread.start()
+        assert discovery.started.wait(timeout=0.2)
+        second_thread.start()
+        assert clock.wait_started.wait(timeout=0.2)
+
+        # When: The in-flight activation fails with a session-budget refusal
+        discovery.release.set()
+        first_thread.join(timeout=1.0)
+        second_thread.join(timeout=1.0)
+
+    # Then: The waiting caller receives the same refusal without starting ffmpeg again
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    first_result = start_results["first"]
+    second_result = start_results["second"]
+    assert isinstance(first_result, LivePublisherStartRefusal)
+    assert first_result.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert second_result == first_result
+    assert len(calls) == 1
+    assert publisher.status().state == LivePublisherState.ERROR
+
+
 def test_recording_priority_preempts_slow_probe_before_spawn(tmp_path: Path) -> None:
     """Recording activation should interrupt startup before ffmpeg spawn when probing is slow."""
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from pathlib import Path
+from threading import Event, Thread
 from typing import Literal, Protocol, cast
 from unittest.mock import patch
 
@@ -506,3 +508,66 @@ def test_startup_requires_running_process_when_ready_deadline_expires(tmp_path: 
     assert status.state == LivePublisherState.ERROR
     assert status.last_error == "Preview publisher exited before producing HLS output"
     assert not (tmp_path / "homesec" / "Front_Door_1").exists()
+
+
+def test_recording_priority_preempts_slow_startup(tmp_path: Path) -> None:
+    """Recording activation should preempt a slow preview startup without blocking."""
+
+    # Given: A publisher whose ffmpeg process stays alive but never produces HLS output
+    class _ThreadClock:
+        def now(self) -> float:
+            return time.monotonic()
+
+        def sleep(self, seconds: float) -> None:
+            time.sleep(seconds)
+
+    publisher = _make_publisher(tmp_path, clock=_ThreadClock())
+    publisher._startup_timeout_s = 0.5
+    calls: list[dict[str, object]] = []
+    spawned = Event()
+    start_result: dict[str, LivePublisherStatus | LivePublisherStartRefusal] = {}
+
+    def on_spawn(proc: FakeProc, cmd: list[str]) -> None:
+        _ = proc
+        _ = cmd
+        spawned.set()
+
+    def run_ensure_active() -> None:
+        with patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(
+                calls,
+                make_output=False,
+                on_spawn=on_spawn,
+            ),
+        ):
+            start_result["result"] = publisher.ensure_active()
+
+    ensure_thread = Thread(target=run_ensure_active)
+    ensure_thread.start()
+    assert spawned.wait(timeout=0.2)
+
+    sync_completed = Event()
+
+    # When: Recording becomes active while startup is still waiting for HLS readiness
+    def run_sync_recording_active() -> None:
+        publisher.sync_recording_active(True)
+        sync_completed.set()
+
+    sync_thread = Thread(target=run_sync_recording_active)
+    sync_thread.start()
+
+    # Then: Recording-priority preemption does not block on the startup wait loop
+    sync_thread.join(timeout=0.3)
+    ensure_thread.join(timeout=0.3)
+
+    assert sync_completed.is_set()
+    assert not sync_thread.is_alive()
+    assert not ensure_thread.is_alive()
+    result = start_result["result"]
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    proc = calls[0]["proc"]
+    assert isinstance(proc, FakeProc)
+    assert proc.terminate_calls == 1
+    assert publisher.status() == LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -285,6 +285,35 @@ def test_auto_codec_prefers_copy_for_h264_and_aac(tmp_path: Path) -> None:
     assert "libx264" not in cmd
 
 
+def test_auto_codec_transcodes_mp4_safe_but_hls_unsafe_audio(tmp_path: Path) -> None:
+    """auto codec mode should transcode non-browser HLS audio even if recording can copy it."""
+    # Given: A publisher whose source probe reports H.264 video and AC-3 audio
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="ac3")),
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The preview keeps video copy but transcodes audio to AAC for browser playback
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "copy"
+    assert cmd[cmd.index("-c:a") + 1] == "aac"
+    assert cmd[cmd.index("-b:a") + 1] == "128k"
+
+
 def test_auto_codec_transcodes_non_browser_safe_source(tmp_path: Path) -> None:
     """auto codec mode should transcode unsupported source codecs to browser-safe outputs."""
     # Given: A publisher whose source probe reports H.265 video and PCMA audio


### PR DESCRIPTION
## Summary
- implement the runtime-owned RTSP HLS live publisher behind the existing preview seam
- manage playlist and segment lifecycle in the configured storage directory, including stale window cleanup, stop cleanup, and idle shutdown
- keep preview work isolated from recording and motion detection, including recording-priority refusal and browser-safe codec selection for the ffmpeg path
- add RTSP-focused tests covering startup, codec planning, idle stop, recording priority, stop cleanup, and failure mapping

## Why
The preview seam and config surface already exist, but the runtime-owned publisher path was still a noop. This fills in the v1 HLS runtime behavior without expanding the control-plane or API surface.

## Validation
- `uv run pytest -q tests/homesec/rtsp/test_live_publisher.py tests/homesec/rtsp/test_runtime.py`
- `uv run python -m mypy src/homesec/sources/rtsp/live_publisher.py tests/homesec/rtsp/test_live_publisher.py`
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check`

## Notes
- Stacked on `codex/preview-foundation`
- Ticket: https://www.notion.so/34ad8336c59f81ab82ffd12a8b722569
