### PR TITLE
fix: prefer hardware encoder for HLS preview

### DIFF
--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -640,6 +640,7 @@ class RTSPSource(ThreadedClipSource):
             audio_enabled=hls_config.audio_enabled,
             audio_codec=hls_config.audio_codec,
             video_codec=hls_config.video_codec,
+            hwaccel_config=self.hwaccel_config,
             rtsp_connect_timeout_s=self.rtsp_connect_timeout_s,
             rtsp_io_timeout_s=self.rtsp_io_timeout_s,
             clock=self._clock,

--- a/src/homesec/sources/rtsp/hardware.py
+++ b/src/homesec/sources/rtsp/hardware.py
@@ -189,7 +189,12 @@ class HardwareAccelDetector:
         except subprocess.TimeoutExpired:
             return True
         except Exception as exc:
-            logger.warning("VAAPI check failed: %s", exc, exc_info=True)
+            logger.warning(
+                "Hardware decode check failed for %s: %s",
+                config.hwaccel or "software",
+                exc,
+                exc_info=True,
+            )
             return False
 
     @staticmethod

--- a/src/homesec/sources/rtsp/hardware.py
+++ b/src/homesec/sources/rtsp/hardware.py
@@ -22,6 +22,15 @@ class HardwareAccelConfig:
         return self.hwaccel is not None
 
 
+@dataclass(frozen=True, slots=True)
+class H264HardwareEncoder:
+    """Preview H.264 encoder derived from an ffmpeg hardware backend."""
+
+    ffmpeg_encoder: str
+    ffmpeg_global_args: tuple[str, ...] = ()
+    requires_hwupload: bool = False
+
+
 class HardwareAccelDetector:
     """Detect available hardware acceleration options for ffmpeg."""
 
@@ -62,6 +71,21 @@ class HardwareAccelDetector:
         return HardwareAccelConfig(hwaccel=None)
 
     @staticmethod
+    def select_h264_encoder(config: HardwareAccelConfig) -> H264HardwareEncoder | None:
+        """Choose a matching H.264 hardware encoder when ffmpeg supports it."""
+        candidate = HardwareAccelDetector._candidate_h264_encoder(config)
+        if candidate is None:
+            return None
+        if HardwareAccelDetector._test_encoder(candidate.ffmpeg_encoder):
+            return candidate
+        logger.info(
+            "Hardware encoder %s unavailable for hwaccel=%s; using software encoding",
+            candidate.ffmpeg_encoder,
+            config.hwaccel,
+        )
+        return None
+
+    @staticmethod
     def _test_hwaccel(method: str) -> bool:
         """Test if a hardware acceleration method is available in ffmpeg."""
         try:
@@ -75,6 +99,46 @@ class HardwareAccelDetector:
             return method in result.stdout
         except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.SubprocessError):
             return False
