### PR TITLE
fix: classify RTSP concurrent preview support

### DIFF
--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -496,17 +496,7 @@ class RTSPSource(ThreadedClipSource):
                         "RTSP session-limit preflight failed for %s; falling back to single-stream defaults",
                         self.camera_name,
                     )
-                    fallback = self._build_fallback_preflight_outcome(
-                        err.camera_key,
-                        concurrent_preview_supported=(
-                            False if self._preview_concurrency_requested else None
-                        ),
-                        concurrent_preview_downgrade_reason=(
-                            "concurrent_preview_not_validated_after_session_limit_fallback"
-                            if self._preview_concurrency_requested
-                            else None
-                        ),
-                    )
+                    fallback = self._build_fallback_preflight_outcome(err.camera_key)
                     self._apply_preflight_outcome(fallback)
                 else:
                     logger.error(
@@ -525,13 +515,7 @@ class RTSPSource(ThreadedClipSource):
                     f"{type(result).__name__}"
                 )
 
-    def _build_fallback_preflight_outcome(
-        self,
-        camera_key: str,
-        *,
-        concurrent_preview_supported: bool | None = None,
-        concurrent_preview_downgrade_reason: str | None = None,
-    ) -> CameraPreflightOutcome:
+    def _build_fallback_preflight_outcome(self, camera_key: str) -> CameraPreflightOutcome:
         motion_profile = MotionProfile(input_url=self.rtsp_url, ffmpeg_input_args=[])
         recording_profile = build_default_recording_profile(self.rtsp_url)
         diagnostics = CameraPreflightDiagnostics(
@@ -539,26 +523,14 @@ class RTSPSource(ThreadedClipSource):
             probes=[],
             selected_motion_url=self.rtsp_url,
             selected_recording_url=self.rtsp_url,
-            selected_preview_url=(
-                self.rtsp_url if concurrent_preview_supported is not None else None
-            ),
-            selected_preview_probe_url=(
-                self.rtsp_url
-                if concurrent_preview_supported is not None and self._preview_startup_probe_required
-                else None
-            ),
             selected_recording_profile=recording_profile.profile_id(),
             session_mode="single_stream",
-            concurrent_preview_supported=concurrent_preview_supported,
-            concurrent_preview_downgrade_reason=concurrent_preview_downgrade_reason,
             notes=["Session-limit preflight failed; using single-stream fallback defaults"],
         )
         return CameraPreflightOutcome(
             camera_key=camera_key,
             motion_profile=motion_profile,
             recording_profile=recording_profile,
-            concurrent_preview_supported=concurrent_preview_supported,
-            concurrent_preview_downgrade_reason=concurrent_preview_downgrade_reason,
             diagnostics=diagnostics,
         )
 

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -566,7 +566,14 @@ class RTSPSource(ThreadedClipSource):
                 self.camera_name,
                 reason,
             )
-            self._live_publisher.downgrade_concurrent_preview(reason)
+            try:
+                self._live_publisher.downgrade_concurrent_preview(reason)
+            except Exception as exc:
+                logger.warning(
+                    "Preview concurrent downgrade sync failed: %s",
+                    exc,
+                    exc_info=True,
+                )
 
         if self._motion_rtsp_url != self.detect_rtsp_url:
             # Motion stream is pinned away from detect stream, so runtime fallback probing

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -314,8 +314,10 @@ class RTSPSource(ThreadedClipSource):
             and config.runtime_preview.recording_policy == "allow_during_recording"
         )
         self._preview_startup_probe_required = False
+        self._preview_audio_enabled = False
         if config.runtime_preview is not None:
             preview_hls_config = config.runtime_preview.config
+            self._preview_audio_enabled = preview_hls_config.audio_enabled
             self._preview_startup_probe_required = preview_hls_config.video_codec == "auto" or (
                 preview_hls_config.audio_enabled and preview_hls_config.audio_codec == "auto"
             )
@@ -485,6 +487,9 @@ class RTSPSource(ThreadedClipSource):
                 self.rtsp_url
                 if self._preview_concurrency_requested and self._preview_startup_probe_required
                 else None
+            ),
+            preview_audio_enabled=(
+                self._preview_concurrency_requested and self._preview_audio_enabled
             ),
         )
         match result:

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -313,6 +313,12 @@ class RTSPSource(ThreadedClipSource):
             and config.runtime_preview.enabled
             and config.runtime_preview.recording_policy == "allow_during_recording"
         )
+        self._preview_startup_probe_required = False
+        if config.runtime_preview is not None:
+            preview_hls_config = config.runtime_preview.config
+            self._preview_startup_probe_required = preview_hls_config.video_codec == "auto" or (
+                preview_hls_config.audio_enabled and preview_hls_config.audio_codec == "auto"
+            )
 
         if config.stream.disable_hwaccel:
             logger.info("Hardware acceleration manually disabled")
@@ -475,6 +481,11 @@ class RTSPSource(ThreadedClipSource):
             primary_rtsp_url=self.rtsp_url,
             detect_rtsp_url=self.detect_rtsp_url,
             preview_rtsp_url=self.rtsp_url if self._preview_concurrency_requested else None,
+            preview_probe_rtsp_url=(
+                self.rtsp_url
+                if self._preview_concurrency_requested and self._preview_startup_probe_required
+                else None
+            ),
         )
         match result:
             case CameraPreflightOutcome() as outcome:
@@ -530,6 +541,11 @@ class RTSPSource(ThreadedClipSource):
             selected_recording_url=self.rtsp_url,
             selected_preview_url=(
                 self.rtsp_url if concurrent_preview_supported is not None else None
+            ),
+            selected_preview_probe_url=(
+                self.rtsp_url
+                if concurrent_preview_supported is not None and self._preview_startup_probe_required
+                else None
             ),
             selected_recording_profile=recording_profile.profile_id(),
             session_mode="single_stream",

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -308,6 +308,11 @@ class RTSPSource(ThreadedClipSource):
             timeout_capabilities=self._timeout_capabilities,
         )
         self._preflight_outcome: CameraPreflightOutcome | None = None
+        self._preview_concurrency_requested = (
+            config.runtime_preview is not None
+            and config.runtime_preview.enabled
+            and config.runtime_preview.recording_policy == "allow_during_recording"
+        )
 
         if config.stream.disable_hwaccel:
             logger.info("Hardware acceleration manually disabled")
@@ -469,6 +474,7 @@ class RTSPSource(ThreadedClipSource):
             camera_name=self.camera_name,
             primary_rtsp_url=self.rtsp_url,
             detect_rtsp_url=self.detect_rtsp_url,
+            preview_rtsp_url=self.rtsp_url if self._preview_concurrency_requested else None,
         )
         match result:
             case CameraPreflightOutcome() as outcome:
@@ -479,7 +485,17 @@ class RTSPSource(ThreadedClipSource):
                         "RTSP session-limit preflight failed for %s; falling back to single-stream defaults",
                         self.camera_name,
                     )
-                    fallback = self._build_fallback_preflight_outcome(err.camera_key)
+                    fallback = self._build_fallback_preflight_outcome(
+                        err.camera_key,
+                        concurrent_preview_supported=(
+                            False if self._preview_concurrency_requested else None
+                        ),
+                        concurrent_preview_downgrade_reason=(
+                            "concurrent_preview_not_validated_after_session_limit_fallback"
+                            if self._preview_concurrency_requested
+                            else None
+                        ),
+                    )
                     self._apply_preflight_outcome(fallback)
                 else:
                     logger.error(
@@ -498,7 +514,13 @@ class RTSPSource(ThreadedClipSource):
                     f"{type(result).__name__}"
                 )
 
-    def _build_fallback_preflight_outcome(self, camera_key: str) -> CameraPreflightOutcome:
+    def _build_fallback_preflight_outcome(
+        self,
+        camera_key: str,
+        *,
+        concurrent_preview_supported: bool | None = None,
+        concurrent_preview_downgrade_reason: str | None = None,
+    ) -> CameraPreflightOutcome:
         motion_profile = MotionProfile(input_url=self.rtsp_url, ffmpeg_input_args=[])
         recording_profile = build_default_recording_profile(self.rtsp_url)
         diagnostics = CameraPreflightDiagnostics(
@@ -506,14 +528,21 @@ class RTSPSource(ThreadedClipSource):
             probes=[],
             selected_motion_url=self.rtsp_url,
             selected_recording_url=self.rtsp_url,
+            selected_preview_url=(
+                self.rtsp_url if concurrent_preview_supported is not None else None
+            ),
             selected_recording_profile=recording_profile.profile_id(),
             session_mode="single_stream",
+            concurrent_preview_supported=concurrent_preview_supported,
+            concurrent_preview_downgrade_reason=concurrent_preview_downgrade_reason,
             notes=["Session-limit preflight failed; using single-stream fallback defaults"],
         )
         return CameraPreflightOutcome(
             camera_key=camera_key,
             motion_profile=motion_profile,
             recording_profile=recording_profile,
+            concurrent_preview_supported=concurrent_preview_supported,
+            concurrent_preview_downgrade_reason=concurrent_preview_downgrade_reason,
             diagnostics=diagnostics,
         )
 
@@ -525,6 +554,19 @@ class RTSPSource(ThreadedClipSource):
             self._frame_pipeline.set_motion_profile(outcome.motion_profile)
         if self._owns_recorder and isinstance(self._recorder, FfmpegRecorder):
             self._recorder.configure_profile(outcome.recording_profile)
+
+        if outcome.concurrent_preview_supported is False:
+            reason = (
+                outcome.concurrent_preview_downgrade_reason
+                or "concurrent_preview_unsupported_by_startup_preflight"
+            )
+            logger.warning(
+                "RTSP concurrent preview while recording unavailable; "
+                "downgrading preview policy for this process: camera=%s reason=%s",
+                self.camera_name,
+                reason,
+            )
+            self._live_publisher.downgrade_concurrent_preview(reason)
 
         if self._motion_rtsp_url != self.detect_rtsp_url:
             # Motion stream is pinned away from detect stream, so runtime fallback probing

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -597,8 +597,11 @@ class HLSLivePublisher(LivePublisher):
                     LivePublisherStartRefusal(
                         reason=_classify_start_refusal(last_error),
                         message="Preview publisher exited early while recording was active",
-                    )
+                    ),
+                    count_failure=True,
                 )
+            else:
+                self._consecutive_recording_preview_failures = 0
             self._status = LivePublisherStatus(
                 state=(
                     LivePublisherState.DEGRADED
@@ -842,12 +845,20 @@ class HLSLivePublisher(LivePublisher):
     def _maybe_downgrade_after_recording_preview_failure_locked(
         self,
         refusal: LivePublisherStartRefusal,
+        *,
+        count_failure: bool | None = None,
     ) -> LivePublisherStartRefusal:
+        should_count = (
+            refusal.reason is LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+            if count_failure is None
+            else count_failure
+        )
         if (
             not self._recording_active
             or self._recording_policy != "allow_during_recording"
             or self._preview_downgraded_locked()
             or refusal.reason is LivePublisherRefusalReason.RECORDING_PRIORITY
+            or not should_count
         ):
             return refusal
 
@@ -929,6 +940,7 @@ class HLSLivePublisher(LivePublisher):
                     last_error="; ".join(teardown_errors),
                 )
             else:
+                self._consecutive_recording_preview_failures = 0
                 self._status = self._idle_status_locked()
 
         if teardown_errors:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -59,6 +59,10 @@ _SESSION_LIMIT_HINTS: tuple[str, ...] = (
     "max sessions",
     "maximum sessions",
 )
+CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON = (
+    "concurrent_preview_downgraded_after_repeated_recording_failures"
+)
+CONCURRENT_PREVIEW_FAILURE_THRESHOLD = 2
 
 
 class LivePublisherState(StrEnum):
@@ -95,6 +99,8 @@ class LivePublisher(Protocol):
     def status(self) -> LivePublisherStatus: ...
 
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal: ...
+
+    def downgrade_concurrent_preview(self, reason: str) -> None: ...
 
     def request_stop(self) -> None: ...
 
@@ -187,6 +193,10 @@ class HLSLivePublisher(LivePublisher):
         )
         self._viewer_window_s = max(_DEFAULT_VIEWER_WINDOW_S, self._segment_duration_s * 2.0)
         self._startup_timeout_s = max(3.0, min(10.0, (self._segment_duration_s * 4.0) + 2.0))
+        self._recording_preview_early_exit_window_s = max(
+            self._startup_timeout_s,
+            self._segment_duration_s * max(1, self._live_window_segments),
+        )
 
         self._lock = RLock()
         self._maintenance_stop = Event()
@@ -205,7 +215,10 @@ class HLSLivePublisher(LivePublisher):
         self._stop_request_token = 0
         self._process: subprocess.Popen[bytes] | None = None
         self._stderr_handle: TextIO | None = None
+        self._preview_ready_at: float | None = None
         self._recording_active = False
+        self._concurrent_preview_downgrade_reason: str | None = None
+        self._consecutive_recording_preview_failures = 0
         self._viewer_activity: dict[str, float] = {}
         self._anonymous_viewer_last_seen: float | None = None
         self._last_activity_at: float | None = None
@@ -244,7 +257,8 @@ class HLSLivePublisher(LivePublisher):
                     # cached READY result and proceed with normal startup logic.
                     if (
                         isinstance(completed_start_result, LivePublisherStatus)
-                        and completed_start_result.state is LivePublisherState.READY
+                        and completed_start_result.state
+                        in (LivePublisherState.READY, LivePublisherState.DEGRADED)
                         and not self._is_process_running_locked()
                     ):
                         self._completed_start_results.pop(queued_start_token, None)
@@ -266,8 +280,8 @@ class HLSLivePublisher(LivePublisher):
                     self._mark_activity_locked(now=now)
                     self._status = self._build_running_status_locked(
                         now=now,
-                        state=LivePublisherState.READY,
-                        degraded_reason=None,
+                        state=self._running_state_locked(),
+                        degraded_reason=self._current_degraded_reason_locked(),
                     )
                     self._ensure_maintenance_thread_started_locked()
                     return self._status
@@ -288,6 +302,10 @@ class HLSLivePublisher(LivePublisher):
                 self._start_in_progress = False
                 if start_result is not None and self._queued_start_waiters.get(start_token, 0) > 0:
                     self._completed_start_results[start_token] = start_result
+
+    def downgrade_concurrent_preview(self, reason: str) -> None:
+        with self._lock:
+            self._downgrade_concurrent_preview_locked(reason=reason)
 
     def request_stop(self) -> None:
         with self._lock:
@@ -310,8 +328,8 @@ class HLSLivePublisher(LivePublisher):
                 self._viewer_activity[viewer_id] = now
             self._status = self._build_running_status_locked(
                 now=now,
-                state=LivePublisherState.READY,
-                degraded_reason=None,
+                state=self._running_state_locked(),
+                degraded_reason=self._current_degraded_reason_locked(),
             )
 
     def sync_recording_active(self, recording_active: bool) -> None:
@@ -321,10 +339,14 @@ class HLSLivePublisher(LivePublisher):
             had_pending_start = self._start_in_progress
             self._recording_active = recording_active
             if not recording_active:
+                self._consecutive_recording_preview_failures = 0
                 self._refresh_locked(now=self._clock.now())
                 return
 
