### PR TITLE
docs: add preview deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ See [`config/example.yaml`](config/example.yaml) for a complete reference of all
 - **Secrets**: Never put secrets in YAML. Use env vars (`*_env`) and set them in your shell or `.env`.
 - **Notifiers**: Notifiers are optional. With no enabled notifiers, alert decisions are still evaluated and recorded, but no external notifications are sent.
 - **YOLO Classes**: Built-in classes include `person`, `car`, `truck`, `motorcycle`, `bicycle`, `dog`, `cat`, `bird`, `backpack`, `handbag`, `suitcase`.
-- **Preview storage**: For HLS live preview output (when available), put `preview.config.storage_dir` on tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
+- **Preview storage**: `preview.config.storage_dir` is scratch space for HLS live preview output (currently not wired in yet). Prefer tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
 
 After installation, the `homesec` command is available:
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ See [`config/example.yaml`](config/example.yaml) for a complete reference of all
 - **Secrets**: Never put secrets in YAML. Use env vars (`*_env`) and set them in your shell or `.env`.
 - **Notifiers**: Notifiers are optional. With no enabled notifiers, alert decisions are still evaluated and recorded, but no external notifications are sent.
 - **YOLO Classes**: Built-in classes include `person`, `car`, `truck`, `motorcycle`, `bicycle`, `dog`, `cat`, `bird`, `backpack`, `handbag`, `suitcase`.
+- **Preview storage**: If you enable live preview, put `preview.config.storage_dir` on tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
 
 After installation, the `homesec` command is available:
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ See [`config/example.yaml`](config/example.yaml) for a complete reference of all
 - **Secrets**: Never put secrets in YAML. Use env vars (`*_env`) and set them in your shell or `.env`.
 - **Notifiers**: Notifiers are optional. With no enabled notifiers, alert decisions are still evaluated and recorded, but no external notifications are sent.
 - **YOLO Classes**: Built-in classes include `person`, `car`, `truck`, `motorcycle`, `bicycle`, `dog`, `cat`, `bird`, `backpack`, `handbag`, `suitcase`.
-- **Preview storage**: If you enable live preview, put `preview.config.storage_dir` on tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
+- **Preview storage**: For HLS live preview output (when available), put `preview.config.storage_dir` on tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
 
 After installation, the `homesec` command is available:
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ See [`config/example.yaml`](config/example.yaml) for a complete reference of all
 - **Secrets**: Never put secrets in YAML. Use env vars (`*_env`) and set them in your shell or `.env`.
 - **Notifiers**: Notifiers are optional. With no enabled notifiers, alert decisions are still evaluated and recorded, but no external notifications are sent.
 - **YOLO Classes**: Built-in classes include `person`, `car`, `truck`, `motorcycle`, `bicycle`, `dog`, `cat`, `bird`, `backpack`, `handbag`, `suitcase`.
-- **Preview storage**: `preview.config.storage_dir` is scratch space for HLS live preview output (currently not wired in yet). Prefer tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
+- **Preview storage**: `preview.config.storage_dir` is scratch space for HLS live preview output (currently unused; no publisher backend is wired in yet). Prefer tmpfs and keep it separate from `recordings/` and durable storage. See [`docs/preview-deployment.md`](docs/preview-deployment.md).
 
 After installation, the `homesec` command is available:
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -96,7 +96,7 @@ state_store:
   dsn_env: DB_DSN  # e.g., postgresql+asyncpg://user:pass@localhost:5432/homesec
 
 # =============================================================================
-# Preview - Live preview config contract (v1 HLS; output may be unavailable until a publisher backend is wired in)
+# Preview - Live preview config contract (v1 HLS; output is currently unavailable until a publisher backend is wired in)
 # =============================================================================
 preview:
   enabled: false

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -96,7 +96,7 @@ state_store:
   dsn_env: DB_DSN  # e.g., postgresql+asyncpg://user:pass@localhost:5432/homesec
 
 # =============================================================================
-# Preview - Live preview config contract (v1 HLS; output may be unavailable)
+# Preview - Live preview config contract (v1 HLS; output may be unavailable until a publisher backend is wired in)
 # =============================================================================
 preview:
   enabled: false
@@ -106,7 +106,7 @@ preview:
   config:
     segment_duration_ms: 1000  # Lower latency means more segment churn
     live_window_segments: 4    # Total window ~= segment_duration_ms * segment count
-    storage_dir: /tmp/homesec-preview  # Prefer tmpfs; keep separate from recordings
+    storage_dir: /tmp/homesec-preview  # Prefer tmpfs; keep separate from recordings (unused if preview is unavailable)
     audio_enabled: true
     audio_codec: auto
     video_codec: auto

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -96,7 +96,7 @@ state_store:
   dsn_env: DB_DSN  # e.g., postgresql+asyncpg://user:pass@localhost:5432/homesec
 
 # =============================================================================
