### PR TITLE
fix: stabilize Safari preview playback

### DIFF
--- a/src/homesec/api/routes/preview.py
+++ b/src/homesec/api/routes/preview.py
@@ -158,6 +158,59 @@ def _read_playlist_text(playlist_path: Path) -> str:
     return playlist_text
 
 
+def _preview_headers(*, content_length: int | None = None) -> dict[str, str]:
+    headers = dict(_PREVIEW_CACHE_HEADERS)
+    if content_length is not None:
+        headers["Content-Length"] = str(content_length)
+    return headers
+
+
+async def _read_active_preview_playlist(
+    app: Application,
+    camera_name: str,
+    *,
+    preview_token: str | None,
+) -> str:
+    await _ensure_preview_playback_enabled(app, camera_name)
+    await _ensure_preview_media_active(app, camera_name)
+    playlist_text = _read_playlist_text(
+        preview_playlist_path(_preview_storage_dir(app), camera_name)
+    )
+    return _rewrite_playlist_for_token(playlist_text, preview_token)
+
+
+async def _active_preview_segment_path(
+    app: Application,
+    camera_name: str,
+    segment_name: str,
+) -> Path:
+    if not is_preview_segment_name(segment_name):
+        raise APIError(
+            "Not Found",
+            status_code=status.HTTP_404_NOT_FOUND,
+            error_code=APIErrorCode.NOT_FOUND,
+        )
+
+    await _ensure_preview_playback_enabled(app, camera_name)
+    await _ensure_preview_media_active(app, camera_name)
+    try:
+        segment_path = preview_segment_path(_preview_storage_dir(app), camera_name, segment_name)
+    except ValueError as exc:
+        raise APIError(
+            "Not Found",
+            status_code=status.HTTP_404_NOT_FOUND,
+            error_code=APIErrorCode.NOT_FOUND,
+        ) from exc
+
+    if not segment_path.is_file():
+        raise APIError(
+            "Preview media unavailable",
+            status_code=status.HTTP_409_CONFLICT,
+            error_code=APIErrorCode.PREVIEW_MEDIA_UNAVAILABLE,
+        )
+    return segment_path
+
+
 def _rewrite_playlist_for_token(playlist_text: str, token: str | None) -> str:
     if token is None:
         return playlist_text
@@ -363,15 +416,36 @@ async def get_preview_playlist(
     app: Application = Depends(get_homesec_app),
 ) -> Response:
     """Return the live HLS playlist for a camera preview session."""
