### PR TITLE
refactor: decouple state and event store wiring

### DIFF
--- a/src/homesec/app.py
+++ b/src/homesec/app.py
@@ -228,6 +228,7 @@ class Application:
             if backup_manager_started:
                 await postgres_backup_manager.shutdown(timeout=10.0)
             await runtime_manager.shutdown()
+            await persistence.event_store.shutdown()
             await persistence.state_store.shutdown()
             await persistence.storage.shutdown()
             raise
@@ -446,6 +447,9 @@ class Application:
         # Stop backup scheduler before closing shared storage.
         if self._postgres_backup_manager:
             await self._postgres_backup_manager.shutdown(timeout=10.0)
+
+        # Close event store before the state store that owns the shared Postgres engine.
+        await self._event_store.shutdown()
 
         # Close state store
         if self._state_store:

--- a/src/homesec/interfaces.py
+++ b/src/homesec/interfaces.py
@@ -218,16 +218,6 @@ class StateStore(Shutdownable, ABC):
         """Health check. Returns True if database is reachable."""
         raise NotImplementedError
 
-    @abstractmethod
-    def create_event_store(self) -> EventStore:
-        """Create an event store associated with this state store.
-
-        Returns NoopEventStore if not supported.
-        """
-        from homesec.state import NoopEventStore
-
-        return NoopEventStore()
-
 
 class EventStore(Shutdownable, ABC):
     """Manages clip lifecycle events in Postgres."""

--- a/src/homesec/maintenance/cleanup_clips.py
+++ b/src/homesec/maintenance/cleanup_clips.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from homesec.config import load_config, resolve_env_var
-from homesec.interfaces import ObjectFilter, StorageBackend
+from homesec.interfaces import EventStore, ObjectFilter, StorageBackend
 from homesec.models.clip import ClipStateData
 from homesec.models.filter import FilterConfig
 from homesec.plugins import discover_all_plugins
@@ -184,26 +184,30 @@ async def run_cleanup(opts: CleanupOptions) -> None:
     if not dsn:
         raise RuntimeError("Postgres DSN is required for cleanup")
 
-    storage = load_storage_plugin(cfg.storage)
-    state_store = PostgresStateStore(dsn)
-    ok = await state_store.initialize()
-    if not ok:
-        raise RuntimeError("Failed to initialize Postgres state store")
-
-    event_store = create_event_store_for_postgres_state_store(state_store)
-    repo = ClipRepository(state_store, event_store, retry=cfg.retry)
-
-    recheck_cfg = _build_recheck_filter_config(cfg.filter, opts)
-    filter_plugin = load_filter(recheck_cfg)
-
-    sem = asyncio.Semaphore(int(opts.workers))
-
-    cache_dir = Path.cwd() / "video_cache" / "cleanup" / run_id
-    cache_dir.mkdir(parents=True, exist_ok=True)
-
-    totals = _Counts()
-
+    storage: StorageBackend | None = None
+    state_store: PostgresStateStore | None = None
+    event_store: EventStore | None = None
+    filter_plugin: ObjectFilter | None = None
     try:
+        storage = load_storage_plugin(cfg.storage)
+        state_store = PostgresStateStore(dsn)
+        ok = await state_store.initialize()
+        if not ok:
+            raise RuntimeError("Failed to initialize Postgres state store")
+
+        event_store = create_event_store_for_postgres_state_store(state_store)
+        repo = ClipRepository(state_store, event_store, retry=cfg.retry)
+
+        recheck_cfg = _build_recheck_filter_config(cfg.filter, opts)
+        filter_plugin = load_filter(recheck_cfg)
+
+        sem = asyncio.Semaphore(int(opts.workers))
+
+        cache_dir = Path.cwd() / "video_cache" / "cleanup" / run_id
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        totals = _Counts()
+
         cursor: tuple[datetime, str] | None = None
         while True:
             rows = await repo.list_candidate_clips_for_cleanup(
@@ -276,10 +280,13 @@ async def run_cleanup(opts: CleanupOptions) -> None:
         )
         _log_json(logging.INFO, "Cleanup summary", summary_payload)
     finally:
-        try:
+        if filter_plugin is not None:
             await filter_plugin.shutdown()
-        finally:
+        if event_store is not None:
+            await event_store.shutdown()
+        if storage is not None:
             await storage.shutdown()
+        if state_store is not None:
             await state_store.shutdown()
 
 

--- a/src/homesec/maintenance/cleanup_clips.py
+++ b/src/homesec/maintenance/cleanup_clips.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from homesec.config import load_config, resolve_env_var
-from homesec.interfaces import EventStore, ObjectFilter, StorageBackend
+from homesec.interfaces import EventStore, ObjectFilter, Shutdownable, StorageBackend
 from homesec.models.clip import ClipStateData
 from homesec.models.filter import FilterConfig
 from homesec.plugins import discover_all_plugins
@@ -188,6 +188,7 @@ async def run_cleanup(opts: CleanupOptions) -> None:
     state_store: PostgresStateStore | None = None
     event_store: EventStore | None = None
     filter_plugin: ObjectFilter | None = None
+    primary_error: Exception | None = None
     try:
         storage = load_storage_plugin(cfg.storage)
         state_store = PostgresStateStore(dsn)
@@ -279,15 +280,34 @@ async def run_cleanup(opts: CleanupOptions) -> None:
             }
         )
         _log_json(logging.INFO, "Cleanup summary", summary_payload)
+    except Exception as exc:
+        primary_error = exc
+        raise
     finally:
+        shutdown_error: Exception | None = None
         if filter_plugin is not None:
-            await filter_plugin.shutdown()
+            error = await _shutdown_cleanup_resource(filter_plugin, label="filter")
+            shutdown_error = shutdown_error or error
         if event_store is not None:
-            await event_store.shutdown()
+            error = await _shutdown_cleanup_resource(event_store, label="event store")
+            shutdown_error = shutdown_error or error
         if storage is not None:
-            await storage.shutdown()
+            error = await _shutdown_cleanup_resource(storage, label="storage")
+            shutdown_error = shutdown_error or error
         if state_store is not None:
-            await state_store.shutdown()
+            error = await _shutdown_cleanup_resource(state_store, label="state store")
+            shutdown_error = shutdown_error or error
+        if primary_error is None and shutdown_error is not None:
+            raise shutdown_error
+
+
+async def _shutdown_cleanup_resource(component: Shutdownable, *, label: str) -> Exception | None:
+    try:
+        await component.shutdown()
+    except Exception as exc:
+        logger.warning("Cleanup failed to shut down %s: %s", label, exc, exc_info=True)
+        return exc
+    return None
 
 
 async def _process_candidate(

--- a/src/homesec/maintenance/cleanup_clips.py
+++ b/src/homesec/maintenance/cleanup_clips.py
@@ -25,7 +25,10 @@ from homesec.plugins.filters import load_filter
 from homesec.plugins.filters.yolo import YoloFilterConfig
 from homesec.plugins.storage import load_storage_plugin
 from homesec.repository.clip_repository import ClipRepository
-from homesec.state.postgres import PostgresStateStore
+from homesec.state.postgres import (
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 
 logger = logging.getLogger("homesec.cleanup_clips")
 
@@ -187,7 +190,7 @@ async def run_cleanup(opts: CleanupOptions) -> None:
     if not ok:
         raise RuntimeError("Failed to initialize Postgres state store")
 
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     repo = ClipRepository(state_store, event_store, retry=cfg.retry)
 
     recheck_cfg = _build_recheck_filter_config(cfg.filter, opts)

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -119,6 +119,7 @@ async def build_runtime_persistence_stack(
 
     storage = _create_storage_backend(config, loader=loader)
     state_store: StateStore | None = None
+    event_store: EventStore | None = None
     try:
         state_store = await _create_state_store(
             config.state_store,
@@ -143,6 +144,8 @@ async def build_runtime_persistence_stack(
             repository=repository,
         )
     except Exception:
+        if event_store is not None:
+            await _safe_shutdown(event_store, label="event store")
         if state_store is not None:
             await _safe_shutdown(state_store, label="state store")
         await _safe_shutdown(storage, label="storage backend")

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Protocol, cast
 from homesec.interfaces import EventStore
 from homesec.plugins.storage import load_storage_plugin
 from homesec.repository import ClipRepository
-from homesec.state import NoopEventStore, PostgresStateStore
+from homesec.state.postgres import (
+    NoopEventStore,
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 
 if TYPE_CHECKING:
     from homesec.interfaces import StateStore, StorageBackend
@@ -24,9 +28,6 @@ class _InitializableStateStore(Protocol):
 
     async def initialize(self) -> bool:
         """Initialize backing resources."""
-
-    def create_event_store(self) -> EventStore:
-        """Create associated event store."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,13 +71,19 @@ async def _create_state_store(
 def _create_event_store(
     state_store: StateStore,
     *,
+    event_store_factory: Callable[[StateStore], EventStore],
     unavailable_warning: str,
 ) -> EventStore:
-    """Create event store from state store and warn when events are unavailable."""
-    event_store = state_store.create_event_store()
+    """Create explicitly wired event store and warn when events are unavailable."""
+    event_store = event_store_factory(state_store)
     if isinstance(event_store, NoopEventStore):
         logger.warning(unavailable_warning)
     return event_store
+
+
+def _create_postgres_event_store(state_store: StateStore) -> EventStore:
+    """Create an event store for the configured Postgres state store."""
+    return create_event_store_for_postgres_state_store(cast(PostgresStateStore, state_store))
 
 
 def _create_repository(
@@ -101,10 +108,14 @@ async def build_runtime_persistence_stack(
     event_store_unavailable_warning: str,
     storage_loader: Callable[[StorageConfig], StorageBackend] | None = None,
     state_store_factory: Callable[[str], _InitializableStateStore] | None = None,
+    event_store_factory: Callable[[StateStore], EventStore] | None = None,
 ) -> RuntimePersistenceStack:
     """Build shared storage and persistence components for a runtime."""
     loader = load_storage_plugin if storage_loader is None else storage_loader
     factory = PostgresStateStore if state_store_factory is None else state_store_factory
+    event_factory = (
+        _create_postgres_event_store if event_store_factory is None else event_store_factory
+    )
 
     storage = _create_storage_backend(config, loader=loader)
     state_store: StateStore | None = None
@@ -117,6 +128,7 @@ async def build_runtime_persistence_stack(
         )
         event_store = _create_event_store(
             state_store,
+            event_store_factory=event_factory,
             unavailable_warning=event_store_unavailable_warning,
         )
         repository = _create_repository(

--- a/src/homesec/runtime/bootstrap.py
+++ b/src/homesec/runtime/bootstrap.py
@@ -83,7 +83,12 @@ def _create_event_store(
 
 def _create_postgres_event_store(state_store: StateStore) -> EventStore:
     """Create an event store for the configured Postgres state store."""
-    return create_event_store_for_postgres_state_store(cast(PostgresStateStore, state_store))
+    if not isinstance(state_store, PostgresStateStore):
+        raise TypeError(
+            "Default event store factory requires PostgresStateStore; "
+            "pass event_store_factory when using a custom state_store_factory"
+        )
+    return create_event_store_for_postgres_state_store(state_store)
 
 
 def _create_repository(
@@ -111,6 +116,12 @@ async def build_runtime_persistence_stack(
     event_store_factory: Callable[[StateStore], EventStore] | None = None,
 ) -> RuntimePersistenceStack:
     """Build shared storage and persistence components for a runtime."""
+    if state_store_factory is not None and event_store_factory is None:
+        raise RuntimeError(
+            "Custom state_store_factory requires event_store_factory so persistence wiring "
+            "stays explicit"
+        )
+
     loader = load_storage_plugin if storage_loader is None else storage_loader
     factory = PostgresStateStore if state_store_factory is None else state_store_factory
     event_factory = (

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -230,6 +230,10 @@ class _RuntimeWorkerService:
             await self._assembler.shutdown_bundle(runtime_bundle)
             self._runtime_bundle = None
 
+        if self._event_store is not None:
+            await self._event_store.shutdown()
+            self._event_store = None
+
         if self._state_store is not None:
             await self._state_store.shutdown()
             self._state_store = None

--- a/src/homesec/state/postgres.py
+++ b/src/homesec/state/postgres.py
@@ -708,6 +708,8 @@ def create_event_store_for_postgres_state_store(state_store: PostgresStateStore)
     """Create a Postgres event store sharing the state store engine.
 
     If the state store failed to initialize, events degrade to the no-op store.
+    The returned Postgres event store borrows the state store's engine; engine
+    disposal remains the responsibility of PostgresStateStore.shutdown().
     """
     if state_store._engine is None:
         return NoopEventStore()

--- a/src/homesec/state/postgres.py
+++ b/src/homesec/state/postgres.py
@@ -579,12 +579,6 @@ class PostgresStateStore(StateStore):
         """Parse JSONB payload from SQLAlchemy into a dict."""
         return _parse_jsonb_payload(raw)
 
-    def create_event_store(self) -> EventStore:
-        """Create a Postgres-backed event store or a no-op fallback."""
-        if self._engine is None:
-            return NoopEventStore()
-        return PostgresEventStore(self._engine)
-
 
 def _parse_jsonb_payload(raw: object) -> dict[str, Any]:
     """Parse JSONB payload from SQLAlchemy into a dict."""
@@ -710,6 +704,16 @@ class PostgresEventStore(EventStore):
             return False
 
 
+def create_event_store_for_postgres_state_store(state_store: PostgresStateStore) -> EventStore:
+    """Create a Postgres event store sharing the state store engine.
+
+    If the state store failed to initialize, events degrade to the no-op store.
+    """
+    if state_store._engine is None:
+        return NoopEventStore()
+    return PostgresEventStore(state_store._engine)
+
+
 class NoopEventStore(EventStore):
     """Event store that drops events (used when Postgres is unavailable)."""
 
@@ -806,7 +810,3 @@ class NoopStateStore(StateStore):
 
     async def ping(self) -> bool:
         return False
-
-    def create_event_store(self) -> EventStore:
-        """Return NoopEventStore."""
-        return NoopEventStore()

--- a/tests/homesec/test_app.py
+++ b/tests/homesec/test_app.py
@@ -11,6 +11,7 @@ import pytest
 
 from homesec.app import Application
 from homesec.config.loader import ConfigError, ConfigErrorCode
+from homesec.interfaces import EventStore
 from homesec.models.config import (
     AlertPolicyConfig,
     CameraConfig,
@@ -42,6 +43,7 @@ from homesec.runtime.models import (
 )
 from homesec.runtime.subprocess_controller import SubprocessRuntimeHandle
 from homesec.sources.local_folder import LocalFolderSourceConfig
+from homesec.state.postgres import NoopEventStore
 from tests.homesec.ui_dist_stub import ensure_stub_ui_dist
 
 
@@ -89,14 +91,13 @@ class _StubStateStore:
     async def ping(self) -> bool:
         return True
 
-    def create_event_store(self) -> object:
-        from homesec.state import NoopEventStore
-
-        return NoopEventStore()
-
     async def shutdown(self, timeout: float | None = None) -> None:
         _ = timeout
         self.shutdown_called = True
+
+
+def _noop_event_store_factory(_state_store: object) -> EventStore:
+    return NoopEventStore()
 
 
 class _StubPostgresBackupManager:
@@ -267,6 +268,10 @@ def _mock_runtime_environment(monkeypatch: pytest.MonkeyPatch) -> _StubRuntimeCo
         "homesec.runtime.bootstrap.load_storage_plugin", lambda cfg: _StubStorage(cfg)
     )
     monkeypatch.setattr("homesec.runtime.bootstrap.PostgresStateStore", _StubStateStore)
+    monkeypatch.setattr(
+        "homesec.runtime.bootstrap.create_event_store_for_postgres_state_store",
+        _noop_event_store_factory,
+    )
     monkeypatch.setattr("homesec.plugins.discover_all_plugins", lambda: None)
     monkeypatch.setattr("homesec.app.validate_plugin_names", lambda *args, **kwargs: None)
     monkeypatch.setattr("homesec.app.validate_config", lambda *args, **kwargs: None)
@@ -727,16 +732,15 @@ async def test_build_runtime_persistence_stack_prefers_env_dsn(
         async def ping(self) -> bool:
             return True
 
-        def create_event_store(self) -> object:
-            from homesec.state import NoopEventStore
-
-            return NoopEventStore()
-
     app = Application(config_path=Path(__file__))
     monkeypatch.setattr("homesec.app.resolve_env_var", lambda _: "postgresql://from-env")
     monkeypatch.setattr("homesec.runtime.bootstrap.PostgresStateStore", _RecordingStateStore)
     monkeypatch.setattr(
         "homesec.runtime.bootstrap.load_storage_plugin", lambda cfg: _StubStorage(cfg)
+    )
+    monkeypatch.setattr(
+        "homesec.runtime.bootstrap.create_event_store_for_postgres_state_store",
+        _noop_event_store_factory,
     )
 
     # When: Building shared runtime persistence

--- a/tests/homesec/test_app.py
+++ b/tests/homesec/test_app.py
@@ -96,8 +96,24 @@ class _StubStateStore:
         self.shutdown_called = True
 
 
+class _RecordingEventStore(NoopEventStore):
+    instances: list[_RecordingEventStore] = []
+
+    def __init__(self) -> None:
+        self.shutdown_called = False
+        self.__class__.instances.append(self)
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        _ = timeout
+        self.shutdown_called = True
+
+
 def _noop_event_store_factory(_state_store: object) -> EventStore:
-    return NoopEventStore()
+    return _RecordingEventStore()
+
+
+def _latest_event_store() -> _RecordingEventStore:
+    return _RecordingEventStore.instances[-1]
 
 
 class _StubPostgresBackupManager:
@@ -264,6 +280,7 @@ def _mock_runtime_environment(monkeypatch: pytest.MonkeyPatch) -> _StubRuntimeCo
     # Given: Runtime dependencies mocked for deterministic tests
     controller = _StubRuntimeController()
     _StubPostgresBackupManager.instances.clear()
+    _RecordingEventStore.instances.clear()
     monkeypatch.setattr(
         "homesec.runtime.bootstrap.load_storage_plugin", lambda cfg: _StubStorage(cfg)
     )
@@ -339,6 +356,7 @@ async def test_application_shuts_down_postgres_backup_manager_before_storage(
     assert isinstance(manager, _StubPostgresBackupManager)
     assert manager.shutdown_called is True
     assert manager.shutdown_timeout == 10.0
+    assert _latest_event_store().shutdown_called is True
 
 
 @pytest.mark.asyncio
@@ -367,6 +385,7 @@ async def test_application_cleans_up_started_backup_manager_when_api_creation_fa
     assert manager.shutdown_timeout == 10.0
     assert isinstance(manager.storage, _StubStorage)
     assert manager.storage.shutdown_called is True
+    assert _latest_event_store().shutdown_called is True
     assert _mock_runtime_environment._handles[0].process is None
 
 

--- a/tests/homesec/test_cleanup_clips.py
+++ b/tests/homesec/test_cleanup_clips.py
@@ -79,8 +79,6 @@ class _CleanupStorage:
 
 
 class _CleanupStateStore:
-    _engine = object()
-
     def __init__(self, calls: list[str], *, initialize_ok: bool) -> None:
         self._calls = calls
         self._initialize_ok = initialize_ok

--- a/tests/homesec/test_cleanup_clips.py
+++ b/tests/homesec/test_cleanup_clips.py
@@ -12,7 +12,10 @@ from homesec.maintenance.cleanup_clips import CleanupOptions, run_cleanup
 from homesec.models.clip import ClipStateData
 from homesec.models.filter import FilterOverrides, FilterResult
 from homesec.plugins.storage.local import LocalStorage, LocalStorageConfig
-from homesec.state.postgres import PostgresStateStore
+from homesec.state.postgres import (
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 
 
 class _TestFilter(ObjectFilter):
@@ -149,7 +152,8 @@ async def test_cleanup_deletes_empty_clips(
     storage_path = Path(upload.storage_uri.split("local:", 1)[1])
     assert not storage_path.exists()
 
-    events = await state_store.create_event_store().get_events(clip_id)
+    event_store = create_event_store_for_postgres_state_store(state_store)
+    events = await event_store.get_events(clip_id)
     assert any(event.event_type == "clip_deleted" for event in events)
 
     await storage.shutdown()
@@ -217,7 +221,8 @@ async def test_cleanup_marks_false_negatives(
     storage_path = Path(upload.storage_uri.split("local:", 1)[1])
     assert storage_path.exists()
 
-    events = await state_store.create_event_store().get_events(clip_id)
+    event_store = create_event_store_for_postgres_state_store(state_store)
+    events = await event_store.get_events(clip_id)
     assert any(event.event_type == "clip_rechecked" for event in events)
     assert not any(event.event_type == "clip_deleted" for event in events)
 

--- a/tests/homesec/test_cleanup_clips.py
+++ b/tests/homesec/test_cleanup_clips.py
@@ -13,6 +13,7 @@ from homesec.models.clip import ClipStateData
 from homesec.models.filter import FilterOverrides, FilterResult
 from homesec.plugins.storage.local import LocalStorage, LocalStorageConfig
 from homesec.state.postgres import (
+    NoopEventStore,
     PostgresStateStore,
     create_event_store_for_postgres_state_store,
 )
@@ -51,6 +52,39 @@ class _TestFilter(ObjectFilter):
     async def ping(self) -> bool:
         """Health check - test filter is always healthy."""
         return not self.shutdown_called
+
+
+class _CleanupStorage:
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        _ = timeout
+        self._calls.append("storage")
+
+
+class _CleanupStateStore:
+    _engine = object()
+
+    def __init__(self, calls: list[str], *, initialize_ok: bool) -> None:
+        self._calls = calls
+        self._initialize_ok = initialize_ok
+
+    async def initialize(self) -> bool:
+        return self._initialize_ok
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        _ = timeout
+        self._calls.append("state")
+
+
+class _CleanupEventStore(NoopEventStore):
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+
+    async def shutdown(self, timeout: float | None = None) -> None:
+        _ = timeout
+        self._calls.append("event")
 
 
 def _write_cleanup_config(path: Path, *, dsn: str, storage_root: Path) -> None:
@@ -158,6 +192,77 @@ async def test_cleanup_deletes_empty_clips(
 
     await storage.shutdown()
     await state_store.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_releases_storage_and_state_when_postgres_init_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup should not leak resources when fail-fast Postgres init fails."""
+    # Given: Cleanup storage is created but Postgres initialization degrades
+    config_path = tmp_path / "config.yaml"
+    _write_cleanup_config(
+        config_path,
+        dsn="postgresql://user:pass@localhost/db",
+        storage_root=tmp_path / "storage",
+    )
+    calls: list[str] = []
+    storage = _CleanupStorage(calls)
+    state_store = _CleanupStateStore(calls, initialize_ok=False)
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.load_storage_plugin", lambda _: storage)
+    monkeypatch.setattr(
+        "homesec.maintenance.cleanup_clips.PostgresStateStore",
+        lambda _dsn: state_store,
+    )
+
+    def _fail_if_filter_loads(_: object) -> object:
+        raise AssertionError("filter should not load after Postgres init failure")
+
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.load_filter", _fail_if_filter_loads)
+
+    # When/Then: Cleanup fails fast and releases resources acquired before failure
+    with pytest.raises(RuntimeError, match="Failed to initialize Postgres state store"):
+        await run_cleanup(CleanupOptions(config_path=config_path))
+
+    assert calls == ["storage", "state"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_releases_persistence_when_filter_composition_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup should unwind explicit persistence wiring if later composition fails."""
+    # Given: Cleanup reaches event-store wiring before filter creation fails
+    config_path = tmp_path / "config.yaml"
+    _write_cleanup_config(
+        config_path,
+        dsn="postgresql://user:pass@localhost/db",
+        storage_root=tmp_path / "storage",
+    )
+    calls: list[str] = []
+    storage = _CleanupStorage(calls)
+    state_store = _CleanupStateStore(calls, initialize_ok=True)
+    event_store = _CleanupEventStore(calls)
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.load_storage_plugin", lambda _: storage)
+    monkeypatch.setattr(
+        "homesec.maintenance.cleanup_clips.PostgresStateStore",
+        lambda _dsn: state_store,
+    )
+    monkeypatch.setattr(
+        "homesec.maintenance.cleanup_clips.create_event_store_for_postgres_state_store",
+        lambda _state_store: event_store,
+    )
+
+    def _raise_filter_failure(_: object) -> object:
+        raise RuntimeError("filter setup failed")
+
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.load_filter", _raise_filter_failure)
+
+    # When/Then: Later composition failure unwinds event store, storage, and state store
+    with pytest.raises(RuntimeError, match="filter setup failed"):
+        await run_cleanup(CleanupOptions(config_path=config_path))
+
+    assert calls == ["event", "storage", "state"]
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/test_cleanup_clips.py
+++ b/tests/homesec/test_cleanup_clips.py
@@ -22,8 +22,16 @@ from homesec.state.postgres import (
 class _TestFilter(ObjectFilter):
     """Deterministic filter for cleanup tests."""
 
-    def __init__(self, *, detect_on: set[str]) -> None:
+    def __init__(
+        self,
+        *,
+        detect_on: set[str],
+        calls: list[str] | None = None,
+        shutdown_error: Exception | None = None,
+    ) -> None:
         self._detect_on = detect_on
+        self._calls = calls
+        self._shutdown_error = shutdown_error
         self.shutdown_called = False
 
     async def detect(
@@ -48,6 +56,10 @@ class _TestFilter(ObjectFilter):
     async def shutdown(self, timeout: float | None = None) -> None:
         _ = timeout
         self.shutdown_called = True
+        if self._calls is not None:
+            self._calls.append("filter")
+        if self._shutdown_error is not None:
+            raise self._shutdown_error
 
     async def ping(self) -> bool:
         """Health check - test filter is always healthy."""
@@ -55,12 +67,15 @@ class _TestFilter(ObjectFilter):
 
 
 class _CleanupStorage:
-    def __init__(self, calls: list[str]) -> None:
+    def __init__(self, calls: list[str], shutdown_error: Exception | None = None) -> None:
         self._calls = calls
+        self._shutdown_error = shutdown_error
 
     async def shutdown(self, timeout: float | None = None) -> None:
         _ = timeout
         self._calls.append("storage")
+        if self._shutdown_error is not None:
+            raise self._shutdown_error
 
 
 class _CleanupStateStore:
@@ -79,12 +94,15 @@ class _CleanupStateStore:
 
 
 class _CleanupEventStore(NoopEventStore):
-    def __init__(self, calls: list[str]) -> None:
+    def __init__(self, calls: list[str], shutdown_error: Exception | None = None) -> None:
         self._calls = calls
+        self._shutdown_error = shutdown_error
 
     async def shutdown(self, timeout: float | None = None) -> None:
         _ = timeout
         self._calls.append("event")
+        if self._shutdown_error is not None:
+            raise self._shutdown_error
 
 
 def _write_cleanup_config(path: Path, *, dsn: str, storage_root: Path) -> None:
@@ -263,6 +281,66 @@ async def test_cleanup_releases_persistence_when_filter_composition_fails(
         await run_cleanup(CleanupOptions(config_path=config_path))
 
     assert calls == ["event", "storage", "state"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_attempts_all_shutdowns_and_preserves_primary_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup shutdown failures should not hide the primary workflow failure."""
+    # Given: Cleanup reaches the main loop and several acquired resources fail on shutdown
+    config_path = tmp_path / "config.yaml"
+    _write_cleanup_config(
+        config_path,
+        dsn="postgresql://user:pass@localhost/db",
+        storage_root=tmp_path / "storage",
+    )
+    calls: list[str] = []
+    storage = _CleanupStorage(calls, RuntimeError("storage shutdown failed"))
+    state_store = _CleanupStateStore(calls, initialize_ok=True)
+    event_store = _CleanupEventStore(calls, RuntimeError("event shutdown failed"))
+    filter_plugin = _TestFilter(
+        detect_on=set(),
+        calls=calls,
+        shutdown_error=RuntimeError("filter shutdown failed"),
+    )
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.load_storage_plugin", lambda _: storage)
+    monkeypatch.setattr(
+        "homesec.maintenance.cleanup_clips.PostgresStateStore",
+        lambda _dsn: state_store,
+    )
+    monkeypatch.setattr(
+        "homesec.maintenance.cleanup_clips.create_event_store_for_postgres_state_store",
+        lambda _state_store: event_store,
+    )
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.load_filter", lambda _: filter_plugin)
+
+    class _FailingRepository:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args
+            _ = kwargs
+
+        async def list_candidate_clips_for_cleanup(
+            self,
+            *,
+            older_than_days: int | None,
+            camera_name: str | None,
+            batch_size: int,
+            cursor: tuple[object, str] | None,
+        ) -> list[tuple[str, ClipStateData, object]]:
+            _ = older_than_days
+            _ = camera_name
+            _ = batch_size
+            _ = cursor
+            raise RuntimeError("primary cleanup failed")
+
+    monkeypatch.setattr("homesec.maintenance.cleanup_clips.ClipRepository", _FailingRepository)
+
+    # When/Then: The primary error is preserved and every resource is asked to shut down
+    with pytest.raises(RuntimeError, match="primary cleanup failed"):
+        await run_cleanup(CleanupOptions(config_path=config_path))
+
+    assert calls == ["filter", "event", "storage", "state"]
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/test_clip_repository.py
+++ b/tests/homesec/test_clip_repository.py
@@ -17,7 +17,11 @@ from homesec.models.vlm import (
     SequenceAnalysis,
 )
 from homesec.repository import ClipRepository
-from homesec.state.postgres import PostgresEventStore, PostgresStateStore
+from homesec.state.postgres import (
+    PostgresEventStore,
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 from tests.homesec.mocks import MockEventStore, MockStateStore
 
 
@@ -34,7 +38,7 @@ async def test_initialize_clip(postgres_dsn: str, tmp_path: Path, clean_test_db:
     # Given: A repository with state and event stores
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     repository = ClipRepository(state_store, event_store)
 
@@ -98,7 +102,7 @@ async def test_record_upload_completed(
     # Given: A clip that's been initialized
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     repository = ClipRepository(state_store, event_store)
 
@@ -144,7 +148,7 @@ async def test_record_filter_completed(
     # Given: A clip that's been initialized
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     repository = ClipRepository(state_store, event_store)
 
@@ -193,7 +197,7 @@ async def test_record_clip_rechecked_updates_state_and_event(
     # Given: A clip initialized in the repository
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     repository = ClipRepository(state_store, event_store)
 
@@ -251,7 +255,7 @@ async def test_record_vlm_completed(postgres_dsn: str, tmp_path: Path, clean_tes
     # Given: A clip that's been initialized
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     repository = ClipRepository(state_store, event_store)
 
@@ -370,7 +374,7 @@ async def test_record_notification_sent(
     # Given: A clip that's been analyzed
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     repository = ClipRepository(state_store, event_store)
 

--- a/tests/homesec/test_event_store.py
+++ b/tests/homesec/test_event_store.py
@@ -13,7 +13,11 @@ from homesec.models.events import (
     FilterCompletedEvent,
     UploadCompletedEvent,
 )
-from homesec.state.postgres import PostgresEventStore, PostgresStateStore
+from homesec.state.postgres import (
+    PostgresEventStore,
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 
 
 @pytest.mark.asyncio
@@ -21,7 +25,7 @@ async def test_append_and_get_events(postgres_dsn: str, clean_test_db: None) -> 
     # Given: A state store and event store with initialized tables
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
 
     clip_id = "test-clip-001"
@@ -88,7 +92,7 @@ async def test_append_and_get_clip_deleted_event(
     # Given: A state store and event store with initialized tables
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
 
     clip_id = "test-clip-delete-001"
@@ -133,7 +137,7 @@ async def test_get_events_after_id(postgres_dsn: str, clean_test_db: None) -> No
     # Given: A clip with multiple events
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
 
     clip_id = "test-clip-002"
@@ -184,7 +188,7 @@ async def test_events_for_nonexistent_clip(postgres_dsn: str) -> None:
     # Given: An initialized event store
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
 
     # When: We query events for a nonexistent clip

--- a/tests/homesec/test_pipeline_events.py
+++ b/tests/homesec/test_pipeline_events.py
@@ -28,7 +28,11 @@ from homesec.plugins.analyzers.openai import OpenAIConfig
 from homesec.plugins.filters.yolo import YoloFilterConfig
 from homesec.plugins.storage.dropbox import DropboxStorageConfig
 from homesec.repository import ClipRepository
-from homesec.state.postgres import PostgresEventStore, PostgresStateStore
+from homesec.state.postgres import (
+    PostgresEventStore,
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 from tests.homesec.mocks import (
     MockFilter,
     MockNotifier,
@@ -118,7 +122,7 @@ async def test_pipeline_emits_success_events(
     # Given: A real Postgres event store and a pipeline with successful mocks
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     config = build_config()
     repository = ClipRepository(state_store, event_store, retry=config.retry)
@@ -189,7 +193,7 @@ async def test_pipeline_emits_notification_events_per_notifier(
     # Given: A real Postgres event store and two notifier entries
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     config = build_config(notifier_count=2)
     repository = ClipRepository(state_store, event_store, retry=config.retry)
@@ -241,7 +245,7 @@ async def test_pipeline_records_alert_decision_without_notification_events_when_
     # Given: A real Postgres event store and runtime-provided empty notifier entries
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     config = build_config(notifier_count=0)
     repository = ClipRepository(state_store, event_store, retry=config.retry)
@@ -286,7 +290,7 @@ async def test_pipeline_emits_vlm_skipped_event(
     # Given: A clip with non-trigger classes and notify_on_motion disabled
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     config = build_config()
     repository = ClipRepository(state_store, event_store, retry=config.retry)
@@ -332,7 +336,7 @@ async def test_pipeline_emits_vlm_skipped_event_for_run_mode_never(
     # Given: A clip with trigger classes but run_mode forcing VLM disabled
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     config = build_config(run_mode="never")
     repository = ClipRepository(state_store, event_store, retry=config.retry)
@@ -378,7 +382,7 @@ async def test_pipeline_emits_upload_failed_event(
     # Given: A pipeline where upload fails but filter/VLM succeed
     state_store = PostgresStateStore(postgres_dsn)
     await state_store.initialize()
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     assert isinstance(event_store, PostgresEventStore)
     config = build_config()
     repository = ClipRepository(state_store, event_store, retry=config.retry)

--- a/tests/homesec/test_runtime_bootstrap.py
+++ b/tests/homesec/test_runtime_bootstrap.py
@@ -16,6 +16,7 @@ from homesec.models.enums import VLMRunMode
 from homesec.models.filter import FilterConfig
 from homesec.models.vlm import VLMConfig
 from homesec.runtime.bootstrap import build_runtime_persistence_stack
+from homesec.state.postgres import NoopEventStore
 
 
 def _make_config() -> Config:
@@ -61,9 +62,6 @@ async def test_build_runtime_persistence_stack_shuts_down_storage_when_state_ini
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
 
-        def create_event_store(self) -> object:
-            raise AssertionError("create_event_store should not be reached")
-
     # When: Building the shared runtime persistence stack
     with pytest.raises(RuntimeError, match="boom"):
         await build_runtime_persistence_stack(
@@ -99,10 +97,10 @@ async def test_build_runtime_persistence_stack_shuts_down_partial_state_when_eve
             _ = timeout
             self.shutdown_called = True
 
-        def create_event_store(self) -> object:
-            raise RuntimeError("event store failed")
-
     store = _StateStoreWithFailingEvents("unused")
+
+    def _raise_event_store_failure(_store: object) -> NoopEventStore:
+        raise RuntimeError("event store failed")
 
     # When: Building the shared runtime persistence stack
     with pytest.raises(RuntimeError, match="event store failed"):
@@ -113,6 +111,7 @@ async def test_build_runtime_persistence_stack_shuts_down_partial_state_when_eve
             event_store_unavailable_warning="events unavailable",
             storage_loader=lambda _cfg: storage,
             state_store_factory=lambda _dsn: store,
+            event_store_factory=_raise_event_store_failure,
         )
 
     # Then: Both initialized resources are shut down on partial-build failure
@@ -142,9 +141,6 @@ async def test_build_runtime_persistence_stack_preserves_primary_failure_when_cl
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
 
-        def create_event_store(self) -> object:
-            raise AssertionError("create_event_store should not be reached")
-
     # When: Building the shared runtime persistence stack
     with pytest.raises(RuntimeError, match="primary failure"):
         await build_runtime_persistence_stack(
@@ -157,3 +153,41 @@ async def test_build_runtime_persistence_stack_preserves_primary_failure_when_cl
         )
 
     # Then: Cleanup errors do not replace the original bootstrap failure
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_persistence_stack_uses_noop_events_when_state_init_returns_false() -> (
+    None
+):
+    # Given: Postgres initialization degrades without raising
+    config = _make_config()
+    storage = _RecordingStorage()
+
+    class _UnavailableStateStore:
+        _engine = None
+
+        def __init__(self, dsn: str) -> None:
+            self.dsn = dsn
+
+        async def initialize(self) -> bool:
+            return False
+
+        async def shutdown(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+    store = _UnavailableStateStore(config.state_store.dsn or "")
+
+    # When: Building the shared runtime persistence stack
+    persistence = await build_runtime_persistence_stack(
+        config,
+        resolve_env=lambda env: env,
+        missing_dsn_message="missing dsn",
+        event_store_unavailable_warning="events unavailable",
+        storage_loader=lambda _cfg: storage,
+        state_store_factory=lambda _dsn: store,
+    )
+
+    # Then: Runtime can continue with best-effort/no-op event persistence
+    assert persistence.state_store is store
+    assert isinstance(persistence.event_store, NoopEventStore)
+    assert storage.shutdown_called is False

--- a/tests/homesec/test_runtime_bootstrap.py
+++ b/tests/homesec/test_runtime_bootstrap.py
@@ -46,6 +46,39 @@ class _RecordingStorage:
         self.shutdown_called = True
 
 
+def _noop_event_store_factory(_store: object) -> NoopEventStore:
+    return NoopEventStore()
+
+
+@pytest.mark.asyncio
+async def test_build_runtime_persistence_stack_requires_event_factory_with_custom_state() -> None:
+    # Given: Custom state-store wiring without the matching event-store factory
+    config = _make_config()
+    storage_loaded = False
+
+    class _CustomStateStore:
+        async def initialize(self) -> bool:
+            return True
+
+    def _load_storage(_cfg: StorageConfig) -> _RecordingStorage:
+        nonlocal storage_loaded
+        storage_loaded = True
+        return _RecordingStorage()
+
+    # When/Then: Bootstrap rejects the partial override before acquiring resources
+    with pytest.raises(RuntimeError, match="event_store_factory"):
+        await build_runtime_persistence_stack(
+            config,
+            resolve_env=lambda env: env,
+            missing_dsn_message="missing dsn",
+            event_store_unavailable_warning="events unavailable",
+            storage_loader=_load_storage,
+            state_store_factory=lambda _dsn: _CustomStateStore(),
+        )
+
+    assert storage_loaded is False
+
+
 @pytest.mark.asyncio
 async def test_build_runtime_persistence_stack_shuts_down_storage_when_state_init_fails() -> None:
     # Given: A storage backend created before state-store initialization fails
@@ -71,6 +104,7 @@ async def test_build_runtime_persistence_stack_shuts_down_storage_when_state_ini
             event_store_unavailable_warning="events unavailable",
             storage_loader=lambda _cfg: storage,
             state_store_factory=_FailingStateStore,
+            event_store_factory=_noop_event_store_factory,
         )
 
     # Then: Storage is cleaned up even though the worker never captured it
@@ -150,6 +184,7 @@ async def test_build_runtime_persistence_stack_preserves_primary_failure_when_cl
             event_store_unavailable_warning="events unavailable",
             storage_loader=lambda _cfg: _FailingStorage(),
             state_store_factory=_FailingStateStore,
+            event_store_factory=_noop_event_store_factory,
         )
 
     # Then: Cleanup errors do not replace the original bootstrap failure
@@ -164,8 +199,6 @@ async def test_build_runtime_persistence_stack_uses_noop_events_when_state_init_
     storage = _RecordingStorage()
 
     class _UnavailableStateStore:
-        _engine = None
-
         def __init__(self, dsn: str) -> None:
             self.dsn = dsn
 
@@ -185,6 +218,7 @@ async def test_build_runtime_persistence_stack_uses_noop_events_when_state_init_
         event_store_unavailable_warning="events unavailable",
         storage_loader=lambda _cfg: storage,
         state_store_factory=lambda _dsn: store,
+        event_store_factory=_noop_event_store_factory,
     )
 
     # Then: Runtime can continue with best-effort/no-op event persistence

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -199,28 +199,43 @@ async def test_runtime_worker_run_runtime_skips_analyzer_load_when_run_mode_neve
     stop_event.set()
 
     class _StubStorage:
+        def __init__(self) -> None:
+            self.shutdown_called = False
+
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
+            self.shutdown_called = True
 
     class _StubStateStore:
+        def __init__(self) -> None:
+            self.shutdown_called = False
+
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
+            self.shutdown_called = True
 
     class _StubEventStore:
+        def __init__(self) -> None:
+            self.shutdown_called = False
+
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
+            self.shutdown_called = True
 
     class _StubFilter:
         async def shutdown(self, timeout: float | None = None) -> None:
             _ = timeout
 
     monkeypatch.setattr(worker_module, "discover_all_plugins", lambda: None)
+    storage = _StubStorage()
+    state_store = _StubStateStore()
+    event_store = _StubEventStore()
 
     async def _fake_build_runtime_persistence_stack() -> RuntimePersistenceStack:
         return RuntimePersistenceStack(
-            storage=cast(Any, _StubStorage()),
-            state_store=cast(Any, _StubStateStore()),
-            event_store=cast(Any, _StubEventStore()),
+            storage=cast(Any, storage),
+            state_store=cast(Any, state_store),
+            event_store=cast(Any, event_store),
             repository=cast(Any, object()),
         )
 
@@ -241,6 +256,9 @@ async def test_runtime_worker_run_runtime_skips_analyzer_load_when_run_mode_neve
 
     # Then: Worker completes lifecycle without invoking analyzer loader
     assert service._runtime_bundle is None
+    assert event_store.shutdown_called is True
+    assert state_store.shutdown_called is True
+    assert storage.shutdown_called is True
 
 
 def test_runtime_worker_preview_status_command_reports_runtime_preview_state() -> None:

--- a/tests/homesec/test_state_store.py
+++ b/tests/homesec/test_state_store.py
@@ -18,8 +18,11 @@ from homesec.postgres_support import (
     drop_schema_cascade,
     normalize_async_dsn,
 )
-from homesec.state import PostgresStateStore
-from homesec.state.postgres import ClipState
+from homesec.state.postgres import (
+    ClipState,
+    PostgresStateStore,
+    create_event_store_for_postgres_state_store,
+)
 from tests.homesec.postgres_test_support import default_test_dsn, reset_store_tables
 
 
@@ -797,7 +800,7 @@ async def test_count_alerts_since_counts_notifying_alert_decision_events(
             local_path="/tmp/old.mp4",
         ),
     )
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     await event_store.append(
         AlertDecisionMadeEvent(
             clip_id="test_alert_count_yes",
@@ -861,7 +864,7 @@ async def test_count_alerts_since_ignores_notification_sent_events(
             local_path="/tmp/delivery.mp4",
         ),
     )
-    event_store = state_store.create_event_store()
+    event_store = create_event_store_for_postgres_state_store(state_store)
     await event_store.append(
         AlertDecisionMadeEvent(
             clip_id=clip_id,

--- a/ui/src/features/cameras/hooks/useCameraPreview.test.tsx
+++ b/ui/src/features/cameras/hooks/useCameraPreview.test.tsx
@@ -8,6 +8,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { apiClient } from '../../../api/client'
 import { useCameraPreview } from './useCameraPreview'
 
+const PREVIEW_TEST_NOW_MS = Date.parse('2026-04-23T12:00:00.000Z')
+
+function freezePreviewClock() {
+  vi.spyOn(Date, 'now').mockReturnValue(PREVIEW_TEST_NOW_MS)
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -67,6 +73,7 @@ describe('useCameraPreview', () => {
 
   it('keeps a fresh preview session when the follow-up status refetch fails', async () => {
     // Given: An idle camera whose preview start succeeds but the invalidated status refresh fails
+    freezePreviewClock()
     vi.spyOn(apiClient, 'getCameraPreviewStatus')
       .mockResolvedValueOnce({
         camera_name: 'front',
@@ -113,6 +120,7 @@ describe('useCameraPreview', () => {
 
   it('does not let an older in-flight status refresh clear a newer preview session', async () => {
     // Given: A stale status refresh that started before preview attach succeeds
+    freezePreviewClock()
     let releaseStaleRefresh: ((value: {
       camera_name: string
       enabled: boolean
@@ -470,6 +478,7 @@ describe('useCameraPreview', () => {
 
   it('drops stale preview sessions after a newer terminal runtime status', async () => {
     // Given: A started preview session whose follow-up status says the runtime has already failed it
+    freezePreviewClock()
     vi.spyOn(apiClient, 'getCameraPreviewStatus')
       .mockResolvedValueOnce({
         camera_name: 'front',
@@ -529,6 +538,7 @@ describe('useCameraPreview', () => {
 
   it('keeps a dropped preview session cleared across later status refreshes', async () => {
     // Given: A preview session invalidated by a newer terminal runtime status
+    freezePreviewClock()
     vi.spyOn(apiClient, 'getCameraPreviewStatus')
       .mockResolvedValueOnce({
         camera_name: 'front',


### PR DESCRIPTION
## Summary
- remove `StateStore.create_event_store()` from the interface and concrete state stores
- add explicit Postgres event-store wiring that shares the state-store engine and degrades to `NoopEventStore` when runtime Postgres initialization leaves no engine
- update runtime bootstrap, cleanup wiring, and persistence tests to use explicit composition
- stabilize a date-sensitive UI preview hook test that started failing once its hard-coded token expiry crossed April 24, 2026

## Ticket
https://www.notion.so/340d8336c59f8110a29ed3706bd68edd

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:15433/homesec make check`

## Notes
- Runtime keeps the existing degraded behavior when Postgres init returns false: state remains no-op/unavailable and event persistence is no-op, so recording/upload wiring can still come up.
- Cleanup remains fail-fast when Postgres state initialization does not succeed.
- `PostgresStateStore` remains the shared engine owner; `PostgresEventStore.shutdown()` still does not dispose the shared engine.