-            if self._recording_policy == "allow_during_recording":
+            if (
+                self._recording_policy == "allow_during_recording"
+                and not self._preview_downgraded_locked()
+            ):
                 if not was_recording_active:
                     logger.info(
                         "Recording became active; preview remains allowed by configuration: camera=%s",
@@ -369,6 +391,17 @@ class HLSLivePublisher(LivePublisher):
             maintenance_thread.join(timeout=2.0)
 
     def _start(
+        self,
+        *,
+        start_token: int,
+    ) -> LivePublisherStatus | LivePublisherStartRefusal:
+        result = self._start_impl(start_token=start_token)
+        if isinstance(result, LivePublisherStartRefusal):
+            with self._lock:
+                return self._maybe_downgrade_after_recording_preview_failure_locked(result)
+        return result
+
+    def _start_impl(
         self,
         *,
         start_token: int,
@@ -440,6 +473,7 @@ class HLSLivePublisher(LivePublisher):
 
                     self._process = process
                     self._stderr_handle = stderr_handle
+                    self._preview_ready_at = None
                     started_now = self._clock.now()
                     self._mark_activity_locked(now=started_now)
                     self._status = LivePublisherStatus(
@@ -452,12 +486,13 @@ class HLSLivePublisher(LivePublisher):
                         if label == "timeouts":
                             self._timeout_capabilities.note_ffmpeg_timeout_success()
                         ready_now = self._clock.now()
+                        self._preview_ready_at = ready_now
                         self._mark_activity_locked(now=ready_now)
                         self._ensure_maintenance_thread_started_locked()
                         self._status = self._build_running_status_locked(
                             now=ready_now,
-                            state=LivePublisherState.READY,
-                            degraded_reason=None,
+                            state=self._running_state_locked(),
+                            degraded_reason=self._current_degraded_reason_locked(),
                         )
                         return self._status
 
@@ -554,16 +589,31 @@ class HLSLivePublisher(LivePublisher):
             self._viewer_activity.clear()
             self._anonymous_viewer_last_seen = None
             self._last_activity_at = None
+            last_error = stderr_tail or f"Preview ffmpeg exited unexpectedly ({exit_code})"
+            early_exit_while_recording = self._is_recording_preview_early_exit_locked(now=now)
+            self._preview_ready_at = None
+            if early_exit_while_recording:
+                self._maybe_downgrade_after_recording_preview_failure_locked(
+                    LivePublisherStartRefusal(
+                        reason=_classify_start_refusal(last_error),
+                        message="Preview publisher exited early while recording was active",
+                    )
+                )
             self._status = LivePublisherStatus(
-                state=LivePublisherState.ERROR,
+                state=(
+                    LivePublisherState.DEGRADED
+                    if self._preview_downgraded_locked()
+                    else LivePublisherState.ERROR
+                ),
                 viewer_count=0,
-                last_error=stderr_tail or f"Preview ffmpeg exited unexpectedly ({exit_code})",
+                degraded_reason=self._current_degraded_reason_locked(),
+                last_error=last_error,
             )
             return
 
         if not self._is_process_running_locked():
             if self._status.state not in (LivePublisherState.ERROR,):
-                self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+                self._status = self._idle_status_locked()
             return
 
         viewer_count = self._viewer_count_locked(now=now)
@@ -579,8 +629,8 @@ class HLSLivePublisher(LivePublisher):
 
         self._status = self._build_running_status_locked(
             now=now,
-            state=LivePublisherState.READY,
-            degraded_reason=None,
+            state=self._running_state_locked(),
+            degraded_reason=self._current_degraded_reason_locked(),
         )
 
     def _build_codec_plans(self) -> tuple[_CodecPlan, ...]:
@@ -674,7 +724,9 @@ class HLSLivePublisher(LivePublisher):
                 return None
 
     def _recording_blocks_preview_locked(self) -> bool:
-        return self._recording_policy == "stop_on_recording" and self._recording_active
+        return self._recording_active and (
+            self._recording_policy == "stop_on_recording" or self._preview_downgraded_locked()
+        )
 
     def _build_ffmpeg_cmd(
         self,
@@ -747,6 +799,86 @@ class HLSLivePublisher(LivePublisher):
             idle_shutdown_at=idle_shutdown_at,
         )
 
+    def _idle_status_locked(self, *, last_error: str | None = None) -> LivePublisherStatus:
+        return LivePublisherStatus(
+            state=(
+                LivePublisherState.DEGRADED
+                if self._recording_active and self._preview_downgraded_locked()
+                else LivePublisherState.IDLE
+            ),
+            viewer_count=0,
+            degraded_reason=self._current_degraded_reason_locked(),
+            last_error=last_error,
+        )
+
+    def _running_state_locked(self) -> LivePublisherState:
+        if self._preview_downgraded_locked():
+            return LivePublisherState.DEGRADED
+        return LivePublisherState.READY
+
+    def _preview_downgraded_locked(self) -> bool:
+        return self._concurrent_preview_downgrade_reason is not None
+
+    def _current_degraded_reason_locked(self) -> str | None:
+        return self._concurrent_preview_downgrade_reason
+
+    def _downgrade_concurrent_preview_locked(self, *, reason: str) -> None:
+        if self._concurrent_preview_downgrade_reason == reason:
+            return
+
+        self._concurrent_preview_downgrade_reason = reason
+        logger.warning(
+            "Downgrading concurrent preview while recording for camera=%s reason=%s",
+            self._camera_name,
+            reason,
+        )
+        if self._recording_active:
+            self._cancel_pending_start_locked()
+            self._stop_locked(clear_error=True)
+            self._last_cancellation_result = self._recording_priority_refusal()
+        elif not self._is_process_running_locked():
+            self._status = self._idle_status_locked()
+
+    def _maybe_downgrade_after_recording_preview_failure_locked(
+        self,
+        refusal: LivePublisherStartRefusal,
+    ) -> LivePublisherStartRefusal:
+        if (
+            not self._recording_active
+            or self._recording_policy != "allow_during_recording"
+            or self._preview_downgraded_locked()
+            or refusal.reason is LivePublisherRefusalReason.RECORDING_PRIORITY
+        ):
+            return refusal
+
+        self._consecutive_recording_preview_failures += 1
+        logger.warning(
+            "Preview failed while recording is active: "
+            "camera=%s consecutive_failures=%s threshold=%s reason=%s",
+            self._camera_name,
+            self._consecutive_recording_preview_failures,
+            CONCURRENT_PREVIEW_FAILURE_THRESHOLD,
+            refusal.reason.value,
+        )
+        if self._consecutive_recording_preview_failures < CONCURRENT_PREVIEW_FAILURE_THRESHOLD:
+            return refusal
+
+        self._downgrade_concurrent_preview_locked(
+            reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
+        )
+        return self._recording_priority_refusal()
+
+    def _is_recording_preview_early_exit_locked(self, *, now: float) -> bool:
+        if (
+            not self._recording_active
+            or self._recording_policy != "allow_during_recording"
+            or self._preview_downgraded_locked()
+        ):
+            return False
+        if self._preview_ready_at is None:
+            return True
+        return (now - self._preview_ready_at) <= self._recording_preview_early_exit_window_s
+
     def _output_ready_locked(self) -> bool:
         if not self._playlist_path.exists():
             return False
@@ -770,13 +902,14 @@ class HLSLivePublisher(LivePublisher):
         has_live_window = self._camera_dir.exists()
         if self._process is None and self._stderr_handle is None and not has_live_window:
             if clear_error:
-                self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+                self._status = self._idle_status_locked()
             return None
 
         self._status = LivePublisherStatus(state=LivePublisherState.STOPPING, viewer_count=0)
         teardown_errors: list[str] = []
         process = self._process
         self._process = None
+        self._preview_ready_at = None
         if process is not None:
             stop_error = self._terminate_process(process)
             if stop_error is not None:
@@ -796,7 +929,7 @@ class HLSLivePublisher(LivePublisher):
                     last_error="; ".join(teardown_errors),
                 )
             else:
-                self._status = LivePublisherStatus(state=LivePublisherState.IDLE, viewer_count=0)
+                self._status = self._idle_status_locked()
 
         if teardown_errors:
             return "; ".join(teardown_errors)
@@ -975,11 +1108,20 @@ class HLSLivePublisher(LivePublisher):
         self._status = LivePublisherStatus(
             state=LivePublisherState.ERROR,
             viewer_count=0,
+            degraded_reason=self._current_degraded_reason_locked(),
             last_error=last_error,
         )
         return LivePublisherStartRefusal(reason=reason, message=message)
 
     def _recording_priority_refusal(self) -> LivePublisherStartRefusal:
+        if self._preview_downgraded_locked():
+            return LivePublisherStartRefusal(
+                reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
+                message=(
+                    "Preview is unavailable while recording is active because concurrent "
+                    "preview was downgraded for this camera"
+                ),
+            )
         return LivePublisherStartRefusal(
             reason=LivePublisherRefusalReason.RECORDING_PRIORITY,
             message="Preview is unavailable while recording is active for this camera",
@@ -1022,6 +1164,9 @@ class NoopLivePublisher(LivePublisher):
             reason=LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE,
             message="Preview publisher is not configured for this RTSP source",
         )
+
+    def downgrade_concurrent_preview(self, reason: str) -> None:
+        _ = reason
 
     def request_stop(self) -> None:
         self._status = LivePublisherStatus(state=LivePublisherState.IDLE)

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -218,7 +218,8 @@ class HLSLivePublisher(LivePublisher):
         self._preview_ready_at: float | None = None
         self._recording_active = False
         self._concurrent_preview_downgrade_reason: str | None = None
-        self._consecutive_recording_preview_failures = 0
+        self._consecutive_recording_preview_start_failures = 0
+        self._consecutive_recording_preview_early_exits = 0
         self._viewer_activity: dict[str, float] = {}
         self._anonymous_viewer_last_seen: float | None = None
         self._last_activity_at: float | None = None
@@ -339,7 +340,7 @@ class HLSLivePublisher(LivePublisher):
             had_pending_start = self._start_in_progress
             self._recording_active = recording_active
             if not recording_active:
-                self._consecutive_recording_preview_failures = 0
+                self._reset_recording_preview_failure_streaks_locked()
                 self._refresh_locked(now=self._clock.now())
                 return
 
@@ -398,7 +399,10 @@ class HLSLivePublisher(LivePublisher):
         result = self._start_impl(start_token=start_token)
         if isinstance(result, LivePublisherStartRefusal):
             with self._lock:
-                return self._maybe_downgrade_after_recording_preview_failure_locked(result)
+                return self._maybe_downgrade_after_recording_preview_failure_locked(
+                    result,
+                    failure_kind="start",
+                )
         return result
 
     def _start_impl(
@@ -487,6 +491,7 @@ class HLSLivePublisher(LivePublisher):
                             self._timeout_capabilities.note_ffmpeg_timeout_success()
                         ready_now = self._clock.now()
                         self._preview_ready_at = ready_now
+                        self._consecutive_recording_preview_start_failures = 0
                         self._mark_activity_locked(now=ready_now)
                         self._ensure_maintenance_thread_started_locked()
                         self._status = self._build_running_status_locked(
@@ -598,10 +603,11 @@ class HLSLivePublisher(LivePublisher):
                         reason=_classify_start_refusal(last_error),
                         message="Preview publisher exited early while recording was active",
                     ),
+                    failure_kind="early_exit",
                     count_failure=True,
                 )
             else:
-                self._consecutive_recording_preview_failures = 0
+                self._reset_recording_preview_failure_streaks_locked()
             self._status = LivePublisherStatus(
                 state=(
                     LivePublisherState.DEGRADED
@@ -846,6 +852,7 @@ class HLSLivePublisher(LivePublisher):
         self,
         refusal: LivePublisherStartRefusal,
         *,
+        failure_kind: Literal["start", "early_exit"],
         count_failure: bool | None = None,
     ) -> LivePublisherStartRefusal:
         should_count = (
@@ -862,22 +869,33 @@ class HLSLivePublisher(LivePublisher):
         ):
             return refusal
 
-        self._consecutive_recording_preview_failures += 1
+        match failure_kind:
+            case "start":
+                self._consecutive_recording_preview_start_failures += 1
+                consecutive_failures = self._consecutive_recording_preview_start_failures
+            case "early_exit":
+                self._consecutive_recording_preview_early_exits += 1
+                consecutive_failures = self._consecutive_recording_preview_early_exits
         logger.warning(
             "Preview failed while recording is active: "
-            "camera=%s consecutive_failures=%s threshold=%s reason=%s",
+            "camera=%s failure_kind=%s consecutive_failures=%s threshold=%s reason=%s",
             self._camera_name,
-            self._consecutive_recording_preview_failures,
+            failure_kind,
+            consecutive_failures,
             CONCURRENT_PREVIEW_FAILURE_THRESHOLD,
             refusal.reason.value,
         )
-        if self._consecutive_recording_preview_failures < CONCURRENT_PREVIEW_FAILURE_THRESHOLD:
+        if consecutive_failures < CONCURRENT_PREVIEW_FAILURE_THRESHOLD:
             return refusal
 
         self._downgrade_concurrent_preview_locked(
             reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
         )
         return self._recording_priority_refusal()
+
+    def _reset_recording_preview_failure_streaks_locked(self) -> None:
+        self._consecutive_recording_preview_start_failures = 0
+        self._consecutive_recording_preview_early_exits = 0
 
     def _is_recording_preview_early_exit_locked(self, *, now: float) -> bool:
         if (
@@ -940,7 +958,7 @@ class HLSLivePublisher(LivePublisher):
                     last_error="; ".join(teardown_errors),
                 )
             else:
-                self._consecutive_recording_preview_failures = 0
+                self._reset_recording_preview_failure_streaks_locked()
                 self._status = self._idle_status_locked()
 
         if teardown_errors:

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -614,7 +614,7 @@ class HLSLivePublisher(LivePublisher):
             self._status = LivePublisherStatus(
                 state=(
                     LivePublisherState.DEGRADED
-                    if self._preview_downgraded_locked()
+                    if early_exit_while_recording and self._preview_downgraded_locked()
                     else LivePublisherState.ERROR
                 ),
                 viewer_count=0,

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -612,11 +612,7 @@ class HLSLivePublisher(LivePublisher):
             else:
                 self._reset_recording_preview_failure_streaks_locked()
             self._status = LivePublisherStatus(
-                state=(
-                    LivePublisherState.DEGRADED
-                    if early_exit_while_recording and self._preview_downgraded_locked()
-                    else LivePublisherState.ERROR
-                ),
+                state=LivePublisherState.ERROR,
                 viewer_count=0,
                 degraded_reason=self._current_degraded_reason_locked(),
                 last_error=last_error,
@@ -814,11 +810,7 @@ class HLSLivePublisher(LivePublisher):
 
     def _idle_status_locked(self, *, last_error: str | None = None) -> LivePublisherStatus:
         return LivePublisherStatus(
-            state=(
-                LivePublisherState.DEGRADED
-                if self._recording_active and self._preview_downgraded_locked()
-                else LivePublisherState.IDLE
-            ),
+            state=LivePublisherState.IDLE,
             viewer_count=0,
             degraded_reason=self._current_degraded_reason_locked(),
             last_error=last_error,

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -37,6 +37,7 @@ from homesec.sources.rtsp.hardware import (
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
     _format_cmd,
+    _is_rtsp_session_limit_error,
     _is_timeout_option_error,
     _redact_rtsp_url,
     _signal_process_group,
@@ -48,17 +49,6 @@ _READY_POLL_INTERVAL_S = 0.1
 _DEFAULT_VIEWER_WINDOW_S = 2.0
 _START_FAILURE_MAX_BYTES = 4_000
 _HLS_BROWSER_COPY_AUDIO_CODECS: frozenset[str] = frozenset({"aac"})
-_SESSION_LIMIT_HINTS: tuple[str, ...] = (
-    "too many clients",
-    "too many connections",
-    "too many sessions",
-    "max number of clients",
-    "maximum number of clients",
-    "maximum number of connections",
-    "session limit",
-    "max sessions",
-    "maximum sessions",
-)
 CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON = (
     "concurrent_preview_downgraded_after_repeated_recording_failures"
 )
@@ -1245,10 +1235,8 @@ def _format_segment_duration(segment_duration_s: float) -> str:
 
 
 def _classify_start_refusal(stderr_tail: str) -> LivePublisherRefusalReason:
-    lowered = stderr_tail.lower()
-    for hint in _SESSION_LIMIT_HINTS:
-        if hint in lowered:
-            return LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    if _is_rtsp_session_limit_error(stderr_tail):
+        return LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
     return LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
 
 

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -217,6 +217,7 @@ class HLSLivePublisher(LivePublisher):
         self._stderr_handle: TextIO | None = None
         self._preview_ready_at: float | None = None
         self._recording_active = False
+        self._recording_active_since: float | None = None
         self._concurrent_preview_downgrade_reason: str | None = None
         self._consecutive_recording_preview_start_failures = 0
         self._consecutive_recording_preview_early_exits = 0
@@ -340,9 +341,12 @@ class HLSLivePublisher(LivePublisher):
             had_pending_start = self._start_in_progress
             self._recording_active = recording_active
             if not recording_active:
+                self._recording_active_since = None
                 self._reset_recording_preview_failure_streaks_locked()
                 self._refresh_locked(now=self._clock.now())
                 return
+            if not was_recording_active:
+                self._recording_active_since = self._clock.now()
 
             if (
                 self._recording_policy == "allow_during_recording"
@@ -604,7 +608,6 @@ class HLSLivePublisher(LivePublisher):
                         message="Preview publisher exited early while recording was active",
                     ),
                     failure_kind="early_exit",
-                    count_failure=True,
                 )
             else:
                 self._reset_recording_preview_failure_streaks_locked()
@@ -904,9 +907,14 @@ class HLSLivePublisher(LivePublisher):
             or self._preview_downgraded_locked()
         ):
             return False
-        if self._preview_ready_at is None:
+        reference_at = self._preview_ready_at
+        if self._recording_active_since is not None and (
+            reference_at is None or self._recording_active_since > reference_at
+        ):
+            reference_at = self._recording_active_since
+        if reference_at is None:
             return True
-        return (now - self._preview_ready_at) <= self._recording_preview_early_exit_window_s
+        return (now - reference_at) <= self._recording_preview_early_exit_window_s
 
     def _output_ready_locked(self) -> bool:
         if not self._playlist_path.exists():

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -601,6 +601,7 @@ class HLSLivePublisher(LivePublisher):
             last_error = stderr_tail or f"Preview ffmpeg exited unexpectedly ({exit_code})"
             early_exit_while_recording = self._is_recording_preview_early_exit_locked(now=now)
             self._preview_ready_at = None
+            was_downgraded = self._preview_downgraded_locked()
             if early_exit_while_recording:
                 self._maybe_downgrade_after_recording_preview_failure_locked(
                     LivePublisherStartRefusal(
@@ -611,6 +612,9 @@ class HLSLivePublisher(LivePublisher):
                 )
             else:
                 self._reset_recording_preview_failure_streaks_locked()
+            if not was_downgraded and self._preview_downgraded_locked():
+                self._status = self._idle_status_locked(last_error=last_error)
+                return
             self._status = LivePublisherStatus(
                 state=LivePublisherState.ERROR,
                 viewer_count=0,

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -628,6 +628,7 @@ class HLSLivePublisher(LivePublisher):
                 self._status = self._idle_status_locked()
             return
 
+        self._reset_recording_preview_early_exit_streak_after_healthy_run_locked(now=now)
         viewer_count = self._viewer_count_locked(now=now)
         if viewer_count == 0 and self._last_activity_at is not None:
             idle_shutdown_at = self._last_activity_at + self._idle_timeout_s
@@ -867,16 +868,19 @@ class HLSLivePublisher(LivePublisher):
             not self._recording_active
             or self._recording_policy != "allow_during_recording"
             or self._preview_downgraded_locked()
-            or refusal.reason is LivePublisherRefusalReason.RECORDING_PRIORITY
-            or not should_count
         ):
+            return refusal
+        if refusal.reason is LivePublisherRefusalReason.RECORDING_PRIORITY or not should_count:
+            self._reset_recording_preview_failure_streaks_locked()
             return refusal
 
         match failure_kind:
             case "start":
+                self._consecutive_recording_preview_early_exits = 0
                 self._consecutive_recording_preview_start_failures += 1
                 consecutive_failures = self._consecutive_recording_preview_start_failures
             case "early_exit":
+                self._consecutive_recording_preview_start_failures = 0
                 self._consecutive_recording_preview_early_exits += 1
                 consecutive_failures = self._consecutive_recording_preview_early_exits
         logger.warning(
@@ -900,6 +904,23 @@ class HLSLivePublisher(LivePublisher):
         self._consecutive_recording_preview_start_failures = 0
         self._consecutive_recording_preview_early_exits = 0
 
+    def _reset_recording_preview_early_exit_streak_after_healthy_run_locked(
+        self,
+        *,
+        now: float,
+    ) -> None:
+        if (
+            not self._recording_active
+            or self._recording_policy != "allow_during_recording"
+            or self._preview_downgraded_locked()
+        ):
+            return
+        reference_at = self._recording_preview_early_exit_reference_at_locked()
+        if reference_at is None:
+            return
+        if (now - reference_at) > self._recording_preview_early_exit_window_s:
+            self._consecutive_recording_preview_early_exits = 0
+
     def _is_recording_preview_early_exit_locked(self, *, now: float) -> bool:
         if (
             not self._recording_active
@@ -907,14 +928,18 @@ class HLSLivePublisher(LivePublisher):
             or self._preview_downgraded_locked()
         ):
             return False
+        reference_at = self._recording_preview_early_exit_reference_at_locked()
+        if reference_at is None:
+            return True
+        return (now - reference_at) <= self._recording_preview_early_exit_window_s
+
+    def _recording_preview_early_exit_reference_at_locked(self) -> float | None:
         reference_at = self._preview_ready_at
         if self._recording_active_since is not None and (
             reference_at is None or self._recording_active_since > reference_at
         ):
             reference_at = self._recording_active_since
-        if reference_at is None:
-            return True
-        return (now - reference_at) <= self._recording_preview_early_exit_window_s
+        return reference_at
 
     def _output_ready_locked(self) -> bool:
         if not self._playlist_path.exists():

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -804,6 +804,7 @@ class RTSPStartupPreflight:
                 return self._build_probe_open_cmd(
                     input_url=spec.input_url,
                     timeout_args=timeout_args,
+                    duration_s=duration_s,
                 )
 
     def _build_stream_open_cmd(
@@ -842,6 +843,7 @@ class RTSPStartupPreflight:
         *,
         input_url: str,
         timeout_args: list[str],
+        duration_s: float,
     ) -> list[str]:
         cmd = [
             "ffprobe",
@@ -849,8 +851,11 @@ class RTSPStartupPreflight:
             "error",
             "-select_streams",
             "v:0",
+            "-read_intervals",
+            f"%+{max(0.5, duration_s):.1f}",
+            "-count_packets",
             "-show_entries",
-            "stream=codec_name,width,height,avg_frame_rate",
+            "stream=codec_name,width,height,avg_frame_rate,nb_read_packets",
             "-of",
             "json",
             "-rtsp_transport",

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -33,6 +33,7 @@ from homesec.sources.rtsp.url_derivation import derive_probe_candidate_urls
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
     _format_cmd,
+    _is_rtsp_session_limit_error,
     _is_timeout_option_error,
     _redact_rtsp_url,
     _signal_process_group,
@@ -43,17 +44,6 @@ logger = logging.getLogger(__name__)
 _NON_MONOTONIC_DTS_RETRY_THRESHOLD = 5
 _QUEUE_BACKWARD_RETRY_THRESHOLD = 1
 _DTS_DISCONTINUITY_RETRY_THRESHOLD = 1
-_SESSION_LIMIT_HINTS: tuple[str, ...] = (
-    "too many clients",
-    "too many connections",
-    "too many sessions",
-    "max number of clients",
-    "maximum number of clients",
-    "maximum number of connections",
-    "session limit",
-    "max sessions",
-    "maximum sessions",
-)
 
 
 class ConcurrentStreamOpenResult(StrEnum):
@@ -1023,8 +1013,7 @@ def _sanitize_stderr(stderr_text: str, input_url: str) -> str:
 
 
 def _is_session_limit_error(stderr: str) -> bool:
-    lowered = stderr.lower()
-    return any(hint in lowered for hint in _SESSION_LIMIT_HINTS)
+    return _is_rtsp_session_limit_error(stderr)
 
 
 def _collect_recording_stability_signals(stderr_text: str) -> RecordingValidationSignals:

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -118,6 +118,7 @@ class CameraPreflightDiagnostics(BaseModel):
     selected_motion_url: str | None = None
     selected_recording_url: str | None = None
     selected_preview_url: str | None = None
+    selected_preview_probe_url: str | None = None
     negotiation_attempts: list[str] = Field(default_factory=list)
     selected_recording_profile: str | None = None
     session_mode: Literal["dual_stream", "single_stream"] | None = None
@@ -179,6 +180,7 @@ class RecordingValidationResult(BaseModel):
 class _SessionOpenSpec:
     role: str
     input_url: str
+    tool: Literal["ffmpeg", "ffprobe"] = "ffmpeg"
 
 
 class RTSPStartupPreflight:
@@ -215,6 +217,7 @@ class RTSPStartupPreflight:
         primary_rtsp_url: str,
         detect_rtsp_url: str,
         preview_rtsp_url: str | None = None,
+        preview_probe_rtsp_url: str | None = None,
     ) -> CameraPreflightOutcome | PreflightError:
         """Run startup preflight and return locked profiles or a typed error."""
 
@@ -272,6 +275,7 @@ class RTSPStartupPreflight:
         diagnostics.selected_motion_url = motion_stream.url
         diagnostics.selected_recording_url = recording_stream.url
         diagnostics.selected_preview_url = preview_rtsp_url
+        diagnostics.selected_preview_probe_url = preview_probe_rtsp_url
 
         negotiation = self._negotiate_recording_profile(
             camera_key=camera_key,
@@ -305,6 +309,7 @@ class RTSPStartupPreflight:
                 motion_profile=motion_profile,
                 recording_profile=recording_profile,
                 preview_rtsp_url=preview_rtsp_url,
+                preview_probe_rtsp_url=preview_probe_rtsp_url,
                 diagnostics=diagnostics,
             )
             return CameraPreflightOutcome(
@@ -339,6 +344,7 @@ class RTSPStartupPreflight:
             motion_profile=motion_profile,
             recording_profile=recording_profile,
             preview_rtsp_url=preview_rtsp_url,
+            preview_probe_rtsp_url=preview_probe_rtsp_url,
             diagnostics=diagnostics,
         )
         return CameraPreflightOutcome(
@@ -356,10 +362,30 @@ class RTSPStartupPreflight:
         motion_profile: MotionProfile,
         recording_profile: RecordingProfile,
         preview_rtsp_url: str | None,
+        preview_probe_rtsp_url: str | None,
         diagnostics: CameraPreflightDiagnostics,
     ) -> None:
         if preview_rtsp_url is None:
             return
+
+        if preview_probe_rtsp_url is not None:
+            probe_validation_result = self._validate_concurrent_preview_probe_session_limits(
+                motion_profile.input_url,
+                recording_profile.input_url,
+                preview_probe_rtsp_url,
+            )
+            if probe_validation_result is ConcurrentStreamOpenResult.SESSION_LIMIT:
+                self._mark_concurrent_preview_unsupported(diagnostics)
+                return
+            if probe_validation_result is not ConcurrentStreamOpenResult.SUPPORTED:
+                diagnostics.notes.append(
+                    "Concurrent preview startup probe could not be classified during startup; "
+                    "runtime will continue best-effort behavior"
+                )
+                return
+            diagnostics.notes.append(
+                "Concurrent preview startup probe validated with motion and recording streams"
+            )
 
         validation_result = self._validate_concurrent_preview_session_limits(
             motion_profile.input_url,
@@ -380,6 +406,12 @@ class RTSPStartupPreflight:
             )
             return
 
+        self._mark_concurrent_preview_unsupported(diagnostics)
+
+    @staticmethod
+    def _mark_concurrent_preview_unsupported(
+        diagnostics: CameraPreflightDiagnostics,
+    ) -> None:
         diagnostics.concurrent_preview_supported = False
         diagnostics.concurrent_preview_downgrade_reason = (
             "concurrent_preview_unsupported_by_startup_preflight"
@@ -604,23 +636,45 @@ class RTSPStartupPreflight:
             ]
         )
 
+    def _validate_concurrent_preview_probe_session_limits(
+        self,
+        motion_url: str,
+        recording_url: str,
+        preview_probe_url: str,
+    ) -> ConcurrentStreamOpenResult:
+        """Validate the preview startup probe alongside motion and recording."""
+        return self._validate_concurrent_stream_opens(
+            [
+                _SessionOpenSpec(role="motion", input_url=motion_url),
+                _SessionOpenSpec(role="recording", input_url=recording_url),
+                _SessionOpenSpec(
+                    role="preview_probe",
+                    input_url=preview_probe_url,
+                    tool="ffprobe",
+                ),
+            ]
+        )
+
     def _validate_concurrent_stream_opens(
         self, specs: list[_SessionOpenSpec]
     ) -> ConcurrentStreamOpenResult:
         """Validate that the requested RTSP consumers can open concurrently."""
-        timeout_args = self._timeout_args()
-        attempts = _build_timeout_attempts(timeout_args)
+        attempts = self._stream_open_attempts(specs)
         session_check_duration_s = max(2.0, self._session_overlap_s + 0.5)
         completion_timeout_s = session_check_duration_s + 1.5
 
-        for label, current_timeout_args in attempts:
+        for label, use_timeout_args in attempts:
             procs: dict[str, subprocess.Popen[str] | None] = {spec.role: None for spec in specs}
+            specs_by_role = {spec.role: spec for spec in specs}
 
             try:
                 for spec in specs:
-                    cmd = self._build_stream_open_cmd(
-                        input_url=spec.input_url,
-                        timeout_args=current_timeout_args,
+                    timeout_args = (
+                        self._timeout_args_for_tool(spec.tool) if use_timeout_args else []
+                    )
+                    cmd = self._build_session_open_cmd(
+                        spec=spec,
+                        timeout_args=timeout_args,
                         duration_s=session_check_duration_s,
                     )
                     procs[spec.role] = subprocess.Popen(
@@ -661,7 +715,7 @@ class RTSPStartupPreflight:
 
             if all(exit_code == 0 for exit_code, _err in exits_and_errors.values()):
                 if label == "timeouts":
-                    self._timeout_capabilities.note_ffmpeg_timeout_success()
+                    self._note_timeout_success(specs)
                 return ConcurrentStreamOpenResult.SUPPORTED
 
             timeout_option_error = label == "timeouts" and any(
@@ -671,11 +725,7 @@ class RTSPStartupPreflight:
                 return ConcurrentStreamOpenResult.SESSION_LIMIT
 
             if timeout_option_error:
-                changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
-                if changed:
-                    logger.warning(
-                        "ffmpeg timeout options unsupported; disabling RTSP timeout options for this process"
-                    )
+                self._mark_timeout_unsupported(specs_by_role, exits_and_errors)
                 logger.debug(
                     "Session-limit validation retrying without timeout options; errors=%s",
                     {role: err for role, (_exit_code, err) in exits_and_errors.items() if err},
@@ -727,6 +777,35 @@ class RTSPStartupPreflight:
         cmd.extend(["-y", str(output_path)])
         return cmd
 
+    def _stream_open_attempts(
+        self,
+        specs: list[_SessionOpenSpec],
+    ) -> tuple[tuple[Literal["timeouts", "no_timeouts"], bool], ...]:
+        has_timeout_args = any(self._timeout_args_for_tool(spec.tool) for spec in specs)
+        if has_timeout_args:
+            return (("timeouts", True), ("no_timeouts", False))
+        return (("no_timeouts", False),)
+
+    def _build_session_open_cmd(
+        self,
+        *,
+        spec: _SessionOpenSpec,
+        timeout_args: list[str],
+        duration_s: float,
+    ) -> list[str]:
+        match spec.tool:
+            case "ffmpeg":
+                return self._build_stream_open_cmd(
+                    input_url=spec.input_url,
+                    timeout_args=timeout_args,
+                    duration_s=duration_s,
+                )
+            case "ffprobe":
+                return self._build_probe_open_cmd(
+                    input_url=spec.input_url,
+                    timeout_args=timeout_args,
+                )
+
     def _build_stream_open_cmd(
         self,
         *,
@@ -758,11 +837,84 @@ class RTSPStartupPreflight:
         )
         return cmd
 
+    def _build_probe_open_cmd(
+        self,
+        *,
+        input_url: str,
+        timeout_args: list[str],
+    ) -> list[str]:
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=codec_name,width,height,avg_frame_rate",
+            "-of",
+            "json",
+            "-rtsp_transport",
+            "tcp",
+        ]
+        cmd.extend(timeout_args)
+        cmd.append(input_url)
+        return cmd
+
     def _timeout_args(self) -> list[str]:
         return self._timeout_capabilities.build_ffmpeg_timeout_args(
             connect_timeout_s=self._rtsp_connect_timeout_s,
             io_timeout_s=self._rtsp_io_timeout_s,
         )
+
+    def _ffprobe_timeout_args(self) -> list[str]:
+        return self._timeout_capabilities.build_ffprobe_timeout_args(
+            connect_timeout_s=self._rtsp_connect_timeout_s,
+            io_timeout_s=self._rtsp_io_timeout_s,
+        )
+
+    def _timeout_args_for_tool(self, tool: Literal["ffmpeg", "ffprobe"]) -> list[str]:
+        match tool:
+            case "ffmpeg":
+                return self._timeout_args()
+            case "ffprobe":
+                return self._ffprobe_timeout_args()
+
+    def _note_timeout_success(self, specs: list[_SessionOpenSpec]) -> None:
+        if any(spec.tool == "ffmpeg" and self._timeout_args() for spec in specs):
+            self._timeout_capabilities.note_ffmpeg_timeout_success()
+        if any(spec.tool == "ffprobe" and self._ffprobe_timeout_args() for spec in specs):
+            self._timeout_capabilities.note_ffprobe_timeout_success()
+
+    def _mark_timeout_unsupported(
+        self,
+        specs_by_role: dict[str, _SessionOpenSpec],
+        exits_and_errors: dict[str, tuple[int | None, str]],
+    ) -> None:
+        ffmpeg_changed = False
+        ffprobe_changed = False
+        for role, (_exit_code, err) in exits_and_errors.items():
+            if not _is_timeout_option_error(err):
+                continue
+            spec = specs_by_role[role]
+            match spec.tool:
+                case "ffmpeg":
+                    ffmpeg_changed = (
+                        self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
+                        or ffmpeg_changed
+                    )
+                case "ffprobe":
+                    ffprobe_changed = (
+                        self._timeout_capabilities.mark_ffprobe_timeout_unsupported()
+                        or ffprobe_changed
+                    )
+        if ffmpeg_changed:
+            logger.warning(
+                "ffmpeg timeout options unsupported; disabling RTSP timeout options for this process"
+            )
+        if ffprobe_changed:
+            logger.warning(
+                "ffprobe timeout options unsupported; disabling RTSP timeout options for this process"
+            )
 
     def _wait_for_process_exit(
         self,

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -181,6 +181,7 @@ class _SessionOpenSpec:
     role: str
     input_url: str
     tool: Literal["ffmpeg", "ffprobe"] = "ffmpeg"
+    include_audio: bool = False
 
 
 class RTSPStartupPreflight:
@@ -218,6 +219,7 @@ class RTSPStartupPreflight:
         detect_rtsp_url: str,
         preview_rtsp_url: str | None = None,
         preview_probe_rtsp_url: str | None = None,
+        preview_audio_enabled: bool = False,
     ) -> CameraPreflightOutcome | PreflightError:
         """Run startup preflight and return locked profiles or a typed error."""
 
@@ -310,6 +312,7 @@ class RTSPStartupPreflight:
                 recording_profile=recording_profile,
                 preview_rtsp_url=preview_rtsp_url,
                 preview_probe_rtsp_url=preview_probe_rtsp_url,
+                preview_audio_enabled=preview_audio_enabled,
                 diagnostics=diagnostics,
             )
             return CameraPreflightOutcome(
@@ -345,6 +348,7 @@ class RTSPStartupPreflight:
             recording_profile=recording_profile,
             preview_rtsp_url=preview_rtsp_url,
             preview_probe_rtsp_url=preview_probe_rtsp_url,
+            preview_audio_enabled=preview_audio_enabled,
             diagnostics=diagnostics,
         )
         return CameraPreflightOutcome(
@@ -363,6 +367,7 @@ class RTSPStartupPreflight:
         recording_profile: RecordingProfile,
         preview_rtsp_url: str | None,
         preview_probe_rtsp_url: str | None,
+        preview_audio_enabled: bool,
         diagnostics: CameraPreflightDiagnostics,
     ) -> None:
         if preview_rtsp_url is None:
@@ -391,6 +396,7 @@ class RTSPStartupPreflight:
             motion_profile.input_url,
             recording_profile.input_url,
             preview_rtsp_url,
+            preview_audio_enabled=preview_audio_enabled,
         )
         if validation_result is ConcurrentStreamOpenResult.SUPPORTED:
             diagnostics.concurrent_preview_supported = True
@@ -626,13 +632,19 @@ class RTSPStartupPreflight:
         motion_url: str,
         recording_url: str,
         preview_url: str,
+        *,
+        preview_audio_enabled: bool = False,
     ) -> ConcurrentStreamOpenResult:
         """Validate the current runtime topology for motion, recording, and preview."""
         return self._validate_concurrent_stream_opens(
             [
                 _SessionOpenSpec(role="motion", input_url=motion_url),
                 _SessionOpenSpec(role="recording", input_url=recording_url),
-                _SessionOpenSpec(role="preview", input_url=preview_url),
+                _SessionOpenSpec(
+                    role="preview",
+                    input_url=preview_url,
+                    include_audio=preview_audio_enabled,
+                ),
             ]
         )
 
@@ -799,6 +811,7 @@ class RTSPStartupPreflight:
                     input_url=spec.input_url,
                     timeout_args=timeout_args,
                     duration_s=duration_s,
+                    include_audio=spec.include_audio,
                 )
             case "ffprobe":
                 return self._build_probe_open_cmd(
@@ -813,6 +826,7 @@ class RTSPStartupPreflight:
         input_url: str,
         timeout_args: list[str],
         duration_s: float,
+        include_audio: bool = False,
     ) -> list[str]:
         cmd = [
             "ffmpeg",
@@ -824,18 +838,12 @@ class RTSPStartupPreflight:
             "tcp",
         ]
         cmd.extend(timeout_args)
-        cmd.extend(
-            [
-                "-i",
-                input_url,
-                "-t",
-                f"{max(0.5, duration_s):.1f}",
-                "-an",
-                "-f",
-                "null",
-                "-",
-            ]
-        )
+        cmd.extend(["-i", input_url, "-t", f"{max(0.5, duration_s):.1f}"])
+        if include_audio:
+            cmd.extend(["-map", "0:v:0", "-map", "0:a:0?"])
+        else:
+            cmd.append("-an")
+        cmd.extend(["-f", "null", "-"])
         return cmd
 
     def _build_probe_open_cmd(
@@ -849,13 +857,11 @@ class RTSPStartupPreflight:
             "ffprobe",
             "-v",
             "error",
-            "-select_streams",
-            "v:0",
             "-read_intervals",
             f"%+{max(0.5, duration_s):.1f}",
             "-count_packets",
             "-show_entries",
-            "stream=codec_name,width,height,avg_frame_rate,nb_read_packets",
+            "stream=codec_type,codec_name,width,height,avg_frame_rate,nb_read_packets",
             "-of",
             "json",
             "-rtsp_transport",

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -380,12 +380,12 @@ class RTSPStartupPreflight:
             if probe_validation_result is not ConcurrentStreamOpenResult.SUPPORTED:
                 diagnostics.notes.append(
                     "Concurrent preview startup probe could not be classified during startup; "
-                    "runtime will continue best-effort behavior"
+                    "continuing with preview stream validation"
                 )
-                return
-            diagnostics.notes.append(
-                "Concurrent preview startup probe validated with motion and recording streams"
-            )
+            else:
+                diagnostics.notes.append(
+                    "Concurrent preview startup probe validated with motion and recording streams"
+                )
 
         validation_result = self._validate_concurrent_preview_session_limits(
             motion_profile.input_url,

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -5,6 +5,7 @@ import re
 import signal
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Literal, Protocol
@@ -98,9 +99,12 @@ class CameraPreflightDiagnostics(BaseModel):
     probes: list[ProbeStreamInfo]
     selected_motion_url: str | None = None
     selected_recording_url: str | None = None
+    selected_preview_url: str | None = None
     negotiation_attempts: list[str] = Field(default_factory=list)
     selected_recording_profile: str | None = None
     session_mode: Literal["dual_stream", "single_stream"] | None = None
+    concurrent_preview_supported: bool | None = None
+    concurrent_preview_downgrade_reason: str | None = None
     notes: list[str] = Field(default_factory=list)
 
 
@@ -112,6 +116,8 @@ class CameraPreflightOutcome(BaseModel):
     camera_key: str
     motion_profile: MotionProfile
     recording_profile: RecordingProfile
+    concurrent_preview_supported: bool | None = None
+    concurrent_preview_downgrade_reason: str | None = None
     diagnostics: CameraPreflightDiagnostics
 
 
@@ -151,6 +157,12 @@ class RecordingValidationResult(BaseModel):
     signals: RecordingValidationSignals = Field(default_factory=RecordingValidationSignals)
 
 
+@dataclass(frozen=True, slots=True)
+class _SessionOpenSpec:
+    role: str
+    input_url: str
+
+
 class RTSPStartupPreflight:
     """Startup-only RTSP preflight: discovery, selection, and negotiation."""
 
@@ -184,6 +196,7 @@ class RTSPStartupPreflight:
         camera_name: str,
         primary_rtsp_url: str,
         detect_rtsp_url: str,
+        preview_rtsp_url: str | None = None,
     ) -> CameraPreflightOutcome | PreflightError:
         """Run startup preflight and return locked profiles or a typed error."""
 
@@ -240,6 +253,7 @@ class RTSPStartupPreflight:
 
         diagnostics.selected_motion_url = motion_stream.url
         diagnostics.selected_recording_url = recording_stream.url
+        diagnostics.selected_preview_url = preview_rtsp_url
 
         negotiation = self._negotiate_recording_profile(
             camera_key=camera_key,
@@ -269,10 +283,20 @@ class RTSPStartupPreflight:
 
         if self._validate_session_limits(motion_profile.input_url, recording_profile.input_url):
             diagnostics.session_mode = "dual_stream"
+            self._classify_concurrent_preview(
+                motion_profile=motion_profile,
+                recording_profile=recording_profile,
+                preview_rtsp_url=preview_rtsp_url,
+                diagnostics=diagnostics,
+            )
             return CameraPreflightOutcome(
                 camera_key=camera_key,
                 motion_profile=motion_profile,
                 recording_profile=recording_profile,
+                concurrent_preview_supported=diagnostics.concurrent_preview_supported,
+                concurrent_preview_downgrade_reason=(
+                    diagnostics.concurrent_preview_downgrade_reason
+                ),
                 diagnostics=diagnostics,
             )
 
@@ -293,11 +317,50 @@ class RTSPStartupPreflight:
             )
 
         diagnostics.session_mode = "single_stream"
+        self._classify_concurrent_preview(
+            motion_profile=motion_profile,
+            recording_profile=recording_profile,
+            preview_rtsp_url=preview_rtsp_url,
+            diagnostics=diagnostics,
+        )
         return CameraPreflightOutcome(
             camera_key=camera_key,
             motion_profile=motion_profile,
             recording_profile=recording_profile,
+            concurrent_preview_supported=diagnostics.concurrent_preview_supported,
+            concurrent_preview_downgrade_reason=diagnostics.concurrent_preview_downgrade_reason,
             diagnostics=diagnostics,
+        )
+
+    def _classify_concurrent_preview(
+        self,
+        *,
+        motion_profile: MotionProfile,
+        recording_profile: RecordingProfile,
+        preview_rtsp_url: str | None,
+        diagnostics: CameraPreflightDiagnostics,
+    ) -> None:
+        if preview_rtsp_url is None:
+            return
+
+        if self._validate_concurrent_preview_session_limits(
+            motion_profile.input_url,
+            recording_profile.input_url,
+            preview_rtsp_url,
+        ):
+            diagnostics.concurrent_preview_supported = True
+            diagnostics.notes.append(
+                "Concurrent preview while recording validated with motion, recording, and preview streams"
+            )
+            return
+
+        diagnostics.concurrent_preview_supported = False
+        diagnostics.concurrent_preview_downgrade_reason = (
+            "concurrent_preview_unsupported_by_startup_preflight"
+        )
+        diagnostics.notes.append(
+            "Concurrent preview while recording failed startup validation; "
+            "preview will use recording-first behavior for this process"
         )
 
     def _negotiate_recording_profile(
@@ -490,41 +553,52 @@ class RTSPStartupPreflight:
 
     def _validate_session_limits(self, motion_url: str, recording_url: str) -> bool:
         """Validate that motion and recording pipelines can open concurrently."""
+        return self._validate_concurrent_stream_opens(
+            [
+                _SessionOpenSpec(role="motion", input_url=motion_url),
+                _SessionOpenSpec(role="recording", input_url=recording_url),
+            ]
+        )
+
+    def _validate_concurrent_preview_session_limits(
+        self,
+        motion_url: str,
+        recording_url: str,
+        preview_url: str,
+    ) -> bool:
+        """Validate the current runtime topology for motion, recording, and preview."""
+        return self._validate_concurrent_stream_opens(
+            [
+                _SessionOpenSpec(role="motion", input_url=motion_url),
+                _SessionOpenSpec(role="recording", input_url=recording_url),
+                _SessionOpenSpec(role="preview", input_url=preview_url),
+            ]
+        )
+
+    def _validate_concurrent_stream_opens(self, specs: list[_SessionOpenSpec]) -> bool:
+        """Validate that the requested RTSP consumers can open concurrently."""
         timeout_args = self._timeout_args()
         attempts = _build_timeout_attempts(timeout_args)
         session_check_duration_s = max(2.0, self._session_overlap_s + 0.5)
         completion_timeout_s = session_check_duration_s + 1.5
 
         for label, current_timeout_args in attempts:
-            motion_cmd = self._build_stream_open_cmd(
-                input_url=motion_url,
-                timeout_args=current_timeout_args,
-                duration_s=session_check_duration_s,
-            )
-            recording_cmd = self._build_stream_open_cmd(
-                input_url=recording_url,
-                timeout_args=current_timeout_args,
-                duration_s=session_check_duration_s,
-            )
-
-            motion_proc: subprocess.Popen[str] | None = None
-            recording_proc: subprocess.Popen[str] | None = None
+            procs: dict[str, subprocess.Popen[str] | None] = {spec.role: None for spec in specs}
 
             try:
-                motion_proc = subprocess.Popen(
-                    motion_cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    start_new_session=True,
-                )
-                recording_proc = subprocess.Popen(
-                    recording_cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    start_new_session=True,
-                )
+                for spec in specs:
+                    cmd = self._build_stream_open_cmd(
+                        input_url=spec.input_url,
+                        timeout_args=current_timeout_args,
+                        duration_s=session_check_duration_s,
+                    )
+                    procs[spec.role] = subprocess.Popen(
+                        cmd,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        start_new_session=True,
+                    )
             except Exception as exc:
                 logger.warning(
                     "Session-limit validation failed to launch ffmpeg (%s): %s",
@@ -532,34 +606,35 @@ class RTSPStartupPreflight:
                     exc,
                     exc_info=True,
                 )
-                self._terminate_process(motion_proc)
-                self._terminate_process(recording_proc)
+                for proc in procs.values():
+                    self._terminate_process(proc)
                 continue
 
             time.sleep(self._session_overlap_s)
 
-            motion_exit = motion_proc.poll()
-            recording_exit = recording_proc.poll()
-            if motion_exit is None and recording_exit is None:
-                motion_exit, motion_err = self._wait_for_process_exit(
-                    motion_proc,
-                    timeout_s=completion_timeout_s,
-                )
-                recording_exit, recording_err = self._wait_for_process_exit(
-                    recording_proc,
-                    timeout_s=completion_timeout_s,
-                )
+            initial_exits = {
+                role: proc.poll() if proc is not None else None for role, proc in procs.items()
+            }
+            if all(exit_code is None for exit_code in initial_exits.values()):
+                exits_and_errors = {
+                    role: self._wait_for_process_exit(
+                        proc,
+                        timeout_s=completion_timeout_s,
+                    )
+                    for role, proc in procs.items()
+                }
             else:
-                motion_exit, motion_err = self._terminate_process(motion_proc)
-                recording_exit, recording_err = self._terminate_process(recording_proc)
+                exits_and_errors = {
+                    role: self._terminate_process(proc) for role, proc in procs.items()
+                }
 
-            if motion_exit == 0 and recording_exit == 0:
+            if all(exit_code == 0 for exit_code, _err in exits_and_errors.values()):
                 if label == "timeouts":
                     self._timeout_capabilities.note_ffmpeg_timeout_success()
                 return True
 
-            timeout_option_error = label == "timeouts" and (
-                _is_timeout_option_error(motion_err) or _is_timeout_option_error(recording_err)
+            timeout_option_error = label == "timeouts" and any(
+                _is_timeout_option_error(err) for _exit_code, err in exits_and_errors.values()
             )
             if timeout_option_error:
                 changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
@@ -568,19 +643,18 @@ class RTSPStartupPreflight:
                         "ffmpeg timeout options unsupported; disabling RTSP timeout options for this process"
                     )
                 logger.debug(
-                    "Session-limit validation retrying without timeout options; motion_err=%s recording_err=%s",
-                    motion_err,
-                    recording_err,
+                    "Session-limit validation retrying without timeout options; errors=%s",
+                    {role: err for role, (_exit_code, err) in exits_and_errors.items() if err},
                 )
                 continue
 
+            exits = {role: exit_code for role, (exit_code, _err) in exits_and_errors.items()}
+            errors = {role: err for role, (_exit_code, err) in exits_and_errors.items() if err}
             logger.warning(
-                "Session-limit validation failed (%s): motion_exit=%s recording_exit=%s motion_err=%s recording_err=%s",
+                "Session-limit validation failed (%s): exits=%s errors=%s",
                 label,
-                motion_exit,
-                recording_exit,
-                motion_err,
-                recording_err,
+                exits,
+                errors,
             )
             if label == "timeouts":
                 return False

--- a/src/homesec/sources/rtsp/preflight.py
+++ b/src/homesec/sources/rtsp/preflight.py
@@ -6,6 +6,7 @@ import signal
 import subprocess
 import time
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Literal, Protocol
@@ -42,6 +43,23 @@ logger = logging.getLogger(__name__)
 _NON_MONOTONIC_DTS_RETRY_THRESHOLD = 5
 _QUEUE_BACKWARD_RETRY_THRESHOLD = 1
 _DTS_DISCONTINUITY_RETRY_THRESHOLD = 1
+_SESSION_LIMIT_HINTS: tuple[str, ...] = (
+    "too many clients",
+    "too many connections",
+    "too many sessions",
+    "max number of clients",
+    "maximum number of clients",
+    "maximum number of connections",
+    "session limit",
+    "max sessions",
+    "maximum sessions",
+)
+
+
+class ConcurrentStreamOpenResult(StrEnum):
+    SUPPORTED = "supported"
+    SESSION_LIMIT = "session_limit"
+    FAILED = "failed"
 
 
 class StreamDiscovery(Protocol):
@@ -343,14 +361,22 @@ class RTSPStartupPreflight:
         if preview_rtsp_url is None:
             return
 
-        if self._validate_concurrent_preview_session_limits(
+        validation_result = self._validate_concurrent_preview_session_limits(
             motion_profile.input_url,
             recording_profile.input_url,
             preview_rtsp_url,
-        ):
+        )
+        if validation_result is ConcurrentStreamOpenResult.SUPPORTED:
             diagnostics.concurrent_preview_supported = True
             diagnostics.notes.append(
                 "Concurrent preview while recording validated with motion, recording, and preview streams"
+            )
+            return
+
+        if validation_result is not ConcurrentStreamOpenResult.SESSION_LIMIT:
+            diagnostics.notes.append(
+                "Concurrent preview while recording could not be classified during startup; "
+                "runtime will continue best-effort behavior"
             )
             return
 
@@ -553,11 +579,14 @@ class RTSPStartupPreflight:
 
     def _validate_session_limits(self, motion_url: str, recording_url: str) -> bool:
         """Validate that motion and recording pipelines can open concurrently."""
-        return self._validate_concurrent_stream_opens(
-            [
-                _SessionOpenSpec(role="motion", input_url=motion_url),
-                _SessionOpenSpec(role="recording", input_url=recording_url),
-            ]
+        return (
+            self._validate_concurrent_stream_opens(
+                [
+                    _SessionOpenSpec(role="motion", input_url=motion_url),
+                    _SessionOpenSpec(role="recording", input_url=recording_url),
+                ]
+            )
+            is ConcurrentStreamOpenResult.SUPPORTED
         )
 
     def _validate_concurrent_preview_session_limits(
@@ -565,7 +594,7 @@ class RTSPStartupPreflight:
         motion_url: str,
         recording_url: str,
         preview_url: str,
-    ) -> bool:
+    ) -> ConcurrentStreamOpenResult:
         """Validate the current runtime topology for motion, recording, and preview."""
         return self._validate_concurrent_stream_opens(
             [
@@ -575,7 +604,9 @@ class RTSPStartupPreflight:
             ]
         )
 
-    def _validate_concurrent_stream_opens(self, specs: list[_SessionOpenSpec]) -> bool:
+    def _validate_concurrent_stream_opens(
+        self, specs: list[_SessionOpenSpec]
+    ) -> ConcurrentStreamOpenResult:
         """Validate that the requested RTSP consumers can open concurrently."""
         timeout_args = self._timeout_args()
         attempts = _build_timeout_attempts(timeout_args)
@@ -631,11 +662,14 @@ class RTSPStartupPreflight:
             if all(exit_code == 0 for exit_code, _err in exits_and_errors.values()):
                 if label == "timeouts":
                     self._timeout_capabilities.note_ffmpeg_timeout_success()
-                return True
+                return ConcurrentStreamOpenResult.SUPPORTED
 
             timeout_option_error = label == "timeouts" and any(
                 _is_timeout_option_error(err) for _exit_code, err in exits_and_errors.values()
             )
+            if any(_is_session_limit_error(err) for _exit_code, err in exits_and_errors.values()):
+                return ConcurrentStreamOpenResult.SESSION_LIMIT
+
             if timeout_option_error:
                 changed = self._timeout_capabilities.mark_ffmpeg_timeout_unsupported()
                 if changed:
@@ -657,9 +691,9 @@ class RTSPStartupPreflight:
                 errors,
             )
             if label == "timeouts":
-                return False
+                return ConcurrentStreamOpenResult.FAILED
 
-        return False
+        return ConcurrentStreamOpenResult.FAILED
 
     def _build_recording_check_cmd(
         self,
@@ -823,6 +857,11 @@ def _sanitize_stderr(stderr_text: str, input_url: str) -> str:
     if not stderr_text:
         return ""
     return stderr_text.replace(input_url, _redact_rtsp_url(input_url)).strip()
+
+
+def _is_session_limit_error(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return any(hint in lowered for hint in _SESSION_LIMIT_HINTS)
 
 
 def _collect_recording_stability_signals(stderr_text: str) -> RecordingValidationSignals:

--- a/src/homesec/sources/rtsp/utils.py
+++ b/src/homesec/sources/rtsp/utils.py
@@ -6,6 +6,18 @@ import shlex
 
 logger = logging.getLogger(__name__)
 
+_SESSION_LIMIT_HINTS: tuple[str, ...] = (
+    "too many clients",
+    "too many connections",
+    "too many sessions",
+    "max number of clients",
+    "maximum number of clients",
+    "maximum number of connections",
+    "session limit",
+    "max sessions",
+    "maximum sessions",
+)
+
 
 def _redact_rtsp_url(url: str) -> str:
     if "://" not in url:
@@ -30,6 +42,11 @@ def _is_timeout_option_error(stderr_text: str) -> bool:
     return ("rw_timeout" in text and ("not found" in text or "unrecognized option" in text)) or (
         "stimeout" in text and ("not found" in text or "unrecognized option" in text)
     )
+
+
+def _is_rtsp_session_limit_error(stderr_text: str) -> bool:
+    text = stderr_text.lower()
+    return any(hint in text for hint in _SESSION_LIMIT_HINTS)
 
 
 def _build_timeout_attempts(timeout_args: list[str]) -> list[tuple[str, list[str]]]:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from homesec.sources.rtsp.discovery import CameraProbeResult, ProbeStreamInfo
 from homesec.sources.rtsp.hardware import HardwareAccelConfig
 from homesec.sources.rtsp.live_publisher import (
+    CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON,
     HLSLivePublisher,
     LivePublisherRefusalReason,
     LivePublisherStartRefusal,
@@ -784,6 +785,189 @@ def test_allow_during_recording_allows_start_while_recording_is_active(tmp_path:
     )
     assert len(calls) == 1
     assert publisher.status() == result
+
+
+def test_concurrent_preview_downgrade_blocks_only_while_recording(tmp_path: Path) -> None:
+    """A process-local downgrade should preserve preview outside recording windows."""
+    # Given: A concurrent-preview publisher downgraded by startup preflight
+    reason = "concurrent_preview_unsupported_by_startup_preflight"
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.downgrade_concurrent_preview(reason)
+
+    # When: Preview starts while the camera is not recording
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        started = publisher.ensure_active()
+        proc = calls[0]["proc"]
+        assert isinstance(proc, FakeProc)
+        publisher.sync_recording_active(True)
+        refused = publisher.ensure_active()
+
+    # Then: Preview is allowed before recording and blocked with an API-visible reason during recording
+    assert started == LivePublisherStatus(
+        state=LivePublisherState.DEGRADED,
+        viewer_count=0,
+        degraded_reason=reason,
+        idle_shutdown_at=5.0,
+    )
+    assert proc.terminate_calls == 1
+    assert isinstance(refused, LivePublisherStartRefusal)
+    assert refused.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert "downgraded" in refused.message
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.DEGRADED,
+        viewer_count=0,
+        degraded_reason=reason,
+    )
+
+    # When: Recording ends
+    publisher.sync_recording_active(False)
+
+    # Then: The downgrade reason remains visible while idle preview can start later
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+        degraded_reason=reason,
+    )
+
+
+def test_repeated_start_failures_while_recording_downgrade_concurrent_preview(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    """Two preview startup failures during recording should trigger a runtime downgrade."""
+    # Given: A concurrent-preview publisher whose ffmpeg start fails while recording is active
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    # When: Preview startup fails twice during the same recording window
+    with (
+        caplog.at_level(logging.WARNING, logger="homesec.sources.rtsp.live_publisher"),
+        patch(
+            "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+            side_effect=_fake_popen_factory(
+                calls,
+                make_output=False,
+                returncode=1,
+                stderr_text="Too many clients already connected.\n",
+            ),
+        ),
+    ):
+        first = publisher.ensure_active()
+        second = publisher.ensure_active()
+        third = publisher.ensure_active()
+
+    # Then: The first noisy failure is returned directly, the second downgrades, and later starts are blocked
+    assert isinstance(first, LivePublisherStartRefusal)
+    assert first.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert isinstance(second, LivePublisherStartRefusal)
+    assert second.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert isinstance(third, LivePublisherStartRefusal)
+    assert third.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert len(calls) == 2
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.DEGRADED,
+        viewer_count=0,
+        degraded_reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON,
+    )
+    assert any(
+        "Downgrading concurrent preview while recording" in record.message
+        for record in caplog.records
+    )
+
+
+def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
+    tmp_path: Path,
+) -> None:
+    """Two early preview exits during recording should trigger a runtime downgrade."""
+    # Given: A concurrent-preview publisher where startup succeeds during recording
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    # When: Two started preview ffmpeg processes exit early while recording is active
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first_start = publisher.ensure_active()
+        first_proc = calls[0]["proc"]
+        assert isinstance(first_proc, FakeProc)
+        first_proc.returncode = 1
+        first_status = publisher.status()
+
+        second_start = publisher.ensure_active()
+        second_proc = calls[1]["proc"]
+        assert isinstance(second_proc, FakeProc)
+        second_proc.returncode = 1
+        second_status = publisher.status()
+        after_downgrade = publisher.ensure_active()
+
+    # Then: The second early exit downgrades concurrent preview for the process
+    assert isinstance(first_start, LivePublisherStatus)
+    assert first_start.state == LivePublisherState.READY
+    assert first_status.state == LivePublisherState.ERROR
+    assert first_status.degraded_reason is None
+    assert isinstance(second_start, LivePublisherStatus)
+    assert second_start.state == LivePublisherState.READY
+    assert second_status.state == LivePublisherState.DEGRADED
+    assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
+    assert isinstance(after_downgrade, LivePublisherStartRefusal)
+    assert after_downgrade.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert len(calls) == 2
+
+
+def test_later_preview_exits_while_recording_do_not_downgrade_concurrent_preview(
+    tmp_path: Path,
+) -> None:
+    """Stable previews should not be treated as noisy concurrent-preview failures."""
+    # Given: A concurrent-preview publisher with a preview that stays up past the early-exit window
+    clock = FakeClock()
+    publisher = _make_publisher(
+        tmp_path,
+        clock=clock,
+        recording_policy="allow_during_recording",
+    )
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    # When: Two preview processes exit after they have been stable for a while
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        first_start = publisher.ensure_active()
+        first_proc = calls[0]["proc"]
+        assert isinstance(first_proc, FakeProc)
+        clock.sleep(7.0)
+        first_proc.returncode = 1
+        first_status = publisher.status()
+
+        second_start = publisher.ensure_active()
+        second_proc = calls[1]["proc"]
+        assert isinstance(second_proc, FakeProc)
+        clock.sleep(7.0)
+        second_proc.returncode = 1
+        second_status = publisher.status()
+
+        third_start = publisher.ensure_active()
+
+    # Then: Later exits remain ordinary preview errors and concurrent preview is still attempted
+    assert isinstance(first_start, LivePublisherStatus)
+    assert first_start.state == LivePublisherState.READY
+    assert first_status.state == LivePublisherState.ERROR
+    assert first_status.degraded_reason is None
+    assert isinstance(second_start, LivePublisherStatus)
+    assert second_start.state == LivePublisherState.READY
+    assert second_status.state == LivePublisherState.ERROR
+    assert second_status.degraded_reason is None
+    assert isinstance(third_start, LivePublisherStatus)
+    assert third_start.state == LivePublisherState.READY
+    assert len(calls) == 3
 
 
 def test_start_failure_maps_session_budget_refusal_and_cleans_storage(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -834,6 +834,39 @@ def test_concurrent_preview_downgrade_blocks_only_while_recording(tmp_path: Path
     )
 
 
+def test_downgraded_preview_crash_reports_error_when_not_recording(tmp_path: Path) -> None:
+    """A downgraded camera should still report local preview crashes as errors."""
+    # Given: A downgraded concurrent-preview publisher running outside a recording window
+    reason = "concurrent_preview_unsupported_by_startup_preflight"
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.downgrade_concurrent_preview(reason)
+
+    # When: Preview starts because recording is inactive, then ffmpeg exits unexpectedly
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            stderr_text="Encoder died after startup.\n",
+        ),
+    ):
+        started = publisher.ensure_active()
+        proc = calls[0]["proc"]
+        assert isinstance(proc, FakeProc)
+        proc.returncode = 1
+        status_after_exit = publisher.status()
+
+    # Then: The downgrade reason remains visible but the dead preview is not reported as playable
+    assert isinstance(started, LivePublisherStatus)
+    assert started.state == LivePublisherState.DEGRADED
+    assert status_after_exit == LivePublisherStatus(
+        state=LivePublisherState.ERROR,
+        viewer_count=0,
+        degraded_reason=reason,
+        last_error="Encoder died after startup.",
+    )
+
+
 def test_repeated_start_failures_while_recording_downgrade_concurrent_preview(
     tmp_path: Path,
     caplog,

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1001,6 +1001,69 @@ def test_successful_start_resets_recording_failure_counter(tmp_path: Path) -> No
     assert len(calls) == 3
 
 
+def test_successful_start_separates_start_failure_from_early_exit(
+    tmp_path: Path,
+) -> None:
+    """A start failure followed by a successful preview should not combine with an early exit."""
+    # Given: A concurrent-preview publisher with one session-budget failure followed by success
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **_: object,
+    ) -> FakeProc:
+        call_index = len(calls)
+        proc = FakeProc(
+            pid=915_000_000 + call_index,
+            returncode=1 if call_index == 0 else None,
+        )
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+                "proc": proc,
+            }
+        )
+        if call_index == 0 and hasattr(stderr, "write") and hasattr(stderr, "flush"):
+            stderr_handle = cast(_Writable, stderr)
+            stderr_handle.write("Too many clients already connected.\n")
+            stderr_handle.flush()
+        elif call_index == 1:
+            playlist_path = Path(cmd[-1])
+            segment_pattern = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+            _write_live_output(
+                playlist_path=playlist_path,
+                segment_pattern=segment_pattern,
+            )
+        return proc
+
+    # When: The successful preview exits early after the initial start failure
+    with patch("homesec.sources.rtsp.live_publisher.subprocess.Popen", side_effect=fake_popen):
+        first = publisher.ensure_active()
+        second = publisher.ensure_active()
+        second_proc = calls[1]["proc"]
+        assert isinstance(second_proc, FakeProc)
+        second_proc.returncode = 1
+        status_after_exit = publisher.status()
+
+    # Then: The early exit starts its own streak instead of downgrading immediately
+    assert isinstance(first, LivePublisherStartRefusal)
+    assert first.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert isinstance(second, LivePublisherStatus)
+    assert second.state == LivePublisherState.READY
+    assert status_after_exit.state == LivePublisherState.ERROR
+    assert status_after_exit.degraded_reason is None
+    assert len(calls) == 2
+
+
 def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
     tmp_path: Path,
 ) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1186,19 +1186,34 @@ def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
         second_proc.returncode = 1
         second_status = publisher.status()
         after_downgrade = publisher.ensure_active()
+        publisher.sync_recording_active(False)
+        after_recording = publisher.status()
+        restarted = publisher.ensure_active()
 
-    # Then: The second early exit downgrades concurrent preview without reporting playable media
+    # Then: The second early exit downgrades concurrent preview without a sticky error state
     assert isinstance(first_start, LivePublisherStatus)
     assert first_start.state == LivePublisherState.READY
     assert first_status.state == LivePublisherState.ERROR
     assert first_status.degraded_reason is None
     assert isinstance(second_start, LivePublisherStatus)
     assert second_start.state == LivePublisherState.READY
-    assert second_status.state == LivePublisherState.ERROR
-    assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
+    assert second_status == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+        degraded_reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON,
+        last_error="Too many clients already connected.",
+    )
     assert isinstance(after_downgrade, LivePublisherStartRefusal)
     assert after_downgrade.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