-    await _ensure_preview_playback_enabled(app, camera_name)
-    await _ensure_preview_media_active(app, camera_name)
-    playlist_text = _read_playlist_text(
-        preview_playlist_path(_preview_storage_dir(app), camera_name)
+    playlist_text = await _read_active_preview_playlist(
+        app,
+        camera_name,
+        preview_token=preview_token,
     )
     return Response(
-        content=_rewrite_playlist_for_token(playlist_text, preview_token),
+        content=playlist_text,
         media_type="application/vnd.apple.mpegurl",
-        headers=_PREVIEW_CACHE_HEADERS,
+        headers=_preview_headers(content_length=len(playlist_text.encode("utf-8"))),
+    )
+
+
+@playback_router.head(
+    "/api/v1/preview/cameras/{camera_name}/playlist.m3u8",
+    include_in_schema=False,
+)
+async def head_preview_playlist(
+    camera_name: str,
+    preview_token: str | None = Depends(verify_preview_access),
+    app: Application = Depends(get_homesec_app),
+) -> Response:
+    """Return live HLS playlist metadata for native media probes."""
+    playlist_text = await _read_active_preview_playlist(
+        app,
+        camera_name,
+        preview_token=preview_token,
+    )
+    return Response(
+        media_type="application/vnd.apple.mpegurl",
+        headers=_preview_headers(content_length=len(playlist_text.encode("utf-8"))),
     )
 
 
@@ -383,31 +457,7 @@ async def get_preview_segment(
     app: Application = Depends(get_homesec_app),
 ) -> FileResponse:
     """Return a live HLS transport-stream segment for a camera preview session."""
-    if not is_preview_segment_name(segment_name):
-        raise APIError(
-            "Not Found",
-            status_code=status.HTTP_404_NOT_FOUND,
-            error_code=APIErrorCode.NOT_FOUND,
-        )
-
-    await _ensure_preview_playback_enabled(app, camera_name)
-    await _ensure_preview_media_active(app, camera_name)
-    try:
-        segment_path = preview_segment_path(_preview_storage_dir(app), camera_name, segment_name)
-    except ValueError as exc:
-        raise APIError(
-            "Not Found",
-            status_code=status.HTTP_404_NOT_FOUND,
-            error_code=APIErrorCode.NOT_FOUND,
-        ) from exc
-
-    if not segment_path.is_file():
-        raise APIError(
-            "Preview media unavailable",
-            status_code=status.HTTP_409_CONFLICT,
-            error_code=APIErrorCode.PREVIEW_MEDIA_UNAVAILABLE,
-        )
-
+    segment_path = await _active_preview_segment_path(app, camera_name, segment_name)
     _schedule_preview_viewer_activity_best_effort(
         app,
         camera_name,
@@ -417,4 +467,23 @@ async def get_preview_segment(
         path=segment_path,
         media_type="video/mp2t",
         headers=_PREVIEW_CACHE_HEADERS,
+    )
+
+
+@playback_router.head(
+    "/api/v1/preview/cameras/{camera_name}/{segment_name}",
+    include_in_schema=False,
+)
+async def head_preview_segment(
+    camera_name: str,
+    segment_name: str,
+    preview_token: str | None = Depends(verify_preview_access),
+    app: Application = Depends(get_homesec_app),
+) -> Response:
+    """Return live HLS transport-stream segment metadata for native media probes."""
+    _ = preview_token
+    segment_path = await _active_preview_segment_path(app, camera_name, segment_name)
+    return Response(
+        media_type="video/mp2t",
+        headers=_preview_headers(content_length=segment_path.stat().st_size),
     )

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -14,6 +14,7 @@ import time
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -207,6 +208,13 @@ class RTSPSourceConfig(BaseModel):
         default=None,
         description="RTSP URL for the detect stream.",
     )
+    preview_stream: Literal["main", "detect"] = Field(
+        default="main",
+        description=(
+            "Which configured RTSP stream to use for live preview. "
+            "'main' uses rtsp_url; 'detect' uses the lower-cost detect stream."
+        ),
+    )
     output_dir: str = Field(
         default="./recordings",
         description="Directory to store recordings and logs.",
@@ -279,6 +287,9 @@ class RTSPSource(ThreadedClipSource):
         else:
             self.detect_rtsp_url = self.rtsp_url
             self._detect_rtsp_url_source = "same_as_rtsp_url"
+        self.preview_rtsp_url = (
+            self.detect_rtsp_url if config.preview_stream == "detect" else self.rtsp_url
+        )
 
         self.output_dir = Path(config.output_dir)
         sanitized_name = self._sanitize_camera_name(camera_name)
@@ -482,9 +493,11 @@ class RTSPSource(ThreadedClipSource):
             camera_name=self.camera_name,
             primary_rtsp_url=self.rtsp_url,
             detect_rtsp_url=self.detect_rtsp_url,
-            preview_rtsp_url=self.rtsp_url if self._preview_concurrency_requested else None,
+            preview_rtsp_url=(
+                self.preview_rtsp_url if self._preview_concurrency_requested else None
+            ),
             preview_probe_rtsp_url=(
-                self.rtsp_url
+                self.preview_rtsp_url
                 if self._preview_concurrency_requested and self._preview_startup_probe_required
                 else None
             ),
@@ -674,7 +687,7 @@ class RTSPSource(ThreadedClipSource):
         hls_config = preview_config.config
         return HLSLivePublisher(
             camera_name=camera_name,
-            rtsp_url=self.rtsp_url,
+            rtsp_url=self.preview_rtsp_url,
             storage_dir=hls_config.storage_dir,
             segment_duration_ms=hls_config.segment_duration_ms,
             live_window_segments=hls_config.live_window_segments,

--- a/src/homesec/sources/rtsp/discovery.py
+++ b/src/homesec/sources/rtsp/discovery.py
@@ -30,6 +30,9 @@ class ProbeStreamInfo(BaseModel):
 
     url: str
     video_codec: str | None = None
+    video_profile: str | None = None
+    video_level: int | None = None
+    video_has_b_frames: int | None = None
     audio_codec: str | None = None
     width: int | None = None
     height: int | None = None
@@ -105,7 +108,7 @@ class FfprobeStreamDiscovery:
             "-v",
             "error",
             "-show_entries",
-            "stream=codec_type,codec_name,width,height,avg_frame_rate",
+            ("stream=codec_type,codec_name,profile,level,has_b_frames,width,height,avg_frame_rate"),
             "-of",
             "json",
             "-rtsp_transport",
@@ -273,6 +276,9 @@ def _parse_ffprobe_payload(payload: str, rtsp_url: str) -> ProbeStreamInfo:
     return ProbeStreamInfo(
         url=rtsp_url,
         video_codec=_coerce_str(video_stream.get("codec_name")),
+        video_profile=_coerce_str(video_stream.get("profile")),
+        video_level=_coerce_int(video_stream.get("level")),
+        video_has_b_frames=_coerce_int(video_stream.get("has_b_frames")),
         audio_codec=_coerce_str(audio_stream.get("codec_name")) if audio_stream else None,
         width=width,
         height=height,

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -1281,10 +1281,6 @@ def _software_h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:
     return (
         "-c:v",
         "libx264",
-        "-preset",
-        "veryfast",
-        "-tune",
-        "zerolatency",
         "-pix_fmt",
         "yuv420p",
         "-sc_threshold",

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -120,6 +120,7 @@ class _CodecPlan:
     video_args: tuple[str, ...]
     audio_args: tuple[str, ...]
     uses_hardware_encoder: bool = False
+    fallback_to_copy_on_encoder_unavailable: bool = False
 
 
 class HLSLivePublisher(LivePublisher):
@@ -558,6 +559,15 @@ class HLSLivePublisher(LivePublisher):
                 )
                 continue
 
+            if _should_retry_with_copy_codec(codec_plan, codec_failure_error):
+                logger.warning(
+                    "Preview H.264 encoder unavailable, falling back to copy: camera=%s encoder=%s error=%s",
+                    self._camera_name,
+                    codec_plan.codec_name,
+                    codec_failure_error,
+                )
+                continue
+
             return codec_refusal
 
         with self._lock:
@@ -646,37 +656,37 @@ class HLSLivePublisher(LivePublisher):
             audio_codec=self._audio_codec,
             stream_info=stream_info,
         )
+        copy_plan = _CodecPlan(
+            codec_name="copy",
+            ffmpeg_global_args=(),
+            video_args=("-c:v", "copy"),
+            audio_args=audio_args,
+        )
 
         if self._video_codec == "copy":
-            return (
-                _CodecPlan(
-                    codec_name="copy",
-                    ffmpeg_global_args=(),
-                    video_args=("-c:v", "copy"),
-                    audio_args=audio_args,
-                ),
-            )
+            return (copy_plan,)
 
         if self._video_codec == "auto" and stream_info is not None:
             if _is_hls_browser_video_copy_compatible(stream_info):
-                return (
-                    _CodecPlan(
-                        codec_name="copy",
-                        ffmpeg_global_args=(),
-                        video_args=("-c:v", "copy"),
-                        audio_args=audio_args,
-                    ),
-                )
+                return (copy_plan,)
 
         software_plan = _CodecPlan(
             codec_name="libx264",
             ffmpeg_global_args=(),
             video_args=_software_h264_transcode_args(self._segment_duration_s),
             audio_args=audio_args,
+            fallback_to_copy_on_encoder_unavailable=(
+                self._video_codec == "auto"
+                and stream_info is not None
+                and _is_h264_video(stream_info)
+            ),
         )
         hardware_encoder = HardwareAccelDetector.select_h264_encoder(self._hwaccel_config)
+        fallback_plans = (
+            (copy_plan,) if software_plan.fallback_to_copy_on_encoder_unavailable else ()
+        )
         if hardware_encoder is None:
-            return (software_plan,)
+            return (software_plan, *fallback_plans)
 
         logger.info(
             "Preview will try hardware H.264 encoder: camera=%s encoder=%s",
@@ -695,6 +705,7 @@ class HLSLivePublisher(LivePublisher):
                 uses_hardware_encoder=True,
             ),
             software_plan,
+            *fallback_plans,
         )
 
     def _probe_stream_info(self) -> ProbeStreamInfo | None:
@@ -1250,7 +1261,7 @@ def _is_hls_browser_audio_copy_compatible(audio_codec: str | None) -> bool:
 
 
 def _is_hls_browser_video_copy_compatible(stream_info: ProbeStreamInfo) -> bool:
-    if (stream_info.video_codec or "").strip().lower() != "h264":
+    if not _is_h264_video(stream_info):
         return False
 
     profile = stream_info.video_profile
@@ -1258,6 +1269,10 @@ def _is_hls_browser_video_copy_compatible(stream_info: ProbeStreamInfo) -> bool:
         return True
 
     return profile.strip().lower() in _HLS_BROWSER_COPY_H264_PROFILES
+
+
+def _is_h264_video(stream_info: ProbeStreamInfo) -> bool:
+    return (stream_info.video_codec or "").strip().lower() == "h264"
 
 
 def _build_audio_codec_args(
@@ -1315,3 +1330,18 @@ def _should_retry_with_software_codec(
     if not codec_plan.uses_hardware_encoder:
         return False
     return refusal.reason is not LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
+
+
+def _should_retry_with_copy_codec(codec_plan: _CodecPlan, error_text: str) -> bool:
+    if not codec_plan.fallback_to_copy_on_encoder_unavailable:
+        return False
+    return _is_encoder_unavailable_error(error_text)
+
+
+def _is_encoder_unavailable_error(error_text: str) -> bool:
+    normalized = error_text.lower()
+    return (
+        "unknown encoder" in normalized
+        or "encoder not found" in normalized
+        or "error selecting an encoder" in normalized
+    )

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -52,6 +52,7 @@ _HLS_BROWSER_COPY_AUDIO_CODECS: frozenset[str] = frozenset({"aac"})
 _HLS_BROWSER_COPY_H264_PROFILES: frozenset[str] = frozenset(
     {"baseline", "constrained baseline", "main"}
 )
+_SOFTWARE_H264_ENCODERS: tuple[str, ...] = ("libx264", "libopenh264")
 CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON = (
     "concurrent_preview_downgraded_after_repeated_recording_failures"
 )
@@ -120,7 +121,7 @@ class _CodecPlan:
     video_args: tuple[str, ...]
     audio_args: tuple[str, ...]
     uses_hardware_encoder: bool = False
-    fallback_to_copy_on_encoder_unavailable: bool = False
+    retry_next_on_encoder_unavailable: bool = False
 
 
 class HLSLivePublisher(LivePublisher):
@@ -559,9 +560,9 @@ class HLSLivePublisher(LivePublisher):
                 )
                 continue
 
-            if _should_retry_with_copy_codec(codec_plan, codec_failure_error):
+            if _should_retry_with_next_codec(codec_plan, codec_failure_error):
                 logger.warning(
-                    "Preview H.264 encoder unavailable, falling back to copy: camera=%s encoder=%s error=%s",
+                    "Preview H.264 encoder unavailable, trying next codec plan: camera=%s encoder=%s error=%s",
                     self._camera_name,
                     codec_plan.codec_name,
                     codec_failure_error,
@@ -670,23 +671,28 @@ class HLSLivePublisher(LivePublisher):
             if _is_hls_browser_video_copy_compatible(stream_info):
                 return (copy_plan,)
 
-        software_plan = _CodecPlan(
-            codec_name="libx264",
-            ffmpeg_global_args=(),
-            video_args=_software_h264_transcode_args(self._segment_duration_s),
-            audio_args=audio_args,
-            fallback_to_copy_on_encoder_unavailable=(
-                self._video_codec == "auto"
-                and stream_info is not None
-                and _is_h264_video(stream_info)
-            ),
+        copy_fallback_enabled = (
+            self._video_codec == "auto" and stream_info is not None and _is_h264_video(stream_info)
         )
+        software_plans = tuple(
+            _CodecPlan(
+                codec_name=encoder,
+                ffmpeg_global_args=(),
+                video_args=_software_h264_transcode_args(
+                    encoder=encoder,
+                    segment_duration_s=self._segment_duration_s,
+                ),
+                audio_args=audio_args,
+                retry_next_on_encoder_unavailable=(
+                    index < len(_SOFTWARE_H264_ENCODERS) - 1 or copy_fallback_enabled
+                ),
+            )
+            for index, encoder in enumerate(_SOFTWARE_H264_ENCODERS)
+        )
+        fallback_plans = (copy_plan,) if copy_fallback_enabled else ()
         hardware_encoder = HardwareAccelDetector.select_h264_encoder(self._hwaccel_config)
-        fallback_plans = (
-            (copy_plan,) if software_plan.fallback_to_copy_on_encoder_unavailable else ()
-        )
         if hardware_encoder is None:
-            return (software_plan, *fallback_plans)
+            return (*software_plans, *fallback_plans)
 
         logger.info(
             "Preview will try hardware H.264 encoder: camera=%s encoder=%s",
@@ -704,7 +710,7 @@ class HLSLivePublisher(LivePublisher):
                 audio_args=audio_args,
                 uses_hardware_encoder=True,
             ),
-            software_plan,
+            *software_plans,
             *fallback_plans,
         )
 
@@ -1292,10 +1298,10 @@ def _build_audio_codec_args(
     return ("-map", "0:a:0?", "-c:a", "aac", "-b:a", "128k")
 
 
-def _software_h264_transcode_args(segment_duration_s: float) -> tuple[str, ...]:
+def _software_h264_transcode_args(*, encoder: str, segment_duration_s: float) -> tuple[str, ...]:
     return (
         "-c:v",
-        "libx264",
+        encoder,
         "-pix_fmt",
         "yuv420p",
         "-sc_threshold",
@@ -1332,8 +1338,8 @@ def _should_retry_with_software_codec(
     return refusal.reason is not LivePublisherRefusalReason.SESSION_BUDGET_EXHAUSTED
 
 
-def _should_retry_with_copy_codec(codec_plan: _CodecPlan, error_text: str) -> bool:
-    if not codec_plan.fallback_to_copy_on_encoder_unavailable:
+def _should_retry_with_next_codec(codec_plan: _CodecPlan, error_text: str) -> bool:
+    if not codec_plan.retry_next_on_encoder_unavailable:
         return False
     return _is_encoder_unavailable_error(error_text)
 

--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -49,6 +49,9 @@ _READY_POLL_INTERVAL_S = 0.1
 _DEFAULT_VIEWER_WINDOW_S = 2.0
 _START_FAILURE_MAX_BYTES = 4_000
 _HLS_BROWSER_COPY_AUDIO_CODECS: frozenset[str] = frozenset({"aac"})
+_HLS_BROWSER_COPY_H264_PROFILES: frozenset[str] = frozenset(
+    {"baseline", "constrained baseline", "main"}
+)
 CONCURRENT_PREVIEW_RUNTIME_DOWNGRADE_REASON = (
     "concurrent_preview_downgraded_after_repeated_recording_failures"
 )
@@ -655,7 +658,7 @@ class HLSLivePublisher(LivePublisher):
             )
 
         if self._video_codec == "auto" and stream_info is not None:
-            if (stream_info.video_codec or "").strip().lower() == "h264":
+            if _is_hls_browser_video_copy_compatible(stream_info):
                 return (
                     _CodecPlan(
                         codec_name="copy",
@@ -1244,6 +1247,17 @@ def _is_hls_browser_audio_copy_compatible(audio_codec: str | None) -> bool:
     if audio_codec is None:
         return False
     return audio_codec.strip().lower() in _HLS_BROWSER_COPY_AUDIO_CODECS
+
+
+def _is_hls_browser_video_copy_compatible(stream_info: ProbeStreamInfo) -> bool:
+    if (stream_info.video_codec or "").strip().lower() != "h264":
+        return False
+
+    profile = stream_info.video_profile
+    if profile is None:
+        return True
+
+    return profile.strip().lower() in _HLS_BROWSER_COPY_H264_PROFILES
 
 
 def _build_audio_codec_args(

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -367,8 +367,8 @@ def test_auto_codec_transcodes_high_profile_h264_for_browser_preview(tmp_path: P
 
 
 def test_auto_codec_falls_back_to_copy_when_h264_encoder_is_missing(tmp_path: Path) -> None:
-    """auto codec mode should preserve preview availability when ffmpeg lacks libx264."""
-    # Given: A high-profile H.264 source on a runtime whose ffmpeg has no software H.264 encoder
+    """auto codec mode should preserve preview availability when H.264 encoders are missing."""
+    # Given: A high-profile H.264 source on a runtime whose ffmpeg has no H.264 encoder
     publisher = _make_publisher(
         tmp_path,
         discovery=FakeDiscovery(
@@ -397,7 +397,7 @@ def test_auto_codec_falls_back_to_copy_when_h264_encoder_is_missing(tmp_path: Pa
         **kwargs: object,
     ) -> FakeProc:
         video_encoder = cmd[cmd.index("-c:v") + 1]
-        if video_encoder == "libx264":
+        if video_encoder in {"libx264", "libopenh264"}:
             return encoder_missing_spawn(
                 cmd,
                 stdout=stdout,
@@ -420,7 +420,79 @@ def test_auto_codec_falls_back_to_copy_when_h264_encoder_is_missing(tmp_path: Pa
     ):
         result = publisher.ensure_active()
 
-    # Then: The publisher falls back to copy-remuxing instead of returning a startup 409
+    # Then: The publisher exhausts encoder choices before falling back to copy-remuxing
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    assert len(calls) == 3
+    first_cmd = calls[0]["cmd"]
+    second_cmd = calls[1]["cmd"]
+    third_cmd = calls[2]["cmd"]
+    assert isinstance(first_cmd, list)
+    assert isinstance(second_cmd, list)
+    assert isinstance(third_cmd, list)
+    assert first_cmd[first_cmd.index("-c:v") + 1] == "libx264"
+    assert second_cmd[second_cmd.index("-c:v") + 1] == "libopenh264"
+    assert third_cmd[third_cmd.index("-c:v") + 1] == "copy"
+
+
+def test_auto_codec_tries_openh264_when_libx264_is_missing(tmp_path: Path) -> None:
+    """auto codec mode should try another software H.264 encoder before copy fallback."""
+    # Given: A high-profile H.264 source and a runtime whose ffmpeg lacks libx264
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(
+            _probe_stream(video_codec="h264", video_profile="High", audio_codec="aac")
+        ),
+    )
+    calls: list[dict[str, object]] = []
+    libx264_missing_spawn = _fake_popen_factory(
+        calls,
+        make_output=False,
+        returncode=1,
+        stderr_text=(
+            "Unknown encoder 'libx264'\n"
+            "Error selecting an encoder\n"
+            "Error opening output files: Encoder not found\n"
+        ),
+    )
+    openh264_spawn = _fake_popen_factory(calls)
+
+    def _fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **kwargs: object,
+    ) -> FakeProc:
+        video_encoder = cmd[cmd.index("-c:v") + 1]
+        if video_encoder == "libx264":
+            return libx264_missing_spawn(
+                cmd,
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=start_new_session,
+                **kwargs,
+            )
+        return openh264_spawn(
+            cmd,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=start_new_session,
+            **kwargs,
+        )
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen,
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The publisher uses libopenh264 instead of falling straight back to copy-remuxing
     assert result == LivePublisherStatus(
         state=LivePublisherState.READY,
         viewer_count=0,
@@ -432,7 +504,7 @@ def test_auto_codec_falls_back_to_copy_when_h264_encoder_is_missing(tmp_path: Pa
     assert isinstance(first_cmd, list)
     assert isinstance(second_cmd, list)
     assert first_cmd[first_cmd.index("-c:v") + 1] == "libx264"
-    assert second_cmd[second_cmd.index("-c:v") + 1] == "copy"
+    assert second_cmd[second_cmd.index("-c:v") + 1] == "libopenh264"
 
 
 def test_auto_codec_transcodes_mp4_safe_but_hls_unsafe_audio(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -362,6 +362,8 @@ def test_auto_codec_transcodes_high_profile_h264_for_browser_preview(tmp_path: P
     assert isinstance(cmd, list)
     assert cmd[cmd.index("-c:v") + 1] == "libx264"
     assert cmd[cmd.index("-c:a") + 1] == "copy"
+    assert "-preset" not in cmd
+    assert "-tune" not in cmd
 
 
 def test_auto_codec_transcodes_mp4_safe_but_hls_unsafe_audio(tmp_path: Path) -> None:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -124,10 +124,12 @@ def _probe_stream(
     *,
     video_codec: str,
     audio_codec: str | None,
+    video_profile: str | None = None,
 ) -> ProbeStreamInfo:
     return ProbeStreamInfo(
         url="rtsp://host/main",
         video_codec=video_codec,
+        video_profile=video_profile,
         audio_codec=audio_codec,
         width=1920,
         height=1080,
@@ -306,7 +308,9 @@ def test_auto_codec_prefers_copy_for_h264_and_aac(tmp_path: Path) -> None:
     # Given: A publisher whose source probe reports H.264 video and AAC audio
     publisher = _make_publisher(
         tmp_path,
-        discovery=FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="aac")),
+        discovery=FakeDiscovery(
+            _probe_stream(video_codec="h264", video_profile="Baseline", audio_codec="aac")
+        ),
     )
     calls: list[dict[str, object]] = []
 
@@ -330,12 +334,44 @@ def test_auto_codec_prefers_copy_for_h264_and_aac(tmp_path: Path) -> None:
     assert "libx264" not in cmd
 
 
+def test_auto_codec_transcodes_high_profile_h264_for_browser_preview(tmp_path: Path) -> None:
+    """auto codec mode should normalize H.264 profiles that are flaky in native HLS."""
+    # Given: A publisher whose source probe reports a high-profile H.264 camera stream
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(
+            _probe_stream(video_codec="h264", video_profile="High", audio_codec="aac")
+        ),
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The HLS ffmpeg path transcodes video instead of remuxing the source bitstream
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "libx264"
+    assert cmd[cmd.index("-c:a") + 1] == "copy"
+
+
 def test_auto_codec_transcodes_mp4_safe_but_hls_unsafe_audio(tmp_path: Path) -> None:
     """auto codec mode should transcode non-browser HLS audio even if recording can copy it."""
     # Given: A publisher whose source probe reports H.264 video and AC-3 audio
     publisher = _make_publisher(
         tmp_path,
-        discovery=FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="ac3")),
+        discovery=FakeDiscovery(
+            _probe_stream(video_codec="h264", video_profile="Baseline", audio_codec="ac3")
+        ),
     )
     calls: list[dict[str, object]] = []
 

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -366,6 +366,75 @@ def test_auto_codec_transcodes_high_profile_h264_for_browser_preview(tmp_path: P
     assert "-tune" not in cmd
 
 
+def test_auto_codec_falls_back_to_copy_when_h264_encoder_is_missing(tmp_path: Path) -> None:
+    """auto codec mode should preserve preview availability when ffmpeg lacks libx264."""
+    # Given: A high-profile H.264 source on a runtime whose ffmpeg has no software H.264 encoder
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(
+            _probe_stream(video_codec="h264", video_profile="High", audio_codec="aac")
+        ),
+    )
+    calls: list[dict[str, object]] = []
+    encoder_missing_spawn = _fake_popen_factory(
+        calls,
+        make_output=False,
+        returncode=1,
+        stderr_text=(
+            "Unknown encoder 'libx264'\n"
+            "Error selecting an encoder\n"
+            "Error opening output files: Encoder not found\n"
+        ),
+    )
+    copy_spawn = _fake_popen_factory(calls)
+
+    def _fake_popen(
+        cmd: list[str],
+        *,
+        stdout: object = None,
+        stderr: object = None,
+        start_new_session: bool = False,
+        **kwargs: object,
+    ) -> FakeProc:
+        video_encoder = cmd[cmd.index("-c:v") + 1]
+        if video_encoder == "libx264":
+            return encoder_missing_spawn(
+                cmd,
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=start_new_session,
+                **kwargs,
+            )
+        return copy_spawn(
+            cmd,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=start_new_session,
+            **kwargs,
+        )
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen,
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The publisher falls back to copy-remuxing instead of returning a startup 409
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    assert len(calls) == 2
+    first_cmd = calls[0]["cmd"]
+    second_cmd = calls[1]["cmd"]
+    assert isinstance(first_cmd, list)
+    assert isinstance(second_cmd, list)
+    assert first_cmd[first_cmd.index("-c:v") + 1] == "libx264"
+    assert second_cmd[second_cmd.index("-c:v") + 1] == "copy"
+
+
 def test_auto_codec_transcodes_mp4_safe_but_hls_unsafe_audio(tmp_path: Path) -> None:
     """auto codec mode should transcode non-browser HLS audio even if recording can copy it."""
     # Given: A publisher whose source probe reports H.264 video and AC-3 audio

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -276,6 +276,23 @@ def test_detect_rtsp_url_env_missing_falls_back(
     assert source._detect_rtsp_url_source == "explicit"
 
 
+def test_preview_stream_detect_uses_detect_rtsp_url(tmp_path: Path) -> None:
+    """Detect preview stream mode should use the lower-cost detect URL for HLS preview."""
+    # Given: An RTSP source with separate main and derived detect streams
+    config = _make_config(
+        tmp_path,
+        rtsp_url="rtsp://host/stream1",
+        preview_stream="detect",
+    )
+
+    # When: initializing the source
+    source = RTSPSource(config, camera_name="cam")
+
+    # Then: preview publishes from the derived detect stream
+    assert source.detect_rtsp_url == "rtsp://host/stream2"
+    assert source.preview_rtsp_url == "rtsp://host/stream2"
+
+
 def test_detect_stream_explicit_overrides_derived(tmp_path: Path) -> None:
     """Explicit detect stream should be used even when subtype=0 is present."""
     # Given: an explicit detect stream URL alongside subtype=0
@@ -366,6 +383,36 @@ def test_runtime_preview_publisher_receives_hwaccel_config(
     assert isinstance(source._live_publisher, CapturingLivePublisher)
     assert captured_kwargs["hwaccel_config"] == HardwareAccelConfig(hwaccel="cuda")
     assert captured_kwargs["recording_policy"] == "allow_during_recording"
+
+
+def test_runtime_preview_publisher_receives_configured_preview_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Preview publisher wiring should honor the RTSP preview stream selection."""
+    # Given: a runtime preview-enabled source configured to use its detect stream for preview
+    captured_kwargs: dict[str, object] = {}
+
+    class CapturingLivePublisher(FakeLivePublisher):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__()
+            captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr("homesec.sources.rtsp.core.HLSLivePublisher", CapturingLivePublisher)
+    config = _make_config(
+        tmp_path,
+        rtsp_url="rtsp://host/stream1",
+        preview_stream="detect",
+        __runtime_preview__={
+            "enabled": True,
+            "recording_policy": "allow_during_recording",
+        },
+    )
+
+    # When: initializing the source
+    RTSPSource(config, camera_name="cam")
+
+    # Then: HLS preview publishes from the derived detect stream
+    assert captured_kwargs["rtsp_url"] == "rtsp://host/stream2"
 
 
 def test_detect_stream_derived_from_subtype(tmp_path: Path) -> None:
@@ -539,6 +586,73 @@ def test_startup_preflight_passes_actual_preview_input_url_when_concurrency_requ
     assert fake_preflight.preview_rtsp_url == "rtsp://host/main"
     assert fake_preflight.preview_probe_rtsp_url == "rtsp://host/main"
     assert fake_preflight.preview_audio_enabled is True
+    assert publisher.concurrent_preview_downgrades == []
+
+
+def test_startup_preflight_passes_detect_preview_input_url_when_configured(
+    tmp_path: Path,
+) -> None:
+    """Startup preflight should validate the configured detect preview input."""
+
+    class _FakePreflight:
+        def __init__(self) -> None:
+            self.preview_rtsp_url: str | None = None
+            self.preview_probe_rtsp_url: str | None = None
+
+        def run(
+            self,
+            *,
+            camera_name: str,
+            primary_rtsp_url: str,
+            detect_rtsp_url: str,
+            preview_rtsp_url: str | None = None,
+            preview_probe_rtsp_url: str | None = None,
+            preview_audio_enabled: bool = False,
+        ) -> CameraPreflightOutcome:
+            # Given: source startup asks preflight to validate the selected preview topology
+            _ = camera_name, preview_audio_enabled
+            self.preview_rtsp_url = preview_rtsp_url
+            self.preview_probe_rtsp_url = preview_probe_rtsp_url
+            recording_profile = build_default_recording_profile(primary_rtsp_url)
+            return CameraPreflightOutcome(
+                camera_key="cam-key",
+                motion_profile=MotionProfile(input_url=detect_rtsp_url),
+                recording_profile=recording_profile,
+                concurrent_preview_supported=True,
+                diagnostics=CameraPreflightDiagnostics(
+                    attempted_urls=[primary_rtsp_url, detect_rtsp_url],
+                    probes=[],
+                    selected_motion_url=detect_rtsp_url,
+                    selected_recording_url=primary_rtsp_url,
+                    selected_preview_url=preview_rtsp_url,
+                    selected_preview_probe_url=preview_probe_rtsp_url,
+                    selected_recording_profile=recording_profile.profile_id(),
+                    session_mode="dual_stream",
+                    concurrent_preview_supported=True,
+                ),
+            )
+
+    # Given: an RTSP source configured to preview from the detect stream
+    publisher = FakeLivePublisher()
+    config = _make_config(
+        tmp_path,
+        rtsp_url="rtsp://host/stream1",
+        preview_stream="detect",
+        __runtime_preview__={
+            "enabled": True,
+            "recording_policy": "allow_during_recording",
+        },
+    )
+    source = RTSPSource(config, camera_name="cam", live_publisher=publisher)
+    fake_preflight = _FakePreflight()
+    source._preflight = fake_preflight  # noqa: SLF001
+
+    # When: startup preflight runs
+    source._run_startup_preflight()  # noqa: SLF001
+
+    # Then: the preview check receives the detect RTSP URL used by HLSLivePublisher
+    assert fake_preflight.preview_rtsp_url == "rtsp://host/stream2"
+    assert fake_preflight.preview_probe_rtsp_url == "rtsp://host/stream2"
     assert publisher.concurrent_preview_downgrades == []
 
 

--- a/tests/homesec/test_api_preview_routes.py
+++ b/tests/homesec/test_api_preview_routes.py
@@ -386,7 +386,7 @@ def test_preview_tokenized_playlist_url_is_playable_end_to_end(
     )
     client = _client(app)
 
-    # When: Starting preview, fetching the returned playlist, then fetching a segment from it
+    # When: Starting preview, probing media metadata, then fetching playlist and segment media
     create_response = client.post(
         "/api/v1/preview/cameras/front door",
         headers={"Authorization": "Bearer secret"},
@@ -394,17 +394,31 @@ def test_preview_tokenized_playlist_url_is_playable_end_to_end(
     assert create_response.status_code == 200
     create_payload = create_response.json()
 
+    head_playlist_response = client.head(create_payload["playlist_url"])
     playlist_response = client.get(create_payload["playlist_url"])
     playlist_lines = [line for line in playlist_response.text.splitlines() if line]
     segment_url = next(line for line in playlist_lines if not line.startswith("#"))
+    head_segment_response = client.head(
+        f"/api/v1/preview/cameras/front door/{segment_url}",
+    )
     segment_response = client.get(
         f"/api/v1/preview/cameras/front door/{segment_url}",
     )
 
-    # Then: Playback succeeds and the segment request records viewer activity using the preview token
+    # Then: Native media probes and playback succeed, while only the segment GET records activity
+    assert head_playlist_response.status_code == 200
+    assert head_playlist_response.headers["content-type"].startswith(
+        "application/vnd.apple.mpegurl"
+    )
+    assert head_playlist_response.headers["content-length"] == str(len(playlist_response.content))
+    assert head_playlist_response.content == b""
     assert playlist_response.status_code == 200
     assert playlist_response.headers["content-type"].startswith("application/vnd.apple.mpegurl")
     assert "segment_000000.ts?token=" in playlist_response.text
+    assert head_segment_response.status_code == 200
+    assert head_segment_response.headers["content-type"].startswith("video/mp2t")
+    assert head_segment_response.headers["content-length"] == str(len(b"segment-bytes"))
+    assert head_segment_response.content == b""
     assert segment_response.status_code == 200
     assert segment_response.content == b"segment-bytes"
     assert app.viewer_activity_calls == [("front door", create_payload["token"])]

--- a/tests/homesec/test_rtsp_discovery.py
+++ b/tests/homesec/test_rtsp_discovery.py
@@ -35,7 +35,8 @@ def test_probe_parses_video_and_audio_streams(monkeypatch: pytest.MonkeyPatch) -
     payload = (
         '{"streams":['
         '{"codec_type":"video","codec_name":"h264","width":1280,'
-        '"height":720,"avg_frame_rate":"15/1"},'
+        '"height":720,"avg_frame_rate":"15/1","profile":"High",'
+        '"level":42,"has_b_frames":1},'
         '{"codec_type":"audio","codec_name":"aac"}'
         "]}"
     )
@@ -52,6 +53,9 @@ def test_probe_parses_video_and_audio_streams(monkeypatch: pytest.MonkeyPatch) -
     # Then: stream metadata is populated
     assert result.streams[0].probe_ok
     assert result.streams[0].video_codec == "h264"
+    assert result.streams[0].video_profile == "High"
+    assert result.streams[0].video_level == 42
+    assert result.streams[0].video_has_b_frames == 1
     assert result.streams[0].audio_codec == "aac"
     assert result.streams[0].width == 1280
     assert result.streams[0].height == 720

--- a/ui/src/features/cameras/add-flow/backends/RtspForm.test.tsx
+++ b/ui/src/features/cameras/add-flow/backends/RtspForm.test.tsx
@@ -18,6 +18,7 @@ describe('RtspForm', () => {
       const [config, setConfig] = useState<Record<string, unknown>>({
         rtsp_url: 'rtsp://old-user:old-pass@camera.local/stream',
         output_dir: './recordings',
+        preview_stream: 'main',
       })
       return (
         <RtspForm
@@ -40,10 +41,24 @@ describe('RtspForm', () => {
 
     // Then: Form emits updated config preserving sibling fields
     expect(screen.getByLabelText('Output directory')).toBeTruthy()
+    expect(screen.getByLabelText('Preview stream')).toBeTruthy()
     expect(onChange).toHaveBeenCalled()
     expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({
       rtsp_url: 'rtsp://new-user:new-pass@camera.local/live',
       output_dir: './recordings',
+      preview_stream: 'main',
+    })
+
+    // When: Operator switches preview to the detect stream
+    fireEvent.change(screen.getByLabelText('Preview stream'), {
+      target: { value: 'detect' },
+    })
+
+    // Then: Form emits the preview stream selection
+    expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({
+      rtsp_url: 'rtsp://new-user:new-pass@camera.local/live',
+      output_dir: './recordings',
+      preview_stream: 'detect',
     })
   })
 })

--- a/ui/src/features/cameras/add-flow/backends/RtspForm.tsx
+++ b/ui/src/features/cameras/add-flow/backends/RtspForm.tsx
@@ -4,6 +4,7 @@ import { readString } from './configReaders'
 export function RtspForm({ config, onChange }: BackendFormStepProps) {
   const rtspUrl = readString(config, 'rtsp_url', '')
   const outputDir = readString(config, 'output_dir', './recordings')
+  const previewStream = readString(config, 'preview_stream', 'main')
 
   return (
     <div className="inline-form">
@@ -38,6 +39,24 @@ export function RtspForm({ config, onChange }: BackendFormStepProps) {
             })
           }}
         />
+      </label>
+
+      <label className="field-label" htmlFor="camera-rtsp-preview-stream">
+        Preview stream
+        <select
+          id="camera-rtsp-preview-stream"
+          className="input"
+          value={previewStream === 'detect' ? 'detect' : 'main'}
+          onChange={(event) => {
+            onChange({
+              ...config,
+              preview_stream: event.target.value,
+            })
+          }}
+        >
+          <option value="main">Main</option>
+          <option value="detect">Detect</option>
+        </select>
       </label>
     </div>
   )

--- a/ui/src/features/cameras/add-flow/backends/index.ts
+++ b/ui/src/features/cameras/add-flow/backends/index.ts
@@ -13,6 +13,7 @@ const RTSP_BACKEND: BackendFormDef = {
   steps: [{ title: 'Configure RTSP source', component: RtspForm }],
   defaultConfig: {
     rtsp_url: 'rtsp://username:password@camera.local/stream',
+    preview_stream: 'main',
     output_dir: './recordings',
   },
   suggestNamePrefix: 'rtsp',
@@ -104,6 +105,7 @@ const ONVIF_BACKEND: BackendFormDef = {
   steps: [{ title: 'Discover and select ONVIF stream', component: OnvifForm }],
   defaultConfig: {
     rtsp_url: '',
+    preview_stream: 'main',
     output_dir: './recordings',
   },
   suggestNamePrefix: 'onvif',
@@ -147,4 +149,3 @@ export function suggestCameraName(prefix: string, existingNames: readonly string
   }
   return `${prefix}_${index}`
 }
-

--- a/ui/src/features/cameras/components/CameraPreviewPanel.test.tsx
+++ b/ui/src/features/cameras/components/CameraPreviewPanel.test.tsx
@@ -24,6 +24,8 @@ const {
   hlsIsSupportedMock: vi.fn(() => true),
 }))
 
+const READY_PLAYLIST = '#EXTM3U\n#EXTINF:1.0,\nsegment_000000.ts\n#EXTINF:1.0,\nsegment_000001.ts\n'
+
 vi.mock('../hooks/useCameraPreview', () => ({
   useCameraPreview: (...args: unknown[]) => useCameraPreviewMock(...args),
 }))
@@ -59,7 +61,7 @@ describe('CameraPreviewPanel', () => {
     hlsIsSupportedMock.mockReset()
     hlsIsSupportedMock.mockReturnValue(true)
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('#EXTM3U', {
+      new Response(READY_PLAYLIST, {
         status: 200,
         headers: { 'content-type': 'application/vnd.apple.mpegurl' },
       }),
@@ -84,6 +86,7 @@ describe('CameraPreviewPanel', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -221,6 +224,73 @@ describe('CameraPreviewPanel', () => {
         'http://localhost:8081/api/v1/preview/cameras/front/playlist.m3u8?token=preview-token',
       )
       expect(hlsAttachMediaMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('waits for a usable live HLS window before initializing playback', async () => {
+    // Given: A ready preview session whose first playlist poll has only one segment
+    const playlistUrl =
+      'http://localhost:8081/api/v1/preview/cameras/front/playlist.m3u8?token=preview-token'
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(
+        new Response('#EXTM3U\n#EXTINF:1.0,\nsegment_000000.ts\n', {
+          status: 200,
+          headers: { 'content-type': 'application/vnd.apple.mpegurl' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(READY_PLAYLIST, {
+          status: 200,
+          headers: { 'content-type': 'application/vnd.apple.mpegurl' },
+        }),
+      )
+    useCameraPreviewMock.mockReturnValue({
+      status: {
+        camera_name: 'front',
+        enabled: true,
+        state: 'ready',
+        viewer_count: 1,
+        degraded_reason: null,
+        last_error: null,
+        idle_shutdown_at: null,
+        httpStatus: 200,
+      },
+      session: {
+        camera_name: 'front',
+        state: 'ready',
+        viewer_count: 1,
+        token: 'preview-token',
+        token_expires_at: null,
+        playlist_url: '/api/v1/preview/cameras/front/playlist.m3u8?token=preview-token',
+        idle_timeout_s: 30,
+        warning: null,
+        httpStatus: 200,
+      },
+      playlistUrl,
+      warning: null,
+      error: null,
+      isPending: false,
+      isStarting: false,
+      isStopping: false,
+      start: vi.fn(),
+      stop: vi.fn(),
+      refreshStatus: vi.fn(),
+    })
+
+    // When: Rendering the preview panel before the playlist has enough media
+    render(<CameraPreviewPanel cameraName="front" />)
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    })
+
+    // Then: The player waits instead of attaching to a thin live window
+    expect(hlsConstructMock).not.toHaveBeenCalled()
+
+    // Then: Playback initialization proceeds once a later poll sees a full enough window
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+      expect(hlsConstructMock).toHaveBeenCalledTimes(1)
+      expect(hlsLoadSourceMock).toHaveBeenCalledWith(playlistUrl)
     })
   })
 

--- a/ui/src/features/cameras/components/CameraPreviewPanel.tsx
+++ b/ui/src/features/cameras/components/CameraPreviewPanel.tsx
@@ -9,6 +9,7 @@ import { useCameraPreview } from '../hooks/useCameraPreview'
 
 const PLAYLIST_POLL_DELAY_MS = 500
 const PLAYLIST_POLL_MAX_ATTEMPTS = 12
+const PLAYLIST_READY_MIN_SEGMENTS = 2
 const PREVIEW_DISPLAY_STATUS_STATES = new Set(['starting', 'ready', 'degraded', 'stopping'])
 
 interface CameraPreviewPanelProps {
@@ -59,6 +60,15 @@ function startLabel(statusState: string | undefined): string {
   return 'Start preview'
 }
 
+function countPlaylistSegments(playlistText: string): number {
+  return playlistText
+    .split(/\r?\n/)
+    .filter((line) => {
+      const stripped = line.trim()
+      return stripped.length > 0 && !stripped.startsWith('#')
+    }).length
+}
+
 export function CameraPreviewPanel({ cameraName }: CameraPreviewPanelProps) {
   const {
     error,
@@ -102,10 +112,14 @@ export function CameraPreviewPanel({ cameraName }: CameraPreviewPanelProps) {
           signal: controller.signal,
         })
         if (response.ok) {
-          if (!cancelled) {
+          const playlistText = await response.text()
+          if (
+            !cancelled
+            && countPlaylistSegments(playlistText) >= PLAYLIST_READY_MIN_SEGMENTS
+          ) {
             setPlaylistReady(true)
+            return
           }
-          return
         }
         if (response.status !== 404 && response.status !== 409) {
           throw new Error(`Preview playlist unavailable (${response.status})`)

--- a/ui/src/features/cameras/forms.ts
+++ b/ui/src/features/cameras/forms.ts
@@ -8,6 +8,7 @@ export const REDACTED_PLACEHOLDER = '***redacted***'
 const CAMERA_SOURCE_CONFIG_TEMPLATES: Record<CameraBackend, CameraCreate['source_config']> = {
   rtsp: {
     rtsp_url: 'rtsp://username:password@camera.local/stream',
+    preview_stream: 'main',
     output_dir: './recordings',
   },
   ftp: {


### PR DESCRIPTION
## Summary

This PR stabilizes live camera preview playback in Safari/iOS native HLS while preserving the existing Firefox/hls.js path. It addresses the issues found while debugging `http://lenovo:8081/` against the live HomeSec runtime:

1. Safari native HLS media probes were receiving `405 Method Not Allowed` because preview playlist and segment endpoints did not handle `HEAD`.
2. The frontend could attach the video element while ffmpeg had only produced a very thin live playlist, which made Safari more likely to fall off the live window during startup.
3. The Tapo cameras (`office`, `garage`) were being copy-remuxed as camera-native H.264 High-profile streams; Safari/iOS native HLS was flaky on those streams, while Firefox/hls.js tolerated them. `front_door` worked because its copied preview stream was Baseline-profile H.264.
4. The first High-profile normalization patch selected software H.264 transcode args that Lenovo's ffmpeg rejected (`Unrecognized option 'preset'`). This PR now uses a more portable software H.264 command shape.
5. Lenovo's ffmpeg lacks `libx264`. The publisher now tries `libx264`, then `libopenh264`, before falling back to copy-remuxing H.264 when encoders are unavailable.
6. Since copied Tapo main streams can still black-screen in Safari, RTSP camera config now supports `preview_stream: "detect"` so preview can use the lower-cost derived detect stream (`stream2`) without duplicating credentials.

## Investigation Notes

Observed behavior:

- `front_door` preview worked reliably in Safari after the initial `HEAD` route fix.
- `office` and `garage` stayed flaky in Safari/mobile browsers while still working in Firefox on macOS.
- After adding High-profile normalization, `office` and `garage` failed in both Firefox and Safari because the preview publisher failed before producing HLS output.
- Runtime status exposed the first backend regression directly: `last_error` was `Unrecognized option 'preset'. Error splitting the argument list: Option not found`.
- After removing `-preset`/`-tune`, runtime status exposed the second backend regression: `Unknown encoder 'libx264'`, `Error selecting an encoder`, and `Error opening output files: Encoder not found`.
- After adding copy fallback, the API returned READY, but Safari still showed a black `0:00 / 0:00` video for `office`; ffprobe showed copied H.264 High-profile level 5.0, 2560x1440, and garage also showed DTS discontinuities.

Checks performed:

- Verified preview control-plane status for `front_door`, `office`, `garage`, and the mistaken `garage_door` name via `/api/v1/preview/cameras/{camera}`.
- Verified playlists and segments over HTTP, including direct playlist playback in Safari.
- Queried HomeSec telemetry DB logs read-only through the `homesec-db-logs` workflow.
- Used ffprobe against the generated HLS playlists.
- Used macOS Safari through Computer Use to confirm the actual black-video behavior.

Important stream difference found:

- `front_door`: copied H.264 Baseline-profile preview stream, plays in Safari.
- `office` / `garage`: copied H.264 High-profile 2560x1440 Tapo main streams, with ffprobe warnings such as truncated SEI / DTS discontinuity, flaky or black in Safari native HLS.

## Backend Changes

### Preview playback routes

Updated `src/homesec/api/routes/preview.py`:

- Added explicit `HEAD` support for preview playlists and segments.
- Shared playlist/segment validation with the existing `GET` paths.
- Preserved empty-body `HEAD` semantics with media headers.
- Kept segment viewer-activity bookkeeping on segment `GET`; `HEAD` probes do not count as active playback.

Why:

Safari native HLS probes media URLs with `HEAD`. Before this PR, those probes returned `405`, which could fail playback before Safari fetched actual media bytes.

### RTSP discovery metadata

Updated `src/homesec/sources/rtsp/discovery.py`:

- Extended ffprobe stream discovery to capture video profile, level, and B-frame metadata.
- Added `video_profile`, `video_level`, and `video_has_b_frames` to `ProbeStreamInfo`.

Why:

The previous preview codec decision only checked `codec_name == h264`, treating all H.264 streams as equally safe to copy into browser HLS. The Tapo failures showed that this is too broad for Safari native HLS.

### Preview codec selection

Updated `src/homesec/sources/rtsp/live_publisher.py`:

- Changed `preview.config.video_codec: auto` behavior:
  - Still copy-remuxes H.264 Baseline / Constrained Baseline / Main profiles.
  - Transcodes H.264 High profile when an encoder is available.
  - Tries software encoders in order: `libx264`, then `libopenh264`.
  - Falls back to copy-remuxing H.264 only after H.264 encoder-unavailable failures.
  - Continues transcoding non-H.264 sources to browser-safe H.264.
- Removed `-preset veryfast` and `-tune zerolatency` from the software H.264 preview args.

Why:

The Tapo cameras produced H.264 High-profile copied output that Safari/iOS native HLS handled poorly. Normalizing those streams is preferred, but Lenovo's ffmpeg currently cannot encode through `libx264`; trying `libopenh264` gives another common software encoder path before falling back to copy.

### Preview stream selection

Updated `src/homesec/sources/rtsp/core.py`:

- Added `RTSPSourceConfig.preview_stream` with values:
  - `main` (default): preview uses `rtsp_url`.
  - `detect`: preview uses the configured or derived detect stream.
- Wired startup preflight to validate the actual preview RTSP URL selected by `preview_stream`.
- Wired `HLSLivePublisher` to publish from `preview_rtsp_url` instead of always using the main recording URL.

Why:

If Lenovo has no usable H.264 encoder, the only way to avoid Safari seeing the problematic copied Tapo main stream is to use a lower-cost preview input. For these Tapo URLs, HomeSec already derives `stream2` as the detect stream, so `preview_stream: "detect"` can route preview to that stream without duplicating RTSP credentials.

## Frontend Changes

Updated `ui/src/features/cameras/components/CameraPreviewPanel.tsx`:

- Added playlist readiness polling that reads the playlist body before attaching playback.
- Requires at least two media segment lines before initializing the video player.
- Keeps retrying during normal startup `404`/`409` states.
- Avoids initializing native HLS or hls.js against a one-segment live window.

Updated RTSP camera forms:

- Added a Preview stream selector with `Main` / `Detect` options.
- Included `preview_stream: "main"` in RTSP and ONVIF-created camera defaults.

## Tests Added / Updated

Backend:

- `tests/homesec/test_api_preview_routes.py`
  - Covers playlist and segment `HEAD` behavior.
  - Verifies tokenized playlist playback remains end-to-end playable.
  - Verifies only segment `GET` records viewer activity.
- `tests/homesec/test_rtsp_discovery.py`
  - Verifies ffprobe parsing captures video profile, level, and B-frame metadata.
- `tests/homesec/rtsp/test_live_publisher.py`
  - Keeps auto-copy behavior for Baseline H.264 + AAC.
  - Adds High-profile H.264 case verifying `auto` selects H.264 transcoding instead of copy.
  - Verifies the High-profile transcode command no longer includes `-preset` or `-tune`.
  - Verifies fallback from `libx264` to `libopenh264`.
  - Verifies copy fallback after H.264 encoder choices are exhausted.
- `tests/homesec/rtsp/test_runtime.py`
  - Verifies `preview_stream: "detect"` uses the derived detect URL.
  - Verifies the live publisher and startup preflight receive the configured preview stream URL.

Frontend:

- `ui/src/features/cameras/components/CameraPreviewPanel.test.tsx`
  - Verifies playback initialization waits for a usable live window.
- `ui/src/features/cameras/add-flow/backends/RtspForm.test.tsx`
  - Verifies RTSP form emits the preview stream selection.

## Validation

Targeted checks:

- `uv run pytest tests/homesec/rtsp/test_live_publisher.py::test_auto_codec_transcodes_high_profile_h264_for_browser_preview tests/homesec/rtsp/test_live_publisher.py::test_auto_codec_tries_openh264_when_libx264_is_missing tests/homesec/rtsp/test_live_publisher.py::test_auto_codec_falls_back_to_copy_when_h264_encoder_is_missing tests/homesec/rtsp/test_runtime.py::test_preview_stream_detect_uses_detect_rtsp_url tests/homesec/rtsp/test_runtime.py::test_runtime_preview_publisher_receives_configured_preview_stream tests/homesec/rtsp/test_runtime.py::test_startup_preflight_passes_detect_preview_input_url_when_configured -q`
- `pnpm --dir ui test src/features/cameras/add-flow/backends/RtspForm.test.tsx src/features/cameras/forms.test.ts`
- `pnpm --dir ui api:check`
- `pnpm --dir ui lint`
- `uv run mypy --package homesec --strict`

Full repo check:

- `TEST_DB_DSN='postgresql://homesec:homesec@localhost:15433/homesec' make check`

Result:

- Backend: `932 passed, 2 warnings`
- Frontend: `50 passed`, `224 tests`
- UI production build completed. Vite emitted the existing Node version warning for Node `20.17.0` versus Vite's recommended `20.19+`, but the build succeeded.

## Rollout / Manual Test Notes

After deploying this branch to Lenovo:

1. Pull latest `codex/fix-safari-preview-head`.
2. Rebuild/restart the service, including frontend assets.
3. For `office` and `garage`, set the RTSP source config to include:

```json
{
  "preview_stream": "detect"
}
```

This can be patched through the camera source config editor without changing the redacted `rtsp_url`.

4. Apply the runtime reload/restart so those sources rebuild their preview publishers.
5. Start `office` and `garage` previews and test Safari again.

Expected result:

- Safari no longer fails media probes with `405`.
- The UI waits for a usable live playlist before attaching playback.
- If Lenovo has `libopenh264`, Tapo main-stream preview should normalize instead of copy.
- If Lenovo has no usable H.264 encoder, `preview_stream: "detect"` should move Tapo preview off the problematic 2560x1440 High-profile main stream.

## Residual Risk

- I could not SSH into Lenovo to directly list ffmpeg encoders (`publickey` denied), so `libopenh264` availability is unknown until this branch runs there.
- `preview_stream: "detect"` assumes the derived detect stream is more Safari-friendly. The logs confirm HomeSec already selects Tapo `stream2` for motion, but we still need a deploy test to verify its exact HLS behavior in Safari.
- If the detect stream is also problematic, the remaining fix is operational: install/use an ffmpeg build with a supported H.264 encoder, then keep `preview.config.video_codec: auto` so HomeSec can normalize the stream.