-# Preview - Optional live preview served directly by HomeSec (v1 HLS)
+# Preview - Live preview config contract (v1 HLS; output may be unavailable)
 # =============================================================================
 preview:
   enabled: false

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -104,9 +104,9 @@ preview:
   token_ttl_s: 60
   idle_timeout_s: 30.0
   config:
-    segment_duration_ms: 1000
-    live_window_segments: 4
-    storage_dir: /tmp/homesec-preview  # Mount tmpfs here when possible
+    segment_duration_ms: 1000  # Lower latency means more segment churn
+    live_window_segments: 4    # Total window ~= segment_duration_ms * segment count
+    storage_dir: /tmp/homesec-preview  # Prefer tmpfs; keep separate from recordings
     audio_enabled: true
     audio_codec: auto
     video_codec: auto

--- a/docs/preview-deployment.md
+++ b/docs/preview-deployment.md
@@ -83,6 +83,19 @@ services:
       - /tmp/homesec-preview:size=64m
 ```
 
+Note: the HomeSec Docker image runs as a non-root `homesec` user. If you hit
+permission errors (or you want to lock down access), set tmpfs ownership and mode
+explicitly:
+
+```yaml
+services:
+  homesec:
+    tmpfs:
+      - /tmp/homesec-preview:uid=1000,gid=1000,mode=1700,size=64m
+```
+
+Replace `uid`/`gid` with the user/group running HomeSec inside the container.
+
 If you change the path in config, change the tmpfs mount path too.
 
 ## Bare-Metal Guidance
@@ -95,6 +108,7 @@ Operator checklist:
 
 - create the directory before starting HomeSec
 - ensure the HomeSec process can read and write it
+- restrict permissions; HLS playlists and segments contain camera audio/video
 - keep it on tmpfs, not the same persistent disk used for clips
 - size it for your expected number of concurrent previews
 
@@ -102,6 +116,7 @@ Operator checklist:
 
 - Preview storage is disposable. Losing it interrupts live preview but should not
   delete recorded clips.
+- Treat preview storage as sensitive media. Keep it private to the HomeSec process.
 - Keep preview storage independent from `output_dir`, uploaded clip storage, and
   Postgres data paths.
 - Larger `segment_duration_ms` or `live_window_segments` values increase memory

--- a/docs/preview-deployment.md
+++ b/docs/preview-deployment.md
@@ -1,0 +1,98 @@
+# Preview Deployment Notes
+
+HomeSec preview v1 writes a short HLS live window to `preview.config.storage_dir`.
+That directory is for ephemeral playlists and segments, not durable recordings. Keep
+it separate from `recordings/` and any long-term storage backend.
+
+## Recommended Storage
+
+Use a tmpfs mount for `preview.config.storage_dir` when possible.
+
+Why:
+
+- preview segments are short-lived scratch data
+- tmpfs avoids unnecessary disk churn
+- stale preview data disappears automatically on restart
+- preview I/O stays isolated from recording and upload paths
+
+The default preview storage path is:
+
+```yaml
+preview:
+  config:
+    storage_dir: /tmp/homesec-preview
+```
+
+If you use a different mount point, keep the config value aligned with the mounted
+path inside the HomeSec process or container.
+
+## Sizing Guidance
+
+Preview footprint scales with:
+
+- `segment_duration_ms`
+- `live_window_segments`
+- number of simultaneously active preview publishers
+- actual encoded preview bitrate
+
+Approximate active-window size per camera:
+
+```text
+encoded_bitrate_bytes_per_second
+  * segment_duration_seconds
+  * live_window_segments
+```
+
+The exact bitrate depends on source content and codec handling:
+
+- `video_codec: copy` preserves the upstream video bitrate
+- `video_codec: h264` or `audio_codec: aac` can reduce or increase output size
+  depending on the source
+
+At the default `1000 ms` segments and `4` retained segments, a conservative
+starting point is `64 MiB` of tmpfs per actively previewed camera. Increase that
+if you:
+
+- copy high-bitrate upstream video
+- keep a longer live window
+- preview multiple cameras at the same time
+
+## Docker Guidance
+
+The bundled `docker-compose.yml` does not add a preview tmpfs mount yet. If you
+enable preview in Docker, add a tmpfs mount that matches `preview.config.storage_dir`.
+
+Example:
+
+```yaml
+services:
+  homesec:
+    tmpfs:
+      - /tmp/homesec-preview:size=64m
+```
+
+If you change the path in config, change the tmpfs mount path too.
+
+## Bare-Metal Guidance
+
+On bare-metal Linux, point `preview.config.storage_dir` at a tmpfs-backed path
+such as `/run/homesec-preview`, `/dev/shm/homesec-preview`, or a dedicated tmpfs
+mount managed by your init system.
+
+Operator checklist:
+
+- create the directory before starting HomeSec
+- ensure the HomeSec process can read and write it
+- keep it on tmpfs, not the same persistent disk used for clips
+- size it for your expected number of concurrent previews
+
+## Operational Notes
+
+- Preview storage is disposable. Losing it interrupts live preview but should not
+  delete recorded clips.
+- Keep preview storage independent from `output_dir`, uploaded clip storage, and
+  Postgres data paths.
+- Larger `segment_duration_ms` or `live_window_segments` values increase memory
+  use linearly.
+- If preview storage fills up, treat that as a preview-capacity issue first. Do
+  not solve it by moving preview segments into the same durable path as recordings.

--- a/docs/preview-deployment.md
+++ b/docs/preview-deployment.md
@@ -1,13 +1,16 @@
 # Preview Deployment Notes
 
-`preview.config.storage_dir` is the scratch directory used by the HLS preview publisher
-for short-lived playlists and segments. It is not durable clip storage. Keep it
+`preview.config.storage_dir` is a scratch directory intended for HLS preview output
+(short-lived playlists and segments). It is not durable clip storage. Keep it
 separate from `recordings/` and any long-term storage backend.
 
-Preview artifacts are only written when a preview publisher is available and active.
-If preview is disabled (or the source backend does not support preview yet), this
-directory will be unused. When preview is unavailable, activation may be refused as
-`preview_temporarily_unavailable` and nothing will be written.
+Current implementation status: HomeSec does not yet wire in a real HLS preview
+publisher. For RTSP sources, preview activation is currently refused as
+`preview_temporarily_unavailable`, and nothing will be written to this directory.
+
+Once a preview publisher is available and active, artifacts are only written while
+preview is active. If preview is disabled (or the source backend does not support
+preview yet), this directory will be unused.
 
 ## Recommended Storage
 
@@ -18,8 +21,9 @@ Why:
 - preview segments are short-lived scratch data
 - tmpfs avoids unnecessary disk churn
 - preview I/O stays isolated from recording and upload paths
-- tmpfs data is disposable and cleared on host reboot
-- capping size prevents preview from consuming unbounded RAM
+- tmpfs data is disposable and cleared on host reboot or container restart
+- tmpfs uses RAM (and may count against container memory limits)
+- capping size bounds preview RAM usage
 
 The default preview storage path is:
 

--- a/docs/preview-deployment.md
+++ b/docs/preview-deployment.md
@@ -1,19 +1,25 @@
 # Preview Deployment Notes
 
-HomeSec preview v1 writes a short HLS live window to `preview.config.storage_dir`.
-That directory is for ephemeral playlists and segments, not durable recordings. Keep
-it separate from `recordings/` and any long-term storage backend.
+`preview.config.storage_dir` is the scratch directory used by the HLS preview publisher
+for short-lived playlists and segments. It is not durable clip storage. Keep it
+separate from `recordings/` and any long-term storage backend.
+
+Preview artifacts are only written when a preview publisher is available and active.
+If preview is disabled (or the source backend does not support preview yet), this
+directory will be unused. When preview is unavailable, activation may be refused as
+`preview_temporarily_unavailable` and nothing will be written.
 
 ## Recommended Storage
 
-Use a tmpfs mount for `preview.config.storage_dir` when possible.
+Use a tmpfs mount for `preview.config.storage_dir` when possible, and cap its size.
 
 Why:
 
 - preview segments are short-lived scratch data
 - tmpfs avoids unnecessary disk churn
-- stale preview data disappears automatically on restart
 - preview I/O stays isolated from recording and upload paths
+- tmpfs data is disposable and cleared on host reboot
+- capping size prevents preview from consuming unbounded RAM
 
 The default preview storage path is:
 
@@ -42,6 +48,8 @@ encoded_bitrate_bytes_per_second
   * segment_duration_seconds
   * live_window_segments
 ```
+
+Plan extra headroom for muxing overhead, playlist files, and delete lag.
 
 The exact bitrate depends on source content and codec handling:
 


### PR DESCRIPTION
## Summary
- add operator guidance for preview tmpfs storage and sizing
- document Docker and bare-metal tmpfs recommendations for preview storage_dir
- link the new deployment guidance from the README and example preview config

## Validation
- TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check