-    assert len(calls) == 2
+    assert after_recording == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+        degraded_reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON,
+    )
+    assert isinstance(restarted, LivePublisherStatus)
+    assert restarted.state == LivePublisherState.DEGRADED
+    assert restarted.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
+    assert len(calls) == 3
 
 
 def test_non_session_early_exits_while_recording_do_not_downgrade_concurrent_preview(
@@ -1370,8 +1385,12 @@ def test_recording_activation_starts_early_exit_window_for_existing_preview(
     assert first_status.degraded_reason is None
     assert isinstance(second_start, LivePublisherStatus)
     assert second_start.state == LivePublisherState.READY
-    assert second_status.state == LivePublisherState.ERROR
-    assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
+    assert second_status == LivePublisherStatus(
+        state=LivePublisherState.IDLE,
+        viewer_count=0,
+        degraded_reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON,
+        last_error="Too many clients already connected.",
+    )
     assert len(calls) == 2
 
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -818,7 +818,7 @@ def test_concurrent_preview_downgrade_blocks_only_while_recording(tmp_path: Path
     assert refused.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
     assert "downgraded" in refused.message
     assert publisher.status() == LivePublisherStatus(
-        state=LivePublisherState.DEGRADED,
+        state=LivePublisherState.IDLE,
         viewer_count=0,
         degraded_reason=reason,
     )
@@ -903,7 +903,7 @@ def test_repeated_start_failures_while_recording_downgrade_concurrent_preview(
     assert third.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
     assert len(calls) == 2
     assert publisher.status() == LivePublisherStatus(
-        state=LivePublisherState.DEGRADED,
+        state=LivePublisherState.IDLE,
         viewer_count=0,
         degraded_reason=CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON,
     )
@@ -1187,14 +1187,14 @@ def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
         second_status = publisher.status()
         after_downgrade = publisher.ensure_active()
 
-    # Then: The second early exit downgrades concurrent preview for the process
+    # Then: The second early exit downgrades concurrent preview without reporting playable media
     assert isinstance(first_start, LivePublisherStatus)
     assert first_start.state == LivePublisherState.READY
     assert first_status.state == LivePublisherState.ERROR
     assert first_status.degraded_reason is None
     assert isinstance(second_start, LivePublisherStatus)
     assert second_start.state == LivePublisherState.READY
-    assert second_status.state == LivePublisherState.DEGRADED
+    assert second_status.state == LivePublisherState.ERROR
     assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
     assert isinstance(after_downgrade, LivePublisherStartRefusal)
     assert after_downgrade.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
@@ -1370,7 +1370,7 @@ def test_recording_activation_starts_early_exit_window_for_existing_preview(
     assert first_status.degraded_reason is None
     assert isinstance(second_start, LivePublisherStatus)
     assert second_start.state == LivePublisherState.READY
-    assert second_status.state == LivePublisherState.DEGRADED
+    assert second_status.state == LivePublisherState.ERROR
     assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
     assert len(calls) == 2
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1076,7 +1076,10 @@ def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
     # When: Two started preview ffmpeg processes exit early while recording is active
     with patch(
         "homesec.sources.rtsp.live_publisher.subprocess.Popen",
-        side_effect=_fake_popen_factory(calls),
+        side_effect=_fake_popen_factory(
+            calls,
+            stderr_text="Too many clients already connected.\n",
+        ),
     ):
         first_start = publisher.ensure_active()
         first_proc = calls[0]["proc"]
@@ -1102,6 +1105,99 @@ def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
     assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
     assert isinstance(after_downgrade, LivePublisherStartRefusal)
     assert after_downgrade.reason == LivePublisherRefusalReason.RECORDING_PRIORITY
+    assert len(calls) == 2
+
+
+def test_non_session_early_exits_while_recording_do_not_downgrade_concurrent_preview(
+    tmp_path: Path,
+) -> None:
+    """Early exits without session-limit signals should not force recording-priority mode."""
+    # Given: A concurrent-preview publisher whose preview exits early with local ffmpeg errors
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    # When: Two started preview ffmpeg processes exit early for non-session reasons
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            stderr_text="Encoder failed before producing the next segment.\n",
+        ),
+    ):
+        first_start = publisher.ensure_active()
+        first_proc = calls[0]["proc"]
+        assert isinstance(first_proc, FakeProc)
+        first_proc.returncode = 1
+        first_status = publisher.status()
+
+        second_start = publisher.ensure_active()
+        second_proc = calls[1]["proc"]
+        assert isinstance(second_proc, FakeProc)
+        second_proc.returncode = 1
+        second_status = publisher.status()
+
+        third_start = publisher.ensure_active()
+
+    # Then: The exits remain ordinary preview errors and concurrent preview is still attempted
+    assert isinstance(first_start, LivePublisherStatus)
+    assert first_start.state == LivePublisherState.READY
+    assert first_status.state == LivePublisherState.ERROR
+    assert first_status.degraded_reason is None
+    assert isinstance(second_start, LivePublisherStatus)
+    assert second_start.state == LivePublisherState.READY
+    assert second_status.state == LivePublisherState.ERROR
+    assert second_status.degraded_reason is None
+    assert isinstance(third_start, LivePublisherStatus)
+    assert third_start.state == LivePublisherState.READY
+    assert len(calls) == 3
+
+
+def test_recording_activation_starts_early_exit_window_for_existing_preview(
+    tmp_path: Path,
+) -> None:
+    """A stable preview should still count if it exits right after recording starts."""
+    # Given: A concurrent-preview publisher with preview already stable before recording starts
+    clock = FakeClock()
+    publisher = _make_publisher(
+        tmp_path,
+        clock=clock,
+        idle_timeout_s=20.0,
+        recording_policy="allow_during_recording",
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: recording starts after the preview is stable, then two previews exit immediately
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(
+            calls,
+            stderr_text="Too many clients already connected.\n",
+        ),
+    ):
+        first_start = publisher.ensure_active()
+        first_proc = calls[0]["proc"]
+        assert isinstance(first_proc, FakeProc)
+        clock.sleep(7.0)
+        publisher.sync_recording_active(True)
+        first_proc.returncode = 1
+        first_status = publisher.status()
+
+        second_start = publisher.ensure_active()
+        second_proc = calls[1]["proc"]
+        assert isinstance(second_proc, FakeProc)
+        second_proc.returncode = 1
+        second_status = publisher.status()
+
+    # Then: the recording transition starts the failure window and the second exit downgrades
+    assert isinstance(first_start, LivePublisherStatus)
+    assert first_start.state == LivePublisherState.READY
+    assert first_status.state == LivePublisherState.ERROR
+    assert first_status.degraded_reason is None
+    assert isinstance(second_start, LivePublisherStatus)
+    assert second_start.state == LivePublisherState.READY
+    assert second_status.state == LivePublisherState.DEGRADED
+    assert second_status.degraded_reason == CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON
     assert len(calls) == 2
 
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -1001,6 +1001,66 @@ def test_successful_start_resets_recording_failure_counter(tmp_path: Path) -> No
     assert len(calls) == 3
 
 
+def test_intervening_temporary_start_failure_resets_recording_failure_counter(
+    tmp_path: Path,
+) -> None:
+    """A non-session start failure should break a session-budget failure streak."""
+    # Given: A concurrent-preview publisher with mixed start failures while recording
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+    stderr_by_call = [
+        "Too many clients already connected.\n",
+        "Encoder failed before producing the first segment.\n",
+        "Too many clients already connected.\n",
+    ]
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **_: object,
+    ) -> FakeProc:
+        call_index = len(calls)
+        proc = FakeProc(pid=916_000_000 + call_index, returncode=1)
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+                "proc": proc,
+            }
+        )
+        if hasattr(stderr, "write") and hasattr(stderr, "flush"):
+            stderr_handle = cast(_Writable, stderr)
+            stderr_handle.write(stderr_by_call[call_index])
+            stderr_handle.flush()
+        return proc
+
+    # When: A generic preview failure lands between two session-budget failures
+    with patch("homesec.sources.rtsp.live_publisher.subprocess.Popen", side_effect=fake_popen):
+        first = publisher.ensure_active()
+        second = publisher.ensure_active()
+        third = publisher.ensure_active()
+
+    # Then: The later session-budget failure starts a new streak instead of downgrading
+    assert isinstance(first, LivePublisherStartRefusal)
+    assert first.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert isinstance(second, LivePublisherStartRefusal)
+    assert second.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert isinstance(third, LivePublisherStartRefusal)
+    assert third.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.ERROR,
+        viewer_count=0,
+        last_error="Too many clients already connected.",
+    )
+    assert len(calls) == 3
+
+
 def test_successful_start_separates_start_failure_from_early_exit(
     tmp_path: Path,
 ) -> None:
@@ -1150,6 +1210,87 @@ def test_non_session_early_exits_while_recording_do_not_downgrade_concurrent_pre
     assert second_status.degraded_reason is None
     assert isinstance(third_start, LivePublisherStatus)
     assert third_start.state == LivePublisherState.READY
+    assert len(calls) == 3
+
+
+def test_intervening_non_session_early_exit_resets_recording_failure_counter(
+    tmp_path: Path,
+) -> None:
+    """A non-session early exit should break a session-budget early-exit streak."""
+    # Given: A concurrent-preview publisher with mixed early exits while recording
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+    stderr_by_call = [
+        "Too many clients already connected.\n",
+        "Encoder failed after startup.\n",
+        "Too many clients already connected.\n",
+    ]
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **_: object,
+    ) -> FakeProc:
+        call_index = len(calls)
+        proc = FakeProc(pid=925_000_000 + call_index)
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+                "proc": proc,
+            }
+        )
+        if hasattr(stderr, "write") and hasattr(stderr, "flush"):
+            stderr_handle = cast(_Writable, stderr)
+            stderr_handle.write(stderr_by_call[call_index])
+            stderr_handle.flush()
+        playlist_path = Path(cmd[-1])
+        segment_pattern = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+        _write_live_output(
+            playlist_path=playlist_path,
+            segment_pattern=segment_pattern,
+        )
+        return proc
+
+    # When: A generic early exit lands between two session-budget early exits
+    with patch("homesec.sources.rtsp.live_publisher.subprocess.Popen", side_effect=fake_popen):
+        first_start = publisher.ensure_active()
+        first_proc = calls[0]["proc"]
+        assert isinstance(first_proc, FakeProc)
+        first_proc.returncode = 1
+        first_status = publisher.status()
+
+        second_start = publisher.ensure_active()
+        second_proc = calls[1]["proc"]
+        assert isinstance(second_proc, FakeProc)
+        second_proc.returncode = 1
+        second_status = publisher.status()
+
+        third_start = publisher.ensure_active()
+        third_proc = calls[2]["proc"]
+        assert isinstance(third_proc, FakeProc)
+        third_proc.returncode = 1
+        third_status = publisher.status()
+
+    # Then: The later session-budget early exit starts a new streak instead of downgrading
+    assert isinstance(first_start, LivePublisherStatus)
+    assert first_start.state == LivePublisherState.READY
+    assert first_status.state == LivePublisherState.ERROR
+    assert first_status.degraded_reason is None
+    assert isinstance(second_start, LivePublisherStatus)
+    assert second_start.state == LivePublisherState.READY
+    assert second_status.state == LivePublisherState.ERROR
+    assert second_status.degraded_reason is None
+    assert isinstance(third_start, LivePublisherStatus)
+    assert third_start.state == LivePublisherState.READY
+    assert third_status.state == LivePublisherState.ERROR
+    assert third_status.degraded_reason is None
     assert len(calls) == 3
 
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -880,6 +880,127 @@ def test_repeated_start_failures_while_recording_downgrade_concurrent_preview(
     )
 
 
+def test_temporary_start_failures_while_recording_do_not_downgrade_concurrent_preview(
+    tmp_path: Path,
+) -> None:
+    """Local preview setup failures should not classify the camera as concurrency-limited."""
+    # Given: A concurrent-preview publisher whose start failures are local preview errors
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **_: object,
+    ) -> FakeProc:
+        call_index = len(calls)
+        proc = FakeProc(
+            pid=905_000_000 + call_index,
+            returncode=1 if call_index < 2 else None,
+        )
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+                "proc": proc,
+            }
+        )
+        if call_index < 2:
+            return proc
+        playlist_path = Path(cmd[-1])
+        segment_pattern = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+        _write_live_output(
+            playlist_path=playlist_path,
+            segment_pattern=segment_pattern,
+        )
+        return proc
+
+    # When: Preview startup fails twice without a session-budget signal, then succeeds
+    with patch("homesec.sources.rtsp.live_publisher.subprocess.Popen", side_effect=fake_popen):
+        first = publisher.ensure_active()
+        second = publisher.ensure_active()
+        third = publisher.ensure_active()
+
+    # Then: The local failures remain temporary refusals and do not force recording-priority mode
+    assert isinstance(first, LivePublisherStartRefusal)
+    assert first.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert isinstance(second, LivePublisherStartRefusal)
+    assert second.reason == LivePublisherRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE
+    assert isinstance(third, LivePublisherStatus)
+    assert third.state == LivePublisherState.READY
+    assert publisher.status().degraded_reason is None
+
+
+def test_successful_start_resets_recording_failure_counter(tmp_path: Path) -> None:
+    """A successful concurrent preview start should break a failure streak."""
+    # Given: A concurrent-preview publisher with one session-budget failure followed by success
+    publisher = _make_publisher(tmp_path, recording_policy="allow_during_recording")
+    calls: list[dict[str, object]] = []
+    publisher.sync_recording_active(True)
+
+    def fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **_: object,
+    ) -> FakeProc:
+        call_index = len(calls)
+        proc = FakeProc(
+            pid=910_000_000 + call_index,
+            returncode=1 if call_index in (0, 2) else None,
+        )
+        calls.append(
+            {
+                "cmd": list(cmd),
+                "stdout": stdout,
+                "stderr": stderr,
+                "start_new_session": start_new_session,
+                "proc": proc,
+            }
+        )
+        if call_index == 1:
+            playlist_path = Path(cmd[-1])
+            segment_pattern = Path(cmd[cmd.index("-hls_segment_filename") + 1])
+            _write_live_output(
+                playlist_path=playlist_path,
+                segment_pattern=segment_pattern,
+            )
+        elif hasattr(stderr, "write") and hasattr(stderr, "flush"):
+            stderr_handle = cast(_Writable, stderr)
+            stderr_handle.write("Too many clients already connected.\n")
+            stderr_handle.flush()
+        return proc
+
+    # When: A start failure is separated from the next failure by a successful preview
+    with patch("homesec.sources.rtsp.live_publisher.subprocess.Popen", side_effect=fake_popen):
+        first = publisher.ensure_active()
+        second = publisher.ensure_active()
+        publisher.request_stop()
+        third = publisher.ensure_active()
+
+    # Then: The later failure is treated as a new streak, not the second consecutive strike
+    assert isinstance(first, LivePublisherStartRefusal)
+    assert first.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert isinstance(second, LivePublisherStatus)
+    assert second.state == LivePublisherState.READY
+    assert isinstance(third, LivePublisherStartRefusal)
+    assert third.reason == LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+    assert publisher.status() == LivePublisherStatus(
+        state=LivePublisherState.ERROR,
+        viewer_count=0,
+        last_error="Too many clients already connected.",
+    )
+    assert len(calls) == 3
+
+
 def test_repeated_early_exits_while_recording_downgrade_concurrent_preview(
     tmp_path: Path,
 ) -> None:

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -20,6 +20,10 @@ from homesec.sources.rtsp.live_publisher import (
     LivePublisherState,
     LivePublisherStatus,
 )
+from homesec.sources.rtsp.preflight import (
+    CameraPreflightDiagnostics,
+    CameraPreflightOutcome,
+)
 from homesec.sources.rtsp.recorder import FfmpegRecorder
 from homesec.sources.rtsp.recording_profile import MotionProfile, build_default_recording_profile
 
@@ -126,6 +130,7 @@ class FakeLivePublisher:
         self.ensure_result: LivePublisherStatus | LivePublisherStartRefusal = self._status
         self.viewer_activity: list[str | None] = []
         self.recording_active: list[bool] = []
+        self.concurrent_preview_downgrades: list[str] = []
         self.stop_calls = 0
         self.shutdown_calls = 0
 
@@ -134,6 +139,9 @@ class FakeLivePublisher:
 
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
         return self.ensure_result
+
+    def downgrade_concurrent_preview(self, reason: str) -> None:
+        self.concurrent_preview_downgrades.append(reason)
 
     def request_stop(self) -> None:
         self.stop_calls += 1
@@ -163,6 +171,10 @@ class RaisingLivePublisher:
     def ensure_active(self) -> LivePublisherStatus | LivePublisherStartRefusal:
         self._raise_if_configured("ensure_active")
         return LivePublisherStatus(state=LivePublisherState.READY)
+
+    def downgrade_concurrent_preview(self, reason: str) -> None:
+        _ = reason
+        self._raise_if_configured("downgrade_concurrent_preview")
 
     def request_stop(self) -> None:
         self._raise_if_configured("request_stop")
@@ -410,6 +422,110 @@ def test_session_limit_fallback_uses_default_recording_profile(tmp_path: Path) -
     expected_profile = build_default_recording_profile(source.rtsp_url)
     assert outcome.recording_profile == expected_profile
     assert outcome.diagnostics.selected_recording_profile == expected_profile.profile_id()
+
+
+def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requested(
+    tmp_path: Path,
+) -> None:
+    """RTSPSource should validate the preview input URL used by the HLS publisher."""
+
+    class _FakePreflight:
+        def __init__(self) -> None:
+            self.preview_rtsp_url: str | None = None
+
+        def run(
+            self,
+            *,
+            camera_name: str,
+            primary_rtsp_url: str,
+            detect_rtsp_url: str,
+            preview_rtsp_url: str | None = None,
+        ) -> CameraPreflightOutcome:
+            # Given: source startup asks preflight to validate current runtime topology
+            _ = camera_name
+            self.preview_rtsp_url = preview_rtsp_url
+            recording_profile = build_default_recording_profile(primary_rtsp_url)
+            return CameraPreflightOutcome(
+                camera_key="cam-key",
+                motion_profile=MotionProfile(input_url=detect_rtsp_url),
+                recording_profile=recording_profile,
+                concurrent_preview_supported=True,
+                diagnostics=CameraPreflightDiagnostics(
+                    attempted_urls=[primary_rtsp_url, detect_rtsp_url],
+                    probes=[],
+                    selected_motion_url=detect_rtsp_url,
+                    selected_recording_url=primary_rtsp_url,
+                    selected_preview_url=preview_rtsp_url,
+                    selected_recording_profile=recording_profile.profile_id(),
+                    session_mode="dual_stream",
+                    concurrent_preview_supported=True,
+                ),
+            )
+
+    # Given: an RTSP source configured for concurrent preview while recording
+    publisher = FakeLivePublisher()
+    config = _make_config(
+        tmp_path,
+        rtsp_url="rtsp://host/main",
+        detect_rtsp_url="rtsp://host/detect",
+        __runtime_preview__={
+            "enabled": True,
+            "recording_policy": "allow_during_recording",
+        },
+    )
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+    fake_preflight = _FakePreflight()
+    source._preflight = fake_preflight  # noqa: SLF001
+
+    # When: startup preflight runs
+    source._run_startup_preflight()  # noqa: SLF001
+
+    # Then: the preview check receives the main RTSP URL used by HLSLivePublisher today
+    assert fake_preflight.preview_rtsp_url == "rtsp://host/main"
+    assert publisher.concurrent_preview_downgrades == []
+
+
+def test_startup_preflight_downgrade_reaches_live_publisher(tmp_path: Path) -> None:
+    """RTSPSource should apply failed preview classification to the live publisher."""
+    # Given: a preflight outcome that marks concurrent preview unsupported
+    publisher = FakeLivePublisher()
+    config = _make_config(
+        tmp_path,
+        __runtime_preview__={
+            "enabled": True,
+            "recording_policy": "allow_during_recording",
+        },
+    )
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+    recording_profile = build_default_recording_profile(source.rtsp_url)
+    outcome = CameraPreflightOutcome(
+        camera_key="cam-key",
+        motion_profile=MotionProfile(input_url=source.detect_rtsp_url),
+        recording_profile=recording_profile,
+        concurrent_preview_supported=False,
+        concurrent_preview_downgrade_reason=("concurrent_preview_unsupported_by_startup_preflight"),
+        diagnostics=CameraPreflightDiagnostics(
+            attempted_urls=[source.rtsp_url],
+            probes=[],
+            selected_motion_url=source.detect_rtsp_url,
+            selected_recording_url=source.rtsp_url,
+            selected_preview_url=source.rtsp_url,
+            selected_recording_profile=recording_profile.profile_id(),
+            session_mode="dual_stream",
+            concurrent_preview_supported=False,
+            concurrent_preview_downgrade_reason=(
+                "concurrent_preview_unsupported_by_startup_preflight"
+            ),
+        ),
+    )
+
+    # When: applying startup preflight output
+    source._apply_preflight_outcome(outcome)  # noqa: SLF001
+
+    # Then: the publisher receives the process-local downgrade reason
+    assert publisher.concurrent_preview_downgrades == [
+        "concurrent_preview_unsupported_by_startup_preflight"
+    ]
 
 
 def test_default_preview_seam_refuses_until_backend_is_wired(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -439,10 +439,11 @@ def test_startup_preflight_fallback_keeps_concurrent_preview_unclassified(
             detect_rtsp_url: str,
             preview_rtsp_url: str | None = None,
             preview_probe_rtsp_url: str | None = None,
+            preview_audio_enabled: bool = False,
         ) -> PreflightError:
             # Given: startup validation cannot classify the RTSP session topology
             _ = camera_name, primary_rtsp_url, detect_rtsp_url
-            _ = preview_rtsp_url, preview_probe_rtsp_url
+            _ = preview_rtsp_url, preview_probe_rtsp_url, preview_audio_enabled
             return PreflightError(
                 camera_key="cam-key",
                 stage="session_limit",
@@ -480,6 +481,7 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
         def __init__(self) -> None:
             self.preview_rtsp_url: str | None = None
             self.preview_probe_rtsp_url: str | None = None
+            self.preview_audio_enabled: bool | None = None
 
         def run(
             self,
@@ -489,11 +491,13 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
             detect_rtsp_url: str,
             preview_rtsp_url: str | None = None,
             preview_probe_rtsp_url: str | None = None,
+            preview_audio_enabled: bool = False,
         ) -> CameraPreflightOutcome:
             # Given: source startup asks preflight to validate current runtime topology
             _ = camera_name
             self.preview_rtsp_url = preview_rtsp_url
             self.preview_probe_rtsp_url = preview_probe_rtsp_url
+            self.preview_audio_enabled = preview_audio_enabled
             recording_profile = build_default_recording_profile(primary_rtsp_url)
             return CameraPreflightOutcome(
                 camera_key="cam-key",
@@ -534,6 +538,7 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
     # Then: the preview check receives the main RTSP URL used by HLSLivePublisher today
     assert fake_preflight.preview_rtsp_url == "rtsp://host/main"
     assert fake_preflight.preview_probe_rtsp_url == "rtsp://host/main"
+    assert fake_preflight.preview_audio_enabled is True
     assert publisher.concurrent_preview_downgrades == []
 
 

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -23,6 +23,7 @@ from homesec.sources.rtsp.live_publisher import (
 from homesec.sources.rtsp.preflight import (
     CameraPreflightDiagnostics,
     CameraPreflightOutcome,
+    PreflightError,
 )
 from homesec.sources.rtsp.recorder import FfmpegRecorder
 from homesec.sources.rtsp.recording_profile import MotionProfile, build_default_recording_profile
@@ -422,6 +423,52 @@ def test_session_limit_fallback_uses_default_recording_profile(tmp_path: Path) -
     expected_profile = build_default_recording_profile(source.rtsp_url)
     assert outcome.recording_profile == expected_profile
     assert outcome.diagnostics.selected_recording_profile == expected_profile.profile_id()
+
+
+def test_startup_preflight_fallback_keeps_concurrent_preview_unclassified(
+    tmp_path: Path,
+) -> None:
+    """Session fallback should not force a process-local preview downgrade by itself."""
+
+    class _FailingPreflight:
+        def run(
+            self,
+            *,
+            camera_name: str,
+            primary_rtsp_url: str,
+            detect_rtsp_url: str,
+            preview_rtsp_url: str | None = None,
+            preview_probe_rtsp_url: str | None = None,
+        ) -> PreflightError:
+            # Given: startup validation cannot classify the RTSP session topology
+            _ = camera_name, primary_rtsp_url, detect_rtsp_url
+            _ = preview_rtsp_url, preview_probe_rtsp_url
+            return PreflightError(
+                camera_key="cam-key",
+                stage="session_limit",
+                message="generic startup validation failure",
+            )
+
+    # Given: an RTSP source configured to request concurrent preview while recording
+    publisher = FakeLivePublisher()
+    config = _make_config(
+        tmp_path,
+        __runtime_preview__={
+            "enabled": True,
+            "recording_policy": "allow_during_recording",
+        },
+    )
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+    source._preflight = _FailingPreflight()  # noqa: SLF001
+
+    # When: startup falls back to the default single-stream profile
+    source._run_startup_preflight()  # noqa: SLF001
+
+    # Then: concurrent preview remains unclassified instead of being downgraded
+    assert source._preflight_outcome is not None  # noqa: SLF001
+    assert source._preflight_outcome.concurrent_preview_supported is None  # noqa: SLF001
+    assert source._preflight_outcome.concurrent_preview_downgrade_reason is None  # noqa: SLF001
+    assert publisher.concurrent_preview_downgrades == []
 
 
 def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requested(

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -528,6 +528,54 @@ def test_startup_preflight_downgrade_reaches_live_publisher(tmp_path: Path) -> N
     ]
 
 
+def test_startup_preflight_downgrade_failure_does_not_abort_source(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Preview downgrade sync errors should not take the RTSP source offline."""
+    # Given: a preflight outcome that marks concurrent preview unsupported
+    publisher = RaisingLivePublisher(methods={"downgrade_concurrent_preview"})
+    config = _make_config(
+        tmp_path,
+        __runtime_preview__={
+            "enabled": True,
+            "recording_policy": "allow_during_recording",
+        },
+    )
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+    recording_profile = build_default_recording_profile(source.rtsp_url)
+    outcome = CameraPreflightOutcome(
+        camera_key="cam-key",
+        motion_profile=MotionProfile(input_url=source.detect_rtsp_url),
+        recording_profile=recording_profile,
+        concurrent_preview_supported=False,
+        concurrent_preview_downgrade_reason=("concurrent_preview_unsupported_by_startup_preflight"),
+        diagnostics=CameraPreflightDiagnostics(
+            attempted_urls=[source.rtsp_url],
+            probes=[],
+            selected_motion_url=source.detect_rtsp_url,
+            selected_recording_url=source.rtsp_url,
+            selected_preview_url=source.rtsp_url,
+            selected_recording_profile=recording_profile.profile_id(),
+            session_mode="dual_stream",
+            concurrent_preview_supported=False,
+            concurrent_preview_downgrade_reason=(
+                "concurrent_preview_unsupported_by_startup_preflight"
+            ),
+        ),
+    )
+
+    # When: applying startup preflight output while the live publisher raises
+    with caplog.at_level("WARNING", logger="homesec.sources.rtsp.core"):
+        source._apply_preflight_outcome(outcome)  # noqa: SLF001
+
+    # Then: the source keeps the preflight profiles and logs the preview-only sync failure
+    assert source._preflight_outcome == outcome  # noqa: SLF001
+    assert any(
+        "Preview concurrent downgrade sync failed" in record.message for record in caplog.records
+    )
+
+
 def test_default_preview_seam_refuses_until_backend_is_wired(tmp_path: Path) -> None:
     """RTSP preview seam should fail closed until a real publisher is configured."""
     # Given: An RTSP source with the default no-op live publisher seam

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -432,6 +432,7 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
     class _FakePreflight:
         def __init__(self) -> None:
             self.preview_rtsp_url: str | None = None
+            self.preview_probe_rtsp_url: str | None = None
 
         def run(
             self,
@@ -440,10 +441,12 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
             primary_rtsp_url: str,
             detect_rtsp_url: str,
             preview_rtsp_url: str | None = None,
+            preview_probe_rtsp_url: str | None = None,
         ) -> CameraPreflightOutcome:
             # Given: source startup asks preflight to validate current runtime topology
             _ = camera_name
             self.preview_rtsp_url = preview_rtsp_url
+            self.preview_probe_rtsp_url = preview_probe_rtsp_url
             recording_profile = build_default_recording_profile(primary_rtsp_url)
             return CameraPreflightOutcome(
                 camera_key="cam-key",
@@ -456,6 +459,7 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
                     selected_motion_url=detect_rtsp_url,
                     selected_recording_url=primary_rtsp_url,
                     selected_preview_url=preview_rtsp_url,
+                    selected_preview_probe_url=preview_probe_rtsp_url,
                     selected_recording_profile=recording_profile.profile_id(),
                     session_mode="dual_stream",
                     concurrent_preview_supported=True,
@@ -482,6 +486,7 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
 
     # Then: the preview check receives the main RTSP URL used by HLSLivePublisher today
     assert fake_preflight.preview_rtsp_url == "rtsp://host/main"
+    assert fake_preflight.preview_probe_rtsp_url == "rtsp://host/main"
     assert publisher.concurrent_preview_downgrades == []
 
 

--- a/tests/homesec/test_api_preview_routes.py
+++ b/tests/homesec/test_api_preview_routes.py
@@ -217,6 +217,30 @@ def test_get_preview_status_returns_runtime_status() -> None:
     assert payload["idle_shutdown_at"] == 123.0
 
 
+def test_get_preview_status_surfaces_concurrent_preview_downgrade_reason() -> None:
+    """GET preview status should expose why concurrent preview while recording is unavailable."""
+    # Given: A camera downgraded to recording-first preview behavior for this process
+    app = _StubPreviewApp(
+        status=CameraPreviewStatus(
+            camera_name="front",
+            enabled=True,
+            state=PreviewState.IDLE,
+            viewer_count=0,
+            degraded_reason="concurrent_preview_unsupported_by_startup_preflight",
+        )
+    )
+    client = _client(app)
+
+    # When: Requesting preview status
+    response = client.get("/api/v1/preview/cameras/front")
+
+    # Then: The status payload includes the process-local downgrade reason
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "idle"
+    assert payload["degraded_reason"] == "concurrent_preview_unsupported_by_startup_preflight"
+
+
 def test_get_preview_status_returns_404_for_missing_camera() -> None:
     """GET /preview/cameras/{camera_name} should return 404 when camera is unknown."""
     # Given: A preview app that reports unknown camera

--- a/tests/homesec/test_api_preview_routes.py
+++ b/tests/homesec/test_api_preview_routes.py
@@ -703,7 +703,7 @@ def test_preview_playback_rejects_stale_files_when_runtime_reports_inactive_prev
     tmp_path: Path,
 ) -> None:
     """Preview playback should fail closed when runtime status says the session is inactive."""
-    # Given: Stale preview artifacts on disk after the runtime has already marked preview idle
+    # Given: Stale preview artifacts after a downgraded camera has no active preview session
     _write_preview_files(tmp_path, "front")
     app = _StubPreviewApp(
         status=CameraPreviewStatus(
@@ -711,6 +711,7 @@ def test_preview_playback_rejects_stale_files_when_runtime_reports_inactive_prev
             enabled=True,
             state=PreviewState.IDLE,
             viewer_count=0,
+            degraded_reason="concurrent_preview_unsupported_by_startup_preflight",
         ),
         preview_config=PreviewConfig(
             enabled=True,

--- a/tests/homesec/test_rtsp_preflight.py
+++ b/tests/homesec/test_rtsp_preflight.py
@@ -302,6 +302,83 @@ def test_preflight_validates_preview_startup_probe_when_required(
     assert outcome.diagnostics.selected_preview_probe_url == "rtsp://cam/high"
 
 
+def test_preflight_continues_preview_classification_after_probe_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe-only failures should not skip the actual preview stream capability check."""
+    # Given: startup probe classification is generic but the runtime preview stream hits a session limit
+    streams = [
+        ProbeStreamInfo(
+            url="rtsp://cam/high",
+            video_codec="h264",
+            audio_codec="aac",
+            width=1920,
+            height=1080,
+            fps=20.0,
+            fps_raw="20/1",
+            probe_ok=True,
+        ),
+        ProbeStreamInfo(
+            url="rtsp://cam/low",
+            video_codec="h264",
+            audio_codec="aac",
+            width=640,
+            height=360,
+            fps=10.0,
+            fps_raw="10/1",
+            probe_ok=True,
+        ),
+    ]
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery(streams),
+    )
+    preview_checks: list[tuple[str, str, str]] = []
+
+    def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
+        return RecordingValidationResult(ok=True)
+
+    def _validate_preview(
+        motion_url: str, recording_url: str, preview_url: str
+    ) -> ConcurrentStreamOpenResult:
+        preview_checks.append((motion_url, recording_url, preview_url))
+        return ConcurrentStreamOpenResult.SESSION_LIMIT
+
+    monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
+    monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_probe_session_limits",
+        lambda _m, _r, _p: ConcurrentStreamOpenResult.FAILED,
+    )
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_session_limits",
+        _validate_preview,
+    )
+
+    # When: running startup preflight with both auto-codec probe and preview validation requested
+    outcome = preflight.run(
+        camera_name="garage",
+        primary_rtsp_url="rtsp://cam/high",
+        detect_rtsp_url="rtsp://cam/low",
+        preview_rtsp_url="rtsp://cam/high",
+        preview_probe_rtsp_url="rtsp://cam/high",
+    )
+
+    # Then: the actual preview stream check still classifies the process-local downgrade
+    assert not isinstance(outcome, PreflightError)
+    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+    assert outcome.concurrent_preview_supported is False
+    assert (
+        outcome.concurrent_preview_downgrade_reason
+        == "concurrent_preview_unsupported_by_startup_preflight"
+    )
+
+
 def test_preflight_downgrades_concurrent_preview_when_three_stream_check_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/homesec/test_rtsp_preflight.py
+++ b/tests/homesec/test_rtsp_preflight.py
@@ -150,6 +150,193 @@ def test_preflight_falls_back_to_single_stream_when_dual_fails(
     assert outcome.diagnostics.session_mode == "single_stream"
 
 
+def test_preflight_classifies_concurrent_preview_when_requested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight should validate the motion, recording, and preview topology on request."""
+    # Given: dual stream validation succeeds and preview is allowed during recording
+    streams = [
+        ProbeStreamInfo(
+            url="rtsp://cam/high",
+            video_codec="h264",
+            audio_codec="aac",
+            width=1920,
+            height=1080,
+            fps=20.0,
+            fps_raw="20/1",
+            probe_ok=True,
+        ),
+        ProbeStreamInfo(
+            url="rtsp://cam/low",
+            video_codec="h264",
+            audio_codec="aac",
+            width=640,
+            height=360,
+            fps=10.0,
+            fps_raw="10/1",
+            probe_ok=True,
+        ),
+    ]
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery(streams),
+    )
+    preview_checks: list[tuple[str, str, str]] = []
+
+    def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
+        return RecordingValidationResult(ok=True)
+
+    def _validate_preview(motion_url: str, recording_url: str, preview_url: str) -> bool:
+        preview_checks.append((motion_url, recording_url, preview_url))
+        return True
+
+    monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
+    monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_session_limits",
+        _validate_preview,
+    )
+
+    # When: running startup preflight with the actual preview input URL requested
+    outcome = preflight.run(
+        camera_name="garage",
+        primary_rtsp_url="rtsp://cam/high",
+        detect_rtsp_url="rtsp://cam/low",
+        preview_rtsp_url="rtsp://cam/high",
+    )
+
+    # Then: the preview check uses motion low, recording high, and preview high
+    assert not isinstance(outcome, PreflightError)
+    assert outcome.concurrent_preview_supported is True
+    assert outcome.concurrent_preview_downgrade_reason is None
+    assert outcome.diagnostics.selected_preview_url == "rtsp://cam/high"
+    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+
+
+def test_preflight_downgrades_concurrent_preview_when_three_stream_check_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight should mark concurrent preview unsupported without failing startup."""
+    # Given: motion plus recording works but the three-stream preview check fails
+    streams = [
+        ProbeStreamInfo(
+            url="rtsp://cam/high",
+            video_codec="h264",
+            audio_codec="aac",
+            width=1920,
+            height=1080,
+            fps=20.0,
+            fps_raw="20/1",
+            probe_ok=True,
+        ),
+        ProbeStreamInfo(
+            url="rtsp://cam/low",
+            video_codec="h264",
+            audio_codec="aac",
+            width=640,
+            height=360,
+            fps=10.0,
+            fps_raw="10/1",
+            probe_ok=True,
+        ),
+    ]
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery(streams),
+    )
+
+    def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
+        return RecordingValidationResult(ok=True)
+
+    monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
+    monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_session_limits",
+        lambda _m, _r, _p: False,
+    )
+
+    # When: running startup preflight with concurrent preview requested
+    outcome = preflight.run(
+        camera_name="garage",
+        primary_rtsp_url="rtsp://cam/high",
+        detect_rtsp_url="rtsp://cam/low",
+        preview_rtsp_url="rtsp://cam/high",
+    )
+
+    # Then: startup succeeds while the process-local preview downgrade is classified
+    assert not isinstance(outcome, PreflightError)
+    assert outcome.concurrent_preview_supported is False
+    assert (
+        outcome.concurrent_preview_downgrade_reason
+        == "concurrent_preview_unsupported_by_startup_preflight"
+    )
+    assert outcome.diagnostics.concurrent_preview_supported is False
+    assert outcome.diagnostics.concurrent_preview_downgrade_reason == (
+        "concurrent_preview_unsupported_by_startup_preflight"
+    )
+
+
+def test_preflight_skips_three_stream_check_when_preview_not_requested(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight should not run preview capability checks unless explicitly requested."""
+    # Given: a viable RTSP camera where preview concurrency was not requested
+    streams = [
+        ProbeStreamInfo(
+            url="rtsp://cam/high",
+            video_codec="h264",
+            audio_codec="aac",
+            width=1920,
+            height=1080,
+            fps=20.0,
+            fps_raw="20/1",
+            probe_ok=True,
+        ),
+    ]
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery(streams),
+    )
+
+    def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
+        return RecordingValidationResult(ok=True)
+
+    def _unexpected_preview_check(_motion_url: str, _recording_url: str, _preview_url: str) -> bool:
+        raise AssertionError("three-stream preview check should not run")
+
+    monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
+    monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_session_limits",
+        _unexpected_preview_check,
+    )
+
+    # When: running startup preflight without a preview input URL
+    outcome = preflight.run(
+        camera_name="garage",
+        primary_rtsp_url="rtsp://cam/high",
+        detect_rtsp_url="rtsp://cam/high",
+    )
+
+    # Then: preview capability remains unclassified for this startup run
+    assert not isinstance(outcome, PreflightError)
+    assert outcome.concurrent_preview_supported is None
+    assert outcome.diagnostics.concurrent_preview_supported is None
+    assert outcome.diagnostics.selected_preview_url is None
+
+
 def test_preflight_returns_negotiation_error_for_unusable_audio(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/homesec/test_rtsp_preflight.py
+++ b/tests/homesec/test_rtsp_preflight.py
@@ -997,6 +997,72 @@ def test_concurrent_preview_session_validation_returns_failed_for_generic_failur
     assert len(calls) == 3
 
 
+def test_concurrent_preview_probe_validation_keeps_ffprobe_open_for_overlap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preview probe validation should keep ffprobe connected during overlap."""
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self._returncode: int | None = None
+
+        def poll(self) -> int | None:
+            return self._returncode
+
+        def terminate(self) -> None:
+            if self._returncode is None:
+                self._returncode = 0
+
+        def communicate(self, timeout: float) -> tuple[str, str]:
+            _ = timeout
+            if self._returncode is None:
+                self._returncode = 0
+            return ("", "")
+
+        def kill(self) -> None:
+            self._returncode = -9
+
+    calls: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], **_kwargs: object) -> _FakeProc:
+        assert _kwargs.get("start_new_session") is True
+        calls.append(list(cmd))
+        return _FakeProc()
+
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery([]),
+        session_overlap_s=1.0,
+    )
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.time.sleep", lambda _seconds: None)
+
+    # Given: the preview startup probe must open beside motion and recording consumers
+    motion_url = "rtsp://cam/motion"
+    recording_url = "rtsp://cam/recording"
+    preview_probe_url = "rtsp://cam/preview"
+
+    # When: validating the current startup-probe topology
+    result = preflight._validate_concurrent_preview_probe_session_limits(
+        motion_url,
+        recording_url,
+        preview_probe_url,
+    )
+
+    # Then: ffprobe reads packets for the overlap window instead of exiting after metadata
+    assert result is ConcurrentStreamOpenResult.SUPPORTED
+    assert [cmd[0] for cmd in calls] == ["ffmpeg", "ffmpeg", "ffprobe"]
+    ffprobe_cmd = calls[2]
+    assert "-read_intervals" in ffprobe_cmd
+    assert "%+2.0" in ffprobe_cmd
+    assert "-count_packets" in ffprobe_cmd
+    assert "stream=codec_name,width,height,avg_frame_rate,nb_read_packets" in ffprobe_cmd
+    assert ffprobe_cmd[-1] == preview_probe_url
+
+
 def test_session_limit_validation_requires_clean_exit_after_overlap(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/homesec/test_rtsp_preflight.py
+++ b/tests/homesec/test_rtsp_preflight.py
@@ -220,6 +220,88 @@ def test_preflight_classifies_concurrent_preview_when_requested(
     assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
 
 
+def test_preflight_validates_preview_startup_probe_when_required(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight should validate the preview startup probe used by auto codecs."""
+    # Given: concurrent preview is requested and preview startup still needs stream probing
+    streams = [
+        ProbeStreamInfo(
+            url="rtsp://cam/high",
+            video_codec="h264",
+            audio_codec="aac",
+            width=1920,
+            height=1080,
+            fps=20.0,
+            fps_raw="20/1",
+            probe_ok=True,
+        ),
+        ProbeStreamInfo(
+            url="rtsp://cam/low",
+            video_codec="h264",
+            audio_codec="aac",
+            width=640,
+            height=360,
+            fps=10.0,
+            fps_raw="10/1",
+            probe_ok=True,
+        ),
+    ]
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery(streams),
+    )
+    probe_checks: list[tuple[str, str, str]] = []
+    preview_checks: list[tuple[str, str, str]] = []
+
+    def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
+        return RecordingValidationResult(ok=True)
+
+    def _validate_probe(
+        motion_url: str, recording_url: str, preview_probe_url: str
+    ) -> ConcurrentStreamOpenResult:
+        probe_checks.append((motion_url, recording_url, preview_probe_url))
+        return ConcurrentStreamOpenResult.SUPPORTED
+
+    def _validate_preview(
+        motion_url: str, recording_url: str, preview_url: str
+    ) -> ConcurrentStreamOpenResult:
+        preview_checks.append((motion_url, recording_url, preview_url))
+        return ConcurrentStreamOpenResult.SUPPORTED
+
+    monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
+    monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_probe_session_limits",
+        _validate_probe,
+    )
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_session_limits",
+        _validate_preview,
+    )
+
+    # When: running startup preflight with the preview probe URL requested
+    outcome = preflight.run(
+        camera_name="garage",
+        primary_rtsp_url="rtsp://cam/high",
+        detect_rtsp_url="rtsp://cam/low",
+        preview_rtsp_url="rtsp://cam/high",
+        preview_probe_rtsp_url="rtsp://cam/high",
+    )
+
+    # Then: the probe and preview checks both validate the current runtime topology
+    assert not isinstance(outcome, PreflightError)
+    assert outcome.concurrent_preview_supported is True
+    assert probe_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+    assert outcome.diagnostics.selected_preview_probe_url == "rtsp://cam/high"
+
+
 def test_preflight_downgrades_concurrent_preview_when_three_stream_check_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/homesec/test_rtsp_preflight.py
+++ b/tests/homesec/test_rtsp_preflight.py
@@ -185,15 +185,19 @@ def test_preflight_classifies_concurrent_preview_when_requested(
         rtsp_io_timeout_s=2.0,
         discovery=_FakeDiscovery(streams),
     )
-    preview_checks: list[tuple[str, str, str]] = []
+    preview_checks: list[tuple[str, str, str, bool]] = []
 
     def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
         return RecordingValidationResult(ok=True)
 
     def _validate_preview(
-        motion_url: str, recording_url: str, preview_url: str
+        motion_url: str,
+        recording_url: str,
+        preview_url: str,
+        *,
+        preview_audio_enabled: bool,
     ) -> ConcurrentStreamOpenResult:
-        preview_checks.append((motion_url, recording_url, preview_url))
+        preview_checks.append((motion_url, recording_url, preview_url, preview_audio_enabled))
         return ConcurrentStreamOpenResult.SUPPORTED
 
     monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
@@ -210,14 +214,15 @@ def test_preflight_classifies_concurrent_preview_when_requested(
         primary_rtsp_url="rtsp://cam/high",
         detect_rtsp_url="rtsp://cam/low",
         preview_rtsp_url="rtsp://cam/high",
+        preview_audio_enabled=True,
     )
 
-    # Then: the preview check uses motion low, recording high, and preview high
+    # Then: the preview check uses motion low, recording high, preview high, and preview audio
     assert not isinstance(outcome, PreflightError)
     assert outcome.concurrent_preview_supported is True
     assert outcome.concurrent_preview_downgrade_reason is None
     assert outcome.diagnostics.selected_preview_url == "rtsp://cam/high"
-    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high", True)]
 
 
 def test_preflight_validates_preview_startup_probe_when_required(
@@ -255,7 +260,7 @@ def test_preflight_validates_preview_startup_probe_when_required(
         discovery=_FakeDiscovery(streams),
     )
     probe_checks: list[tuple[str, str, str]] = []
-    preview_checks: list[tuple[str, str, str]] = []
+    preview_checks: list[tuple[str, str, str, bool]] = []
 
     def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
         return RecordingValidationResult(ok=True)
@@ -267,9 +272,13 @@ def test_preflight_validates_preview_startup_probe_when_required(
         return ConcurrentStreamOpenResult.SUPPORTED
 
     def _validate_preview(
-        motion_url: str, recording_url: str, preview_url: str
+        motion_url: str,
+        recording_url: str,
+        preview_url: str,
+        *,
+        preview_audio_enabled: bool,
     ) -> ConcurrentStreamOpenResult:
-        preview_checks.append((motion_url, recording_url, preview_url))
+        preview_checks.append((motion_url, recording_url, preview_url, preview_audio_enabled))
         return ConcurrentStreamOpenResult.SUPPORTED
 
     monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
@@ -292,13 +301,14 @@ def test_preflight_validates_preview_startup_probe_when_required(
         detect_rtsp_url="rtsp://cam/low",
         preview_rtsp_url="rtsp://cam/high",
         preview_probe_rtsp_url="rtsp://cam/high",
+        preview_audio_enabled=True,
     )
 
     # Then: the probe and preview checks both validate the current runtime topology
     assert not isinstance(outcome, PreflightError)
     assert outcome.concurrent_preview_supported is True
     assert probe_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
-    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high", True)]
     assert outcome.diagnostics.selected_preview_probe_url == "rtsp://cam/high"
 
 
@@ -336,15 +346,19 @@ def test_preflight_continues_preview_classification_after_probe_failure(
         rtsp_io_timeout_s=2.0,
         discovery=_FakeDiscovery(streams),
     )
-    preview_checks: list[tuple[str, str, str]] = []
+    preview_checks: list[tuple[str, str, str, bool]] = []
 
     def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
         return RecordingValidationResult(ok=True)
 
     def _validate_preview(
-        motion_url: str, recording_url: str, preview_url: str
+        motion_url: str,
+        recording_url: str,
+        preview_url: str,
+        *,
+        preview_audio_enabled: bool,
     ) -> ConcurrentStreamOpenResult:
-        preview_checks.append((motion_url, recording_url, preview_url))
+        preview_checks.append((motion_url, recording_url, preview_url, preview_audio_enabled))
         return ConcurrentStreamOpenResult.SESSION_LIMIT
 
     monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
@@ -367,11 +381,12 @@ def test_preflight_continues_preview_classification_after_probe_failure(
         detect_rtsp_url="rtsp://cam/low",
         preview_rtsp_url="rtsp://cam/high",
         preview_probe_rtsp_url="rtsp://cam/high",
+        preview_audio_enabled=True,
     )
 
     # Then: the actual preview stream check still classifies the process-local downgrade
     assert not isinstance(outcome, PreflightError)
-    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high")]
+    assert preview_checks == [("rtsp://cam/low", "rtsp://cam/high", "rtsp://cam/high", True)]
     assert outcome.concurrent_preview_supported is False
     assert (
         outcome.concurrent_preview_downgrade_reason
@@ -422,7 +437,7 @@ def test_preflight_downgrades_concurrent_preview_when_three_stream_check_fails(
     monkeypatch.setattr(
         preflight,
         "_validate_concurrent_preview_session_limits",
-        lambda _m, _r, _p: ConcurrentStreamOpenResult.SESSION_LIMIT,
+        lambda _m, _r, _p, **_kwargs: ConcurrentStreamOpenResult.SESSION_LIMIT,
     )
 
     # When: running startup preflight with concurrent preview requested
@@ -489,7 +504,7 @@ def test_preflight_leaves_concurrent_preview_unclassified_on_generic_three_strea
     monkeypatch.setattr(
         preflight,
         "_validate_concurrent_preview_session_limits",
-        lambda _m, _r, _p: ConcurrentStreamOpenResult.FAILED,
+        lambda _m, _r, _p, **_kwargs: ConcurrentStreamOpenResult.FAILED,
     )
 
     # When: running startup preflight with concurrent preview requested
@@ -537,7 +552,10 @@ def test_preflight_skips_three_stream_check_when_preview_not_requested(
         return RecordingValidationResult(ok=True)
 
     def _unexpected_preview_check(
-        _motion_url: str, _recording_url: str, _preview_url: str
+        _motion_url: str,
+        _recording_url: str,
+        _preview_url: str,
+        **_kwargs: object,
     ) -> ConcurrentStreamOpenResult:
         raise AssertionError("three-stream preview check should not run")
 
@@ -1074,6 +1092,73 @@ def test_concurrent_preview_session_validation_returns_failed_for_generic_failur
     assert len(calls) == 3
 
 
+def test_concurrent_preview_session_validation_models_audio_enabled_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent preview validation should open the same audio track as HLS preview."""
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self._returncode: int | None = None
+
+        def poll(self) -> int | None:
+            return self._returncode
+
+        def terminate(self) -> None:
+            if self._returncode is None:
+                self._returncode = 0
+
+        def communicate(self, timeout: float) -> tuple[str, str]:
+            _ = timeout
+            if self._returncode is None:
+                self._returncode = 0
+            return ("", "")
+
+        def kill(self) -> None:
+            self._returncode = -9
+
+    calls: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], **_kwargs: object) -> _FakeProc:
+        assert _kwargs.get("start_new_session") is True
+        calls.append(list(cmd))
+        return _FakeProc()
+
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery([]),
+    )
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.time.sleep", lambda _seconds: None)
+
+    # Given: HLS preview is configured to include optional source audio
+    motion_url = "rtsp://cam/motion"
+    recording_url = "rtsp://cam/recording"
+    preview_url = "rtsp://cam/preview"
+
+    # When: validating concurrent preview session limits
+    result = preflight._validate_concurrent_preview_session_limits(
+        motion_url,
+        recording_url,
+        preview_url,
+        preview_audio_enabled=True,
+    )
+
+    # Then: only the preview validation leg maps the optional audio stream
+    assert result is ConcurrentStreamOpenResult.SUPPORTED
+    assert len(calls) == 3
+    assert "-an" in calls[0]
+    assert "-an" in calls[1]
+    preview_cmd = calls[2]
+    assert "-an" not in preview_cmd
+    assert preview_cmd.count("-map") == 2
+    assert "0:v:0" in preview_cmd
+    assert "0:a:0?" in preview_cmd
+
+
 def test_concurrent_preview_probe_validation_keeps_ffprobe_open_for_overlap(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1136,7 +1221,8 @@ def test_concurrent_preview_probe_validation_keeps_ffprobe_open_for_overlap(
     assert "-read_intervals" in ffprobe_cmd
     assert "%+2.0" in ffprobe_cmd
     assert "-count_packets" in ffprobe_cmd
-    assert "stream=codec_name,width,height,avg_frame_rate,nb_read_packets" in ffprobe_cmd
+    assert "-select_streams" not in ffprobe_cmd
+    assert "stream=codec_type,codec_name,width,height,avg_frame_rate,nb_read_packets" in ffprobe_cmd
     assert ffprobe_cmd[-1] == preview_probe_url
 
 

--- a/tests/homesec/test_rtsp_preflight.py
+++ b/tests/homesec/test_rtsp_preflight.py
@@ -8,6 +8,7 @@ import pytest
 
 from homesec.sources.rtsp.discovery import CameraProbeResult, ProbeStreamInfo
 from homesec.sources.rtsp.preflight import (
+    ConcurrentStreamOpenResult,
     PreflightError,
     RecordingValidationResult,
     RecordingValidationSignals,
@@ -189,9 +190,11 @@ def test_preflight_classifies_concurrent_preview_when_requested(
     def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
         return RecordingValidationResult(ok=True)
 
-    def _validate_preview(motion_url: str, recording_url: str, preview_url: str) -> bool:
+    def _validate_preview(
+        motion_url: str, recording_url: str, preview_url: str
+    ) -> ConcurrentStreamOpenResult:
         preview_checks.append((motion_url, recording_url, preview_url))
-        return True
+        return ConcurrentStreamOpenResult.SUPPORTED
 
     monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
     monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
@@ -260,7 +263,7 @@ def test_preflight_downgrades_concurrent_preview_when_three_stream_check_fails(
     monkeypatch.setattr(
         preflight,
         "_validate_concurrent_preview_session_limits",
-        lambda _m, _r, _p: False,
+        lambda _m, _r, _p: ConcurrentStreamOpenResult.SESSION_LIMIT,
     )
 
     # When: running startup preflight with concurrent preview requested
@@ -282,6 +285,68 @@ def test_preflight_downgrades_concurrent_preview_when_three_stream_check_fails(
     assert outcome.diagnostics.concurrent_preview_downgrade_reason == (
         "concurrent_preview_unsupported_by_startup_preflight"
     )
+
+
+def test_preflight_leaves_concurrent_preview_unclassified_on_generic_three_stream_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preflight should not downgrade preview concurrency on transient validation failures."""
+    # Given: motion plus recording works but the preview classification has a generic failure
+    streams = [
+        ProbeStreamInfo(
+            url="rtsp://cam/high",
+            video_codec="h264",
+            audio_codec="aac",
+            width=1920,
+            height=1080,
+            fps=20.0,
+            fps_raw="20/1",
+            probe_ok=True,
+        ),
+        ProbeStreamInfo(
+            url="rtsp://cam/low",
+            video_codec="h264",
+            audio_codec="aac",
+            width=640,
+            height=360,
+            fps=10.0,
+            fps_raw="10/1",
+            probe_ok=True,
+        ),
+    ]
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery(streams),
+    )
+
+    def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
+        return RecordingValidationResult(ok=True)
+
+    monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
+    monkeypatch.setattr(preflight, "_validate_session_limits", lambda _m, _r: True)
+    monkeypatch.setattr(
+        preflight,
+        "_validate_concurrent_preview_session_limits",
+        lambda _m, _r, _p: ConcurrentStreamOpenResult.FAILED,
+    )
+
+    # When: running startup preflight with concurrent preview requested
+    outcome = preflight.run(
+        camera_name="garage",
+        primary_rtsp_url="rtsp://cam/high",
+        detect_rtsp_url="rtsp://cam/low",
+        preview_rtsp_url="rtsp://cam/high",
+    )
+
+    # Then: startup succeeds and preview concurrency remains process-local/unclassified
+    assert not isinstance(outcome, PreflightError)
+    assert outcome.concurrent_preview_supported is None
+    assert outcome.concurrent_preview_downgrade_reason is None
+    assert outcome.diagnostics.concurrent_preview_supported is None
+    assert outcome.diagnostics.concurrent_preview_downgrade_reason is None
 
 
 def test_preflight_skips_three_stream_check_when_preview_not_requested(
@@ -312,7 +377,9 @@ def test_preflight_skips_three_stream_check_when_preview_not_requested(
     def _validate_profile(_profile: RecordingProfile) -> RecordingValidationResult:
         return RecordingValidationResult(ok=True)
 
-    def _unexpected_preview_check(_motion_url: str, _recording_url: str, _preview_url: str) -> bool:
+    def _unexpected_preview_check(
+        _motion_url: str, _recording_url: str, _preview_url: str
+    ) -> ConcurrentStreamOpenResult:
         raise AssertionError("three-stream preview check should not run")
 
     monkeypatch.setattr(preflight, "_validate_recording_profile", _validate_profile)
@@ -726,6 +793,126 @@ def test_session_limit_validation_non_timeout_failure_does_not_retry_without_tim
     assert not ok
     assert len(calls) == 2
     assert "-rw_timeout" in calls[0] or "-stimeout" in calls[0]
+
+
+def test_concurrent_preview_session_validation_classifies_session_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent preview validation should distinguish session-budget failures."""
+
+    class _FakeProc:
+        def __init__(self, *, returncode: int | None, stderr_text: str) -> None:
+            self._returncode = returncode
+            self._stderr_text = stderr_text
+
+        def poll(self) -> int | None:
+            return self._returncode
+
+        def terminate(self) -> None:
+            if self._returncode is None:
+                self._returncode = 0
+
+        def communicate(self, timeout: float) -> tuple[str, str]:
+            _ = timeout
+            if self._returncode is None:
+                self._returncode = 0
+            return ("", self._stderr_text)
+
+        def kill(self) -> None:
+            self._returncode = -9
+
+    calls: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], **_kwargs: object) -> _FakeProc:
+        assert _kwargs.get("start_new_session") is True
+        calls.append(list(cmd))
+        return _FakeProc(returncode=1, stderr_text="Too many clients already connected")
+
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery([]),
+    )
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.time.sleep", lambda _seconds: None)
+
+    # Given: the three-stream preview topology hits a camera session-budget limit
+    motion_url = "rtsp://cam/motion"
+    recording_url = "rtsp://cam/recording"
+    preview_url = "rtsp://cam/preview"
+
+    # When: validating concurrent preview session limits
+    result = preflight._validate_concurrent_preview_session_limits(
+        motion_url,
+        recording_url,
+        preview_url,
+    )
+
+    # Then: validation reports a session-limit classification for startup downgrade
+    assert result is ConcurrentStreamOpenResult.SESSION_LIMIT
+    assert len(calls) == 3
+
+
+def test_concurrent_preview_session_validation_returns_failed_for_generic_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent preview validation should keep generic failures unclassified."""
+
+    class _FakeProc:
+        def __init__(self, *, returncode: int | None, stderr_text: str) -> None:
+            self._returncode = returncode
+            self._stderr_text = stderr_text
+
+        def poll(self) -> int | None:
+            return self._returncode
+
+        def terminate(self) -> None:
+            if self._returncode is None:
+                self._returncode = 0
+
+        def communicate(self, timeout: float) -> tuple[str, str]:
+            _ = timeout
+            if self._returncode is None:
+                self._returncode = 0
+            return ("", self._stderr_text)
+
+        def kill(self) -> None:
+            self._returncode = -9
+
+    calls: list[list[str]] = []
+
+    def _fake_popen(cmd: list[str], **_kwargs: object) -> _FakeProc:
+        assert _kwargs.get("start_new_session") is True
+        calls.append(list(cmd))
+        return _FakeProc(returncode=1, stderr_text="Connection refused")
+
+    preflight = RTSPStartupPreflight(
+        output_dir=tmp_path,
+        rtsp_connect_timeout_s=2.0,
+        rtsp_io_timeout_s=2.0,
+        discovery=_FakeDiscovery([]),
+    )
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("homesec.sources.rtsp.preflight.time.sleep", lambda _seconds: None)
+
+    # Given: the three-stream preview topology fails for a generic RTSP reason
+    motion_url = "rtsp://cam/motion"
+    recording_url = "rtsp://cam/recording"
+    preview_url = "rtsp://cam/preview"
+
+    # When: validating concurrent preview session limits
+    result = preflight._validate_concurrent_preview_session_limits(
+        motion_url,
+        recording_url,
+        preview_url,
+    )
+
+    # Then: validation reports a generic failure instead of forcing a startup downgrade
+    assert result is ConcurrentStreamOpenResult.FAILED
+    assert len(calls) == 3
 
 
 def test_session_limit_validation_requires_clean_exit_after_overlap(


### PR DESCRIPTION
## Summary
- add startup classification for RTSP concurrent preview + recording support using the actual preview input URL
- downgrade unsupported cameras to process-local recording-first preview behavior with API-visible degraded reasons
- add runtime two-strike downgrade on preview start failures or early exits while recording is active

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check`

Refs: https://www.notion.so/34bd8336c59f8157ab75fedf8517f4ba