### PR TITLE
fix: avoid preview transcode for H.264 sources

### DIFF
--- a/src/homesec/sources/rtsp/live_publisher.py
+++ b/src/homesec/sources/rtsp/live_publisher.py
@@ -644,7 +644,13 @@ class HLSLivePublisher(LivePublisher):
             stream_info=stream_info,
         )
 
-        if self._video_codec == "copy":
+        source_video_codec = (
+            (stream_info.video_codec or "").strip().lower() if stream_info is not None else None
+        )
+
+        if self._video_codec == "copy" or (
+            self._video_codec in ("auto", "h264") and source_video_codec == "h264"
+        ):
             return (
                 _CodecPlan(
                     codec_name="copy",
@@ -653,17 +659,6 @@ class HLSLivePublisher(LivePublisher):
                     audio_args=audio_args,
                 ),
             )
-
-        if self._video_codec == "auto" and stream_info is not None:
-            if (stream_info.video_codec or "").strip().lower() == "h264":
-                return (
-                    _CodecPlan(
-                        codec_name="copy",
-                        ffmpeg_global_args=(),
-                        video_args=("-c:v", "copy"),
-                        audio_args=audio_args,
-                    ),
-                )
 
         software_plan = _CodecPlan(
             codec_name="libx264",
@@ -695,7 +690,7 @@ class HLSLivePublisher(LivePublisher):
         )
 
     def _probe_stream_info(self) -> ProbeStreamInfo | None:
-        needs_probe = self._video_codec == "auto" or (
+        needs_probe = self._video_codec in ("auto", "h264") or (
             self._audio_enabled and self._audio_codec == "auto"
         )
         if not needs_probe:

--- a/tests/homesec/rtsp/test_live_publisher.py
+++ b/tests/homesec/rtsp/test_live_publisher.py
@@ -359,6 +359,38 @@ def test_auto_codec_transcodes_mp4_safe_but_hls_unsafe_audio(tmp_path: Path) -> 
     assert cmd[cmd.index("-b:a") + 1] == "128k"
 
 
+def test_h264_codec_copies_already_h264_video(tmp_path: Path) -> None:
+    """h264 video mode should avoid transcoding sources that already satisfy the output codec."""
+    # Given: A forced-H.264 preview whose source video is already H.264
+    publisher = _make_publisher(
+        tmp_path,
+        discovery=FakeDiscovery(_probe_stream(video_codec="h264", audio_codec="aac")),
+        audio_codec="aac",
+        video_codec="h264",
+    )
+    calls: list[dict[str, object]] = []
+
+    # When: Activating preview
+    with patch(
+        "homesec.sources.rtsp.live_publisher.subprocess.Popen",
+        side_effect=_fake_popen_factory(calls),
+    ):
+        result = publisher.ensure_active()
+
+    # Then: The publisher copy-remuxes video while preserving the requested AAC output
+    assert result == LivePublisherStatus(
+        state=LivePublisherState.READY,
+        viewer_count=0,
+        idle_shutdown_at=5.0,
+    )
+    cmd = calls[0]["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("-c:v") + 1] == "copy"
+    assert cmd[cmd.index("-c:a") + 1] == "aac"
+    assert "libx264" not in cmd
+    assert "-preset" not in cmd
+
+
 def test_auto_codec_transcodes_non_browser_safe_source(tmp_path: Path) -> None:
     """auto codec mode should transcode unsupported source codecs to browser-safe outputs."""
     # Given: A publisher whose source probe reports H.265 video and PCMA audio


### PR DESCRIPTION
## Summary
- Reproduce the live preview failure against `http://lenovo:8081` and trace the 409 to preview publisher startup refusal.
- Probe forced-`h264` preview streams and copy-remux source video that is already H.264 instead of forcing the libx264 path.
- Add RTSP live publisher coverage for `video_codec="h264"` with an already-H.264 source.

## Root Cause
The live server preview config currently sets `preview.config.video_codec: h264`. In that mode, `HLSLivePublisher` always selected the software `libx264` transcode plan. That plan includes `-preset veryfast -tune zerolatency`, and the live server's ffmpeg rejects `-preset` with:

```text
Unrecognized option 'preset'.
Error splitting the argument list: Option not found
```

When ffmpeg exits before the HLS playlist becomes ready, `HLSLivePublisher._start_impl()` classifies the failure as `PreviewRefusalReason.PREVIEW_TEMPORARILY_UNAVAILABLE`. The API route then returns the observed 409.

Exact reproduced route:

```text
POST /api/v1/preview/cameras/front_door
HTTP 409
{"detail":"Preview publisher failed to become ready","error_code":"PREVIEW_TEMPORARILY_UNAVAILABLE","reason":"preview_temporarily_unavailable"}
```

I reproduced the same 409 for `office` and `garage`.

## Change
For `video_codec="h264"`, the publisher now probes the stream and copy-remuxes video when the source codec is already H.264. Non-H.264 sources still fall back to the existing H.264 transcode plans.

## Validation
- `uv run pytest tests/homesec/rtsp/test_live_publisher.py -q` passed: 48 tests.
- `make check` was run. `ruff check`, `ruff format --check`, and `mypy --package homesec --strict` passed. Full pytest reached 894 passed, then failed on local DB-backed tests because the local Postgres at `localhost:5432` rejected the configured `homesec` password (`asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "homesec"`).
- GitHub PR checks passed after push: `Validate PR title`, `ci`, `codecov/patch`, and `codecov/project`.