### PR TITLE
fix: default clips detected filter to true

### DIFF
--- a/ui/src/features/clips/ClipsPage.tsx
+++ b/ui/src/features/clips/ClipsPage.tsx
@@ -11,6 +11,8 @@ import {
   CLIP_LIMIT_OPTIONS,
   CLIP_STATUS_OPTIONS,
   DEFAULT_CLIPS_LIMIT,
+  DEFAULT_DETECTED_FILTER,
+  formStateToSearchParams,
   formStateToQuery,
   parseClipsQuery,
   queryToFormState,
@@ -223,13 +225,14 @@ export function ClipsPage() {
 
   function applyFilters(formState: ClipsFilterFormState): void {
     const nextQuery = formStateToQuery(formState)
-    const nextParams = queryToSearchParams(queryWithoutCursor(nextQuery))
-    clearCursorHistory(nextParams.toString())
+    const nextParams = formStateToSearchParams(formState)
+    clearCursorHistory(queryToSearchParams(queryWithoutCursor(nextQuery)).toString())
     setSearchParams(nextParams)
   }
 
   function resetFilters(): void {
     const resetQuery = {
+      detected: DEFAULT_DETECTED_FILTER,
       limit: DEFAULT_CLIPS_LIMIT,
     }
     const nextParams = queryToSearchParams(resetQuery)
@@ -251,18 +254,21 @@ export function ClipsPage() {
     await Promise.all([clipsQuery.refetch(), camerasQuery.refetch()])
   }
 
+  function queryToRouteSearchParams(nextQuery: ReturnType<typeof queryWithoutCursor>): URLSearchParams {
+    const params = queryToSearchParams(nextQuery)
+    if (query.detected === undefined && searchParams.get('detected') === 'any') {
+      params.set('detected', 'any')
+    }
+    return params
+  }
+
   function goToNextCursor(): void {
     const nextCursor = clipsQuery.data?.next_cursor
     if (!nextCursor) {
       return
     }
     setCursorState((current) => pushCursorHistory(current, filterSignature, query.cursor))
-    setSearchParams(
-      queryToSearchParams({
-        ...query,
-        cursor: nextCursor,
-      }),
-    )
+    setSearchParams(queryToRouteSearchParams({ ...query, cursor: nextCursor }))
   }
 
   function goToPreviousCursor(): void {
@@ -271,12 +277,7 @@ export function ClipsPage() {
       return
     }
     setCursorState(popped.state)
-    setSearchParams(
-      queryToSearchParams({
-        ...query,
-        cursor: popped.previousCursor,
-      }),
-    )
+    setSearchParams(queryToRouteSearchParams({ ...query, cursor: popped.previousCursor }))
   }
 
   return (

--- a/ui/src/features/clips/queryParams.test.ts
+++ b/ui/src/features/clips/queryParams.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_CLIPS_LIMIT,
+  DEFAULT_DETECTED_FILTER,
+  formStateToSearchParams,
   formStateToQuery,
   parseClipsQuery,
   queryToFormState,
@@ -57,9 +59,33 @@ describe('parseClipsQuery', () => {
     // Then: Unsupported values should be dropped or clamped to defaults
     expect(query.status).toBeUndefined()
     expect(query.alerted).toBeUndefined()
-    expect(query.detected).toBeUndefined()
+    expect(query.detected).toBe(DEFAULT_DETECTED_FILTER)
     expect(query.limit).toBe(1)
     expect(query.cursor).toBeUndefined()
+  })
+
+  it('defaults missing detected filter to true', () => {
+    // Given: URL search params without an explicit detected filter
+    const params = new URLSearchParams()
+
+    // When: Parsing into query object
+    const query = parseClipsQuery(params)
+
+    // Then: Clips are filtered to detected results by default
+    expect(query.detected).toBe(true)
+  })
+
+  it('parses explicit detected any as no API detected filter', () => {
+    // Given: URL search params representing the UI's explicit Any selection
+    const params = new URLSearchParams({
+      detected: 'any',
+    })
+
+    // When: Parsing into query object
+    const query = parseClipsQuery(params)
+
+    // Then: The API query omits the detected filter
+    expect(query.detected).toBeUndefined()
   })
 })
 
@@ -96,5 +122,30 @@ describe('form/query conversion', () => {
     expect(hydratedForm.detected).toBe('false')
     expect(hydratedForm.activityType).toBe('vehicle')
     expect(hydratedForm.limit).toBe(DEFAULT_CLIPS_LIMIT)
+  })
+
+  it('preserves explicit detected any in route search params', () => {
+    // Given: Form state with the detected filter set to Any
+    const formState = {
+      camera: '',
+      status: '',
+      alerted: 'any',
+      detected: 'any',
+      riskLevel: '',
+      activityType: '',
+      sinceLocal: '',
+      untilLocal: '',
+      limit: DEFAULT_CLIPS_LIMIT,
+    } as const
+
+    // When: Converting form state to URL search params
+    const params = formStateToSearchParams(formState)
+    const parsed = parseClipsQuery(params)
+    const hydratedForm = queryToFormState(parsed)
+
+    // Then: The route keeps Any distinct from the default detected=true filter
+    expect(params.get('detected')).toBe('any')
+    expect(parsed.detected).toBeUndefined()
+    expect(hydratedForm.detected).toBe('any')
   })
 })

--- a/ui/src/features/clips/queryParams.ts
+++ b/ui/src/features/clips/queryParams.ts
@@ -1,6 +1,7 @@
 import type { ClipStatus, ListClipsQuery } from '../../api/generated/types'
 
 export const DEFAULT_CLIPS_LIMIT = 25
+export const DEFAULT_DETECTED_FILTER = true
 const MIN_CLIPS_LIMIT = 1
 const MAX_CLIPS_LIMIT = 100
 
@@ -50,6 +51,16 @@ function isClipStatus(value: string | null): value is ClipStatus {
   return (CLIP_STATUS_OPTIONS as readonly string[]).includes(value)
 }
 
+function parseDetectedFilter(value: string | null): boolean | undefined {
+  if (value === 'any') {
+    return undefined
+  }
+  if (value === 'false') {
+    return false
+  }
+  return DEFAULT_DETECTED_FILTER
+}
+
 function toIsoUtc(localValue: string): string | undefined {
   if (!localValue.trim()) {
     return undefined
@@ -80,15 +91,13 @@ function toLocalDateTimeInput(isoValue: string | null | undefined): string {
 export function parseClipsQuery(searchParams: URLSearchParams): ListClipsQuery {
   const alertedRaw = searchParams.get('alerted')
   const alerted = alertedRaw === 'true' ? true : alertedRaw === 'false' ? false : undefined
-  const detectedRaw = searchParams.get('detected')
-  const detected = detectedRaw === 'true' ? true : detectedRaw === 'false' ? false : undefined
   const statusRaw = searchParams.get('status')
 
   return {
     camera: searchParams.get('camera')?.trim() || undefined,
     status: isClipStatus(statusRaw) ? statusRaw : undefined,
     alerted,
-    detected,
+    detected: parseDetectedFilter(searchParams.get('detected')),
     risk_level: searchParams.get('risk_level')?.trim() || undefined,
     activity_type: searchParams.get('activity_type')?.trim().toLowerCase() || undefined,
     since: searchParams.get('since')?.trim() || undefined,
@@ -124,6 +133,14 @@ export function formStateToQuery(form: ClipsFilterFormState): ListClipsQuery {
     until: toIsoUtc(form.untilLocal),
     limit: form.limit,
   }
+}
+
+export function formStateToSearchParams(form: ClipsFilterFormState): URLSearchParams {
+  const params = queryToSearchParams(formStateToQuery(form))
+  if (form.detected === 'any') {
+    params.set('detected', 'any')
+  }
+  return params
 }
 
 export function queryToSearchParams(query: ListClipsQuery): URLSearchParams {


### PR DESCRIPTION
## Summary
- Default the Clips page detected filter to true when no detected route parameter is present.
- Preserve an explicit UI-only detected=any route value so users can still choose Any without the default taking over.
- Keep reset and cursor pagination aligned with the new detected default.

## Validation
- pnpm vitest run src/features/clips/queryParams.test.ts
- pnpm check
- make check (fails in local Postgres-backed tests: password authentication failed for user "homesec"; static checks passed before pytest reached DB-backed tests)