### PR TITLE
fix: bundle preview tmpfs into docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
         condition: service_healthy
     ports:
       - "8081:8081"
+    tmpfs:
+      - /tmp/homesec-preview:size=64m
     volumes:
       - ./config/config.yaml:/config/config.yaml:ro
       - ./.env:/config/.env:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "8081:8081"
     tmpfs:
-      - /tmp/homesec-preview:size=64m
+      - /tmp/homesec-preview:size=${HOMESEC_PREVIEW_TMPFS_SIZE:-256m}
     volumes:
       - ./config/config.yaml:/config/config.yaml:ro
       - ./.env:/config/.env:ro

--- a/docs/preview-deployment.md
+++ b/docs/preview-deployment.md
@@ -78,11 +78,15 @@ directory as tmpfs:
 services:
   homesec:
     tmpfs:
-      - /tmp/homesec-preview:size=64m
+      - /tmp/homesec-preview:size=${HOMESEC_PREVIEW_TMPFS_SIZE:-256m}
 ```
 
-That matches the default `preview.config.storage_dir`. If you change the path in
-config, change the tmpfs mount path too.
+That matches the default `preview.config.storage_dir`. The bundled default is
+`256 MiB`, which is conservative headroom for a few simultaneous previews at the
+default segment/window settings without forcing operators to edit the Compose
+file on day one. If you change the path in config, change the tmpfs mount path
+too. If you know your expected concurrency, set `HOMESEC_PREVIEW_TMPFS_SIZE`
+explicitly in `.env` to match it.
 
 The HomeSec Docker image runs as a non-root `homesec` user created by:
 
@@ -105,7 +109,7 @@ Example with explicit ownership and mode:
 services:
   homesec:
     tmpfs:
-      - /tmp/homesec-preview:uid=1000,gid=1000,mode=1700,size=64m
+      - /tmp/homesec-preview:uid=1000,gid=1000,mode=1700,size=${HOMESEC_PREVIEW_TMPFS_SIZE:-256m}
 ```
 
 Replace `uid`/`gid` with the user/group reported for the image you actually run.

--- a/docs/preview-deployment.md
+++ b/docs/preview-deployment.md
@@ -71,10 +71,8 @@ if you:
 
 ## Docker Guidance
 
-The bundled `docker-compose.yml` does not add a preview tmpfs mount yet. If you
-enable preview in Docker, add a tmpfs mount that matches `preview.config.storage_dir`.
-
-Example:
+The bundled `docker-compose.yml` now mounts the default preview scratch
+directory as tmpfs:
 
 ```yaml
 services:
@@ -83,9 +81,25 @@ services:
       - /tmp/homesec-preview:size=64m
 ```
 
-Note: the HomeSec Docker image runs as a non-root `homesec` user. If you hit
-permission errors (or you want to lock down access), set tmpfs ownership and mode
-explicitly:
+That matches the default `preview.config.storage_dir`. If you change the path in
+config, change the tmpfs mount path too.
+
+The HomeSec Docker image runs as a non-root `homesec` user created by:
+
+```dockerfile
+RUN useradd --create-home --shell /bin/bash homesec
+```
+
+On the current `python:3.14-slim-bookworm` base image, that resolves to
+`uid=1000,gid=1000`, but the Dockerfile does not pin numeric IDs. If you want
+to set tmpfs ownership and mode explicitly, inspect the image you deploy instead
+of assuming those numbers will stay fixed:
+
+```bash
+docker run --rm --entrypoint id leva/homesec:latest homesec
+```
+
+Example with explicit ownership and mode:
 
 ```yaml
 services:
@@ -94,9 +108,7 @@ services:
       - /tmp/homesec-preview:uid=1000,gid=1000,mode=1700,size=64m
 ```
 
-Replace `uid`/`gid` with the user/group running HomeSec inside the container.
-
-If you change the path in config, change the tmpfs mount path too.
+Replace `uid`/`gid` with the user/group reported for the image you actually run.
 
 ## Bare-Metal Guidance
 


### PR DESCRIPTION
## Summary
- add the default preview tmpfs mount to the bundled `homesec` compose service
- update the preview deployment docs so they describe the bundled compose behavior
- document the current container user setup without hardcoding unpinned UID/GID assumptions into compose

## Why
Ticket #103 requires the preview scratch tmpfs described in the docs to be bundled directly into `docker-compose.yml`. The docs in this stacked branch still said operators had to add that mount manually.

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check`