+
+    @staticmethod
+    def _test_encoder(encoder: str) -> bool:
+        """Test if a named ffmpeg encoder is available."""
+        try:
+            result = subprocess.run(
+                ["ffmpeg", "-hide_banner", "-encoders"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+            output = f"{result.stdout}\n{result.stderr}"
+            return encoder in output
+        except (subprocess.TimeoutExpired, FileNotFoundError, subprocess.SubprocessError):
+            return False
+
+    @staticmethod
+    def _candidate_h264_encoder(config: HardwareAccelConfig) -> H264HardwareEncoder | None:
+        """Map a detected hwaccel backend to the corresponding H.264 encoder."""
+        hwaccel = (config.hwaccel or "").strip().lower()
+
+        match hwaccel:
+            case "vaapi":
+                ffmpeg_global_args: tuple[str, ...] = ()
+                if config.hwaccel_device:
+                    ffmpeg_global_args = ("-vaapi_device", config.hwaccel_device)
+                return H264HardwareEncoder(
+                    ffmpeg_encoder="h264_vaapi",
+                    ffmpeg_global_args=ffmpeg_global_args,
+                    requires_hwupload=True,
+                )
+            case "cuda":
+                return H264HardwareEncoder(ffmpeg_encoder="h264_nvenc")
+            case "videotoolbox":
+                return H264HardwareEncoder(ffmpeg_encoder="h264_videotoolbox")
+            case "qsv":
+                return H264HardwareEncoder(ffmpeg_encoder="h264_qsv")
+            case _:
+                return None
 
     @staticmethod
     def _test_decode(rtsp_url: str, config: HardwareAccelConfig) -> bool:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -29,6 +29,11 @@ from homesec.sources.rtsp.discovery import (
     ProbeStreamInfo,
     build_camera_key,
 )
+from homesec.sources.rtsp.hardware import (
+    H264HardwareEncoder,
+    HardwareAccelConfig,
+    HardwareAccelDetector,
+)
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
     _format_cmd,
@@ -111,8 +116,11 @@ class StreamDiscovery(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class _CodecPlan:
+    codec_name: str
+    ffmpeg_global_args: tuple[str, ...]
     video_args: tuple[str, ...]
     audio_args: tuple[str, ...]
+    uses_hardware_encoder: bool = False
 
 
 class HLSLivePublisher(LivePublisher):
@@ -132,6 +140,7 @@ class HLSLivePublisher(LivePublisher):
         video_codec: Literal["auto", "copy", "h264"] = "auto",
         rtsp_connect_timeout_s: float,
         rtsp_io_timeout_s: float,
+        hwaccel_config: HardwareAccelConfig | None = None,
         clock: Clock | None = None,
         timeout_capabilities: RTSPTimeoutCapabilities | None = None,
         stream_discovery: StreamDiscovery | None = None,
@@ -156,6 +165,7 @@ class HLSLivePublisher(LivePublisher):
         self._audio_enabled = bool(audio_enabled)
         self._audio_codec = audio_codec
         self._video_codec = video_codec
+        self._hwaccel_config = hwaccel_config or HardwareAccelConfig(hwaccel=None)
         self._rtsp_connect_timeout_s = float(rtsp_connect_timeout_s)
         self._rtsp_io_timeout_s = float(rtsp_io_timeout_s)
         self._clock = clock or SystemClock()
@@ -326,7 +336,7 @@ class HLSLivePublisher(LivePublisher):
         *,
         start_token: int,
     ) -> LivePublisherStatus | LivePublisherStartRefusal:
-        codec_plan = self._build_codec_plan()
+        codec_plans = self._build_codec_plans()
         timeout_args = self._timeout_capabilities.build_ffmpeg_timeout_args_for_user_flags(
             connect_timeout_s=self._rtsp_connect_timeout_s,
             io_timeout_s=self._rtsp_io_timeout_s,
@@ -334,129 +344,147 @@ class HLSLivePublisher(LivePublisher):
         )
 
         attempts = _build_timeout_attempts(timeout_args)
-        last_refusal: LivePublisherStartRefusal | None = None
 
-        for label, timeout_attempt_args in attempts:
-            attempt_refusal: LivePublisherStartRefusal | None = None
-            timeout_option_error = False
-            stop_error: str | None = None
-            with self._lock:
-                if self._start_was_cancelled_locked(start_token):
-                    self._stop_locked(clear_error=True)
-                    return self._last_cancellation_result
+        for codec_plan in codec_plans:
+            codec_refusal: LivePublisherStartRefusal | None = None
+            codec_failure_error = ""
 
-                if self._recording_active:
-                    return self._recording_priority_refusal()
+            for label, timeout_attempt_args in attempts:
+                attempt_refusal: LivePublisherStartRefusal | None = None
+                timeout_option_error = False
+                stop_error: str | None = None
+                attempt_last_error = ""
+                with self._lock:
+                    if self._start_was_cancelled_locked(start_token):
+                        self._stop_locked(clear_error=True)
+                        return self._last_cancellation_result
 
-                if not self._prepare_live_dir_locked():
-                    return self._set_error_locked(
-                        reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                        message="Preview storage directory is unavailable",
-                        last_error="Preview storage directory could not be prepared",
+                    if self._recording_active:
+                        return self._recording_priority_refusal()
+
+                    if not self._prepare_live_dir_locked():
+                        return self._set_error_locked(
+                            reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                            message="Preview storage directory is unavailable",
+                            last_error="Preview storage directory could not be prepared",
+                        )
+
+                    cmd = self._build_ffmpeg_cmd(
+                        codec_plan=codec_plan,
+                        timeout_args=timeout_attempt_args,
+                    )
+                    self._log_ffmpeg_cmd(label=f"{codec_plan.codec_name}:{label}", cmd=cmd)
+
+                    try:
+                        stderr_handle = open(self._stderr_log_path, "w", encoding="utf-8")
+                    except Exception as exc:
+                        logger.warning("Failed to open preview stderr log: %s", exc, exc_info=True)
+                        return self._set_error_locked(
+                            reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                            message="Preview stderr log could not be created",
+                            last_error=f"Preview stderr log create failed: {type(exc).__name__}",
+                        )
+
+                    try:
+                        process = subprocess.Popen(
+                            cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=stderr_handle,
+                            start_new_session=True,
+                        )
+                    except Exception as exc:
+                        stderr_handle.close()
+                        logger.warning("Failed to start preview ffmpeg: %s", exc, exc_info=True)
+                        return self._set_error_locked(
+                            reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
+                            message="Preview ffmpeg could not be started",
+                            last_error=f"Preview ffmpeg start failed: {type(exc).__name__}",
+                        )
+
+                    self._process = process
+                    self._stderr_handle = stderr_handle
+                    started_now = self._clock.now()
+                    self._mark_activity_locked(now=started_now)
+                    self._status = LivePublisherStatus(
+                        state=LivePublisherState.STARTING,
+                        viewer_count=self._viewer_count_locked(now=started_now),
+                        idle_shutdown_at=started_now + self._idle_timeout_s,
                     )
 
-                cmd = self._build_ffmpeg_cmd(
-                    codec_plan=codec_plan,
-                    timeout_args=timeout_attempt_args,
-                )
-                self._log_ffmpeg_cmd(label=label, cmd=cmd)
+                    if self._wait_until_ready_locked():
+                        if label == "timeouts":
+                            self._timeout_capabilities.note_ffmpeg_timeout_success()
+                        ready_now = self._clock.now()
+                        self._mark_activity_locked(now=ready_now)
+                        self._ensure_maintenance_thread_started_locked()
+                        self._status = self._build_running_status_locked(
+                            now=ready_now,
+                            state=LivePublisherState.READY,
+                            degraded_reason=None,
+                        )
+                        return self._status
 
-                try:
-                    stderr_handle = open(self._stderr_log_path, "w", encoding="utf-8")
-                except Exception as exc:
-                    logger.warning("Failed to open preview stderr log: %s", exc, exc_info=True)
-                    return self._set_error_locked(
-                        reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                        message="Preview stderr log could not be created",
-                        last_error=f"Preview stderr log create failed: {type(exc).__name__}",
+                    if self._start_was_cancelled_locked(start_token):
+                        self._stop_locked(clear_error=True)
+                        return self._last_cancellation_result
+
+                    if self._recording_active:
+                        self._stop_locked(clear_error=True)
+                        return self._recording_priority_refusal()
+
+                    stderr_tail = self._read_stderr_tail_locked()
+                    timeout_option_error = (
+                        bool(stderr_tail)
+                        and label == "timeouts"
+                        and (_is_timeout_option_error(stderr_tail))
                     )
+                    stop_error = self._stop_locked(clear_error=False)
 
-                try:
-                    process = subprocess.Popen(
-                        cmd,
-                        stdout=subprocess.DEVNULL,
-                        stderr=stderr_handle,
-                        start_new_session=True,
-                    )
-                except Exception as exc:
-                    stderr_handle.close()
-                    logger.warning("Failed to start preview ffmpeg: %s", exc, exc_info=True)
-                    return self._set_error_locked(
-                        reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
-                        message="Preview ffmpeg could not be started",
-                        last_error=f"Preview ffmpeg start failed: {type(exc).__name__}",
-                    )
+                    if stop_error is not None:
+                        stderr_tail = f"{stderr_tail}; {stop_error}" if stderr_tail else stop_error
 
-                self._process = process
-                self._stderr_handle = stderr_handle
-                started_now = self._clock.now()
-                self._mark_activity_locked(now=started_now)
-                self._status = LivePublisherStatus(
-                    state=LivePublisherState.STARTING,
-                    viewer_count=self._viewer_count_locked(now=started_now),
-                    idle_shutdown_at=started_now + self._idle_timeout_s,
-                )
+                    if not timeout_option_error or stop_error is not None:
+                        refusal_reason = _classify_start_refusal(stderr_tail)
+                        message = (
+                            "Preview could not start because the camera session budget is exhausted"
+                            if refusal_reason is LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+                            else "Preview publisher failed to become ready"
+                        )
+                        attempt_last_error = (
+                            stderr_tail or "Preview publisher exited before producing HLS output"
+                        )
+                        attempt_refusal = self._set_error_locked(
+                            reason=refusal_reason,
+                            message=message,
+                            last_error=attempt_last_error,
+                        )
 
-                if self._wait_until_ready_locked():
-                    if label == "timeouts":
-                        self._timeout_capabilities.note_ffmpeg_timeout_success()
-                    ready_now = self._clock.now()
-                    self._mark_activity_locked(now=ready_now)
-                    self._ensure_maintenance_thread_started_locked()
-                    self._status = self._build_running_status_locked(
-                        now=ready_now,
-                        state=LivePublisherState.READY,
-                        degraded_reason=None,
-                    )
-                    return self._status
+                if timeout_option_error and stop_error is None:
+                    changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
+                    if changed:
+                        logger.warning(
+                            "Preview ffmpeg timeout options unsupported; retrying without timeout options"
+                        )
+                    continue
 
-                if self._start_was_cancelled_locked(start_token):
-                    self._stop_locked(clear_error=True)
-                    return self._last_cancellation_result
+                if attempt_refusal is not None:
+                    codec_refusal = attempt_refusal
+                    codec_failure_error = attempt_last_error
+                    break
 
-                if self._recording_active:
-                    self._stop_locked(clear_error=True)
-                    return self._recording_priority_refusal()
-
-                stderr_tail = self._read_stderr_tail_locked()
-                timeout_option_error = (
-                    bool(stderr_tail)
-                    and label == "timeouts"
-                    and (_is_timeout_option_error(stderr_tail))
-                )
-                stop_error = self._stop_locked(clear_error=False)
-
-                if stop_error is not None:
-                    stderr_tail = f"{stderr_tail}; {stop_error}" if stderr_tail else stop_error
-
-                if not timeout_option_error or stop_error is not None:
-                    refusal_reason = _classify_start_refusal(stderr_tail)
-                    message = (
-                        "Preview could not start because the camera session budget is exhausted"
-                        if refusal_reason is LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
-                        else "Preview publisher failed to become ready"
-                    )
-                    attempt_refusal = self._set_error_locked(
-                        reason=refusal_reason,
-                        message=message,
-                        last_error=stderr_tail
-                        or "Preview publisher exited before producing HLS output",
-                    )
-
-            if timeout_option_error and stop_error is None:
-                changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
-                if changed:
-                    logger.warning(
-                        "Preview ffmpeg timeout options unsupported; retrying without timeout options"
-                    )
+            if codec_refusal is None:
                 continue
 
-            if attempt_refusal is not None:
-                last_refusal = attempt_refusal
-                break
+            if _should_retry_with_software_codec(codec_plan, codec_refusal):
+                logger.warning(
+                    "Preview hardware encoder failed, retrying with software: camera=%s encoder=%s error=%s",
+                    self._camera_name,
+                    codec_plan.codec_name,
+                    codec_failure_error,
+                )
+                continue
 
-        if last_refusal is not None:
-            return last_refusal
+            return codec_refusal
 
         with self._lock:
             return self._set_error_locked(
@@ -518,34 +546,63 @@ class HLSLivePublisher(LivePublisher):
             degraded_reason=None,
         )
 
-    def _build_codec_plan(self) -> _CodecPlan:
+    def _build_codec_plans(self) -> tuple[_CodecPlan, ...]:
         stream_info = self._probe_stream_info()
-        video_args: tuple[str, ...]
-        audio_args: tuple[str, ...]
+        audio_args = _build_audio_codec_args(
+            audio_enabled=self._audio_enabled,
+            audio_codec=self._audio_codec,
+            stream_info=stream_info,
+        )
 
         if self._video_codec == "copy":
-            video_args = ("-c:v", "copy")
-        elif self._video_codec == "h264":
-            video_args = _h264_transcode_args(self._segment_duration_s)
-        elif stream_info is not None and (stream_info.video_codec or "").lower() == "h264":
-            video_args = ("-c:v", "copy")
-        else:
-            video_args = _h264_transcode_args(self._segment_duration_s)
+            return (
+                _CodecPlan(
+                    codec_name="copy",
+                    ffmpeg_global_args=(),
+                    video_args=("-c:v", "copy"),
+                    audio_args=audio_args,
+                ),
+            )
 
-        if not self._audio_enabled:
-            audio_args = ("-an",)
-        elif self._audio_codec == "copy":
-            audio_args = ("-map", "0:a:0?", "-c:a", "copy")
-        elif self._audio_codec == "aac":
-            audio_args = ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
-        elif stream_info is not None and _is_hls_browser_audio_copy_compatible(
-            stream_info.audio_codec
-        ):
-            audio_args = ("-map", "0:a:0?", "-c:a", "copy")
-        else:
-            audio_args = ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
+        if self._video_codec == "auto" and stream_info is not None:
+            if (stream_info.video_codec or "").strip().lower() == "h264":
+                return (
+                    _CodecPlan(
+                        codec_name="copy",
+                        ffmpeg_global_args=(),
+                        video_args=("-c:v", "copy"),
+                        audio_args=audio_args,
+                    ),
+                )
 
-        return _CodecPlan(video_args=video_args, audio_args=audio_args)
+        software_plan = _CodecPlan(
+            codec_name="libx264",
+            ffmpeg_global_args=(),
+            video_args=_software_h264_transcode_args(self._segment_duration_s),
+            audio_args=audio_args,
+        )
+        hardware_encoder = HardwareAccelDetector.select_h264_encoder(self._hwaccel_config)
+        if hardware_encoder is None:
+            return (software_plan,)
+
+        logger.info(
+            "Preview will try hardware H.264 encoder: camera=%s encoder=%s",
+            self._camera_name,
+            hardware_encoder.ffmpeg_encoder,
+        )
+        return (
+            _CodecPlan(
+                codec_name=hardware_encoder.ffmpeg_encoder,
+                ffmpeg_global_args=hardware_encoder.ffmpeg_global_args,
+                video_args=_hardware_h264_transcode_args(
+                    hardware_encoder,
+                    self._segment_duration_s,
+                ),
+                audio_args=audio_args,
+                uses_hardware_encoder=True,
+            ),
+            software_plan,
+        )
 
     def _probe_stream_info(self) -> ProbeStreamInfo | None:
         needs_probe = self._video_codec == "auto" or (
@@ -598,6 +655,7 @@ class HLSLivePublisher(LivePublisher):
             "-user_agent",
             "Lavf",
         ]
+        cmd.extend(codec_plan.ffmpeg_global_args)
         cmd.extend(timeout_args)
         cmd.extend(["-fflags", "+genpts+igndts", "-i", self._rtsp_url, "-map", "0:v:0"])
         cmd.extend(codec_plan.video_args)
@@ -956,7 +1014,24 @@ def _is_hls_browser_audio_copy_compatible(audio_codec: str | None) -> bool:
     return audio_codec.strip().lower() in _HLS_BROWSER_COPY_AUDIO_CODECS
 
 
-def _h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:
+def _build_audio_codec_args(
+    *,
+    audio_enabled: bool,
+    audio_codec: Literal["auto", "copy", "aac"],
+    stream_info: ProbeStreamInfo | None,
+) -> tuple[str, ...]:
+    if not audio_enabled:
+        return ("-an",)
+    if audio_codec == "copy":
+        return ("-map", "0:a:0?", "-c:a", "copy")
+    if audio_codec == "aac":
+        return ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
+    if stream_info is not None and _is_hls_browser_audio_copy_compatible(stream_info.audio_codec):
+        return ("-map", "0:a:0?", "-c:a", "copy")
+    return ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
+
+
+def _software_h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:
     return (
         "-c:v",
         "libx264",
@@ -971,3 +1046,30 @@ def _h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:
         "-force_key_frames",
         f"expr:gte(t,n_forced*{_format_segment_duration(segment_duration_s)})",
     )
+
+
+def _hardware_h264_transcode_args(
+    encoder: H264HardwareEncoder,
+    segment_duration_s: float,
+) -> tuple[str, ...]:
+    args: list[str] = []
+    if encoder.requires_hwupload:
+        args.extend(["-vf", "format=nv12,hwupload"])
+    args.extend(
+        [
+            "-c:v",
+            encoder.ffmpeg_encoder,
+            "-force_key_frames",
+            f"expr:gte(t,n_forced*{_format_segment_duration(segment_duration_s)})",
+        ]
+    )
+    return tuple(args)
+
+
+def _should_retry_with_software_codec(
+    codec_plan: _CodecPlan,
+    refusal: LivePublisherStartRefusal,
+) -> bool:
+    if not codec_plan.uses_hardware_encoder:
+        return False
+    return refusal.reason is not LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED

--- a/tests/homesec/rtsp/test_hardware.py
+++ b/tests/homesec/rtsp/test_hardware.py
@@ -109,3 +109,69 @@ def test_detect_returns_software_when_no_accel_available(
 
     # Then: software decode is selected
     assert config.hwaccel is None
+
+
+def test_select_h264_encoder_returns_matching_videotoolbox_encoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Encoder selection should map VideoToolbox decode to VideoToolbox H.264 encode."""
+
+    # Given: a VideoToolbox decode config and ffmpeg encoder support
+    monkeypatch.setattr(
+        "homesec.sources.rtsp.hardware.HardwareAccelDetector._test_encoder",
+        lambda _encoder: True,
+    )
+    config = HardwareAccelConfig(hwaccel="videotoolbox")
+
+    # When: selecting the preview H.264 encoder
+    encoder = HardwareAccelDetector.select_h264_encoder(config)
+
+    # Then: the matching VideoToolbox encoder is returned
+    assert encoder is not None
+    assert encoder.ffmpeg_encoder == "h264_videotoolbox"
+    assert encoder.ffmpeg_global_args == ()
+    assert not encoder.requires_hwupload
+
+
+def test_select_h264_encoder_adds_vaapi_device_and_hwupload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """VAAPI selection should keep the render device and upload requirement explicit."""
+
+    # Given: a VAAPI decode config with a render device and ffmpeg encoder support
+    monkeypatch.setattr(
+        "homesec.sources.rtsp.hardware.HardwareAccelDetector._test_encoder",
+        lambda _encoder: True,
+    )
+    config = HardwareAccelConfig(
+        hwaccel="vaapi",
+        hwaccel_device="/dev/dri/renderD128",
+    )
+
+    # When: selecting the preview H.264 encoder
+    encoder = HardwareAccelDetector.select_h264_encoder(config)
+
+    # Then: the VAAPI encoder keeps the device and upload requirement
+    assert encoder is not None
+    assert encoder.ffmpeg_encoder == "h264_vaapi"
+    assert encoder.ffmpeg_global_args == ("-vaapi_device", "/dev/dri/renderD128")
+    assert encoder.requires_hwupload
+
+
+def test_select_h264_encoder_returns_none_when_encoder_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing ffmpeg encoder support should fall back to software encode."""
+
+    # Given: a CUDA decode config whose matching H.264 encoder is unavailable
+    monkeypatch.setattr(
+        "homesec.sources.rtsp.hardware.HardwareAccelDetector._test_encoder",
+        lambda _encoder: False,
+    )
+    config = HardwareAccelConfig(hwaccel="cuda")
+
+    # When: selecting the preview H.264 encoder
+    encoder = HardwareAccelDetector.select_h264_encoder(config)
+
+    # Then: no hardware encoder is selected
+    assert encoder is None

--- a/tests/homesec/rtsp/test_hardware.py
+++ b/tests/homesec/rtsp/test_hardware.py
@@ -70,6 +70,28 @@ def test_test_decode_treats_timeout_as_success(
     assert ok
 
 
+def test_test_decode_logs_backend_name_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected decode probe failures should log the active backend name."""
+
+    # Given: ffmpeg raises an unexpected runtime error during decode probing
+    def _boom(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr("homesec.sources.rtsp.hardware.subprocess.run", _boom)
+    config = HardwareAccelConfig(hwaccel="cuda")
+
+    # When: testing decode
+    with caplog.at_level("WARNING"):
+        ok = HardwareAccelDetector._test_decode("rtsp://host/stream", config)
+
+    # Then: decode fails closed and the backend name is preserved in logs
+    assert not ok
+    assert "Hardware decode check failed for cuda" in caplog.text
+
+
 def test_check_nvidia_returns_false_on_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -8,6 +8,7 @@ from typing import Literal, Protocol, cast
 from unittest.mock import patch
 
 from homesec.sources.rtsp.discovery import CameraProbeResult, ProbeStreamInfo
+from homesec.sources.rtsp.hardware import HardwareAccelConfig
 from homesec.sources.rtsp.live_publisher import (
     HLSLivePublisher,
     LivePublisherRefusalReason,
@@ -143,6 +144,7 @@ def _make_publisher(
     idle_timeout_s: float = 5.0,
     audio_codec: Literal["auto", "copy", "aac"] = "auto",
     video_codec: Literal["auto", "copy", "h264"] = "auto",
+    hwaccel_config: HardwareAccelConfig | None = None,
     background_maintenance: bool = False,
     maintenance_interval_s: float | None = None,
 ) -> HLSLivePublisher:
@@ -158,6 +160,7 @@ def _make_publisher(
         video_codec=video_codec,
         rtsp_connect_timeout_s=1.0,
         rtsp_io_timeout_s=1.0,
+        hwaccel_config=hwaccel_config,
         clock=clock or FakeClock(),
         stream_discovery=discovery
         or FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="aac")),
@@ -377,6 +380,152 @@ def test_auto_codec_transcodes_non_browser_safe_source(tmp_path: Path) -> None:
     assert cmd[cmd.index("-c:v") + 1] == "libx264"
     assert cmd[cmd.index("-c:a") + 1] == "aac"
     assert cmd[cmd.index("-b:a") + 1] == "128k"
+
+
+def test_transcode_prefers_matching_hardware_encoder_when_available(tmp_path: Path) -> None:
+    """Transcode mode should use the matching hardware H.264 encoder before software."""
+    # Given: A non-H.264 preview source and a supported VideoToolbox encoder
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="hevc", audio_codec="aac")),
+        hwaccel_config=HardwareAccelConfig(hwaccel="videotoolbox"),
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with (
+        patch(
+            "homesec.sources.rtsp.hardware.HardwareAccelDetector._test_encoder",
+            return_value=True,
+        ),
+        patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(calls),
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The preview transcodes with the matching hardware encoder
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "h264_videotoolbox"
+    assert "libx264" not in cmd
+
+
+def test_hardware_transcode_falls_back_to_software_when_encoder_startup_fails(
+    tmp_path: Path,
+) -> None:
+    """Hardware transcode failures should retry once with the software H.264 path."""
+    # Given: A non-H.264 preview source whose supported NVENC path fails immediately
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="hevc", audio_codec="aac")),
+        hwaccel_config=HardwareAccelConfig(hwaccel="cuda"),
+    )
+    calls: list[dict[str, object]] = []
+    hardware_spawn = _fake_popen_factory(
+        calls,
+        make_output=False,
+        returncode=1,
+        stderr_text="Error initializing output stream",
+    )
+    software_spawn = _fake_popen_factory(calls)
+
+    def _fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **kwargs: object,
+    ) -> FakeProc:
+        video_encoder = cmd[cmd.index("-c:v") + 1]
+        if video_encoder == "h264_nvenc":
+            return hardware_spawn(
+                cmd,
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=start_new_session,
+                **kwargs,
+            )
+        return software_spawn(
+            cmd,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=start_new_session,
+            **kwargs,
+        )
+
+    # When: Activating preview
+    with (
+        patch(
+            "homesec.sources.rtsp.hardware.HardwareAccelDetector._test_encoder",
+            return_value=True,
+        ),
+        patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen,
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: Preview retries with libx264 and becomes ready
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    assert len(calls) == 2
+    first_cmd = calls[0]["cmd"]
+    second_cmd = calls[1]["cmd"]
+    assert isinstance(first_cmd, list)
+    assert isinstance(second_cmd, list)
+    assert first_cmd[first_cmd.index("-c:v") + 1] == "h264_nvenc"
+    assert second_cmd[second_cmd.index("-c:v") + 1] == "libx264"
+
+
+def test_hardware_transcode_does_not_retry_software_on_session_budget_exhaustion(
+    tmp_path: Path,
+) -> None:
+    """Session-limit refusals should not hide behind a software fallback retry."""
+    # Given: A non-H.264 preview source whose hardware attempt hits the camera session limit
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="hevc", audio_codec="aac")),
+        hwaccel_config=HardwareAccelConfig(hwaccel="cuda"),
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with (
+        patch(
+            "homesec.sources.rtsp.hardware.HardwareAccelDetector._test_encoder",
+            return_value=True,
+        ),
+        patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(
+                calls,
+                make_output=False,
+                returncode=1,
+                stderr_text="Too many clients already connected",
+            ),
+        ),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: Preview reports the session-budget refusal without retrying software encode
+    assert isinstance(result, LivePublisherStartRefusal)
+    assert result.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert len(calls) == 1
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "h264_nvenc"
 
 
 def test_request_stop_terminates_process_and_removes_live_window(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -319,6 +319,38 @@ def test_hwaccel_detection_used_when_enabled(
     assert source.hwaccel_config.is_available
 
 
+def test_runtime_preview_publisher_receives_hwaccel_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Preview runtime wiring should pass detected hwaccel config into the publisher."""
+
+    # Given: a detected CUDA backend and a runtime preview-enabled source config
+    captured_kwargs: dict[str, object] = {}
+
+    class CapturingLivePublisher(FakeLivePublisher):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__()
+            captured_kwargs.update(kwargs)
+
+    def _detect(_: str) -> HardwareAccelConfig:
+        return HardwareAccelConfig(hwaccel="cuda")
+
+    monkeypatch.setattr("homesec.sources.rtsp.core.HardwareAccelDetector.detect", _detect)
+    monkeypatch.setattr("homesec.sources.rtsp.core.HLSLivePublisher", CapturingLivePublisher)
+    config = _make_config(
+        tmp_path,
+        stream={"disable_hwaccel": False},
+        __runtime_preview__={"enabled": True},
+    )
+
+    # When: initializing the source
+    source = RTSPSource(config, camera_name="cam")
+
+    # Then: the live publisher receives the detected hwaccel config
+    assert isinstance(source._live_publisher, CapturingLivePublisher)
+    assert captured_kwargs["hwaccel_config"] == HardwareAccelConfig(hwaccel="cuda")
+
+
 def test_detect_stream_derived_from_subtype(tmp_path: Path) -> None:
     """Subtype=0 URLs should derive a subtype=1 detect stream."""
     # Given: a subtype=0 main stream with no explicit detect stream


### PR DESCRIPTION
## Summary
- select a matching H.264 hardware encoder for HLS preview transcodes when the RTSP stack has a supported hardware backend
- fall back explicitly to the existing libx264 path when the hardware encoder cannot start, while preserving session-budget refusals
- add focused RTSP hardware and live-publisher tests for encoder mapping, hardware fallback, and session-limit behavior

## Root cause
The preview HLS transcode path always used libx264 whenever video copy was not possible, even when the RTSP stack had already detected a usable hardware backend.

## Validation
- TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check