### PR TITLE
fix: clean up telemetry log payload shaping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # HomeSec Development Guidelines
 
-**Last reviewed:** 2026-01-18
+**Last reviewed:** 2026-04-25
 **Purpose:** Critical patterns to prevent runtime bugs when extending HomeSec. For architecture overview, see `DESIGN.md`.
 
 ---
@@ -20,6 +20,48 @@
 - **Pydantic everywhere**: Validate config, DB payloads, VLM outputs, and MQTT payloads with Pydantic models.
 - **Clarify before complexity**: Ask user for clarification when simpler design may exist. Don't proceed with complex workarounds.
 - **Product priorities**: Recording + uploading (P0) must work even if Postgres is down. Analysis/notifications are best-effort (P1).
+
+---
+
+## Logging Guidance
+
+**Rule:** Use regular Python logging for operational logs, and structured extras for queryable telemetry. Logging is best-effort observability; use `ClipRepository` for workflow state and durable events.
+
+**Structured logging conventions:**
+- Use normal log levels (`debug`, `info`, `warning`, `error`) for severity.
+- Put queryable context in `extra={...}` instead of packing metadata into the message string.
+- For telemetry events, include a stable low-cardinality `event_type` such as `vlm_usage`, `recording_started`, or `upload_failed`.
+- Treat `event_type` as the canonical event marker. DB filtering and payload shaping classify any truthy `event_type` as `kind="event"`.
+- `kind="event"` is optional when `event_type` is present. Never set `kind="log"` on a record that has `event_type`.
+- Do not manually add standard `LogRecord` fields such as `message`, `asctime`, `levelname`, `pathname`, or `lineno` in `extra`.
+- Prefer the existing logging context injection for `camera_name` and `recording_id`; only pass them explicitly when the caller is outside that context and has accurate values.
+- Never log secrets, tokens, credentials, or full DSNs. Log secret source names such as env var names when needed.
+
+**Template: Telemetry Event Log**
+
+```python
+logger.info(
+    "VLM usage recorded",
+    extra={
+        "event_type": "vlm_usage",
+        "camera_name": camera_name,
+        "recording_id": clip_id,
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": usage.total_tokens,
+    },
+)
+```
+
+**Template: Operational Log**
+
+```python
+logger.warning(
+    "Upload failed; continuing without storage URI",
+    extra={"recording_id": clip_id, "storage_backend": backend},
+    exc_info=exc,
+)
+```
 
 ---
 

--- a/src/homesec/log_records.py
+++ b/src/homesec/log_records.py
@@ -42,6 +42,16 @@ def extract_log_record_extras(
     return {key: value for key, value in record.__dict__.items() if key not in excluded}
 
 
+def log_record_kind(record: logging.LogRecord) -> str:
+    """Return the canonical telemetry kind for a log record."""
+    kind = getattr(record, "kind", None)
+    if kind == "event" or bool(getattr(record, "event_type", None)):
+        return "event"
+    if kind:
+        return str(kind)
+    return "log"
+
+
 def is_event_log_record(record: logging.LogRecord) -> bool:
     """Return true when a log record should be treated as structured event telemetry."""
-    return getattr(record, "kind", None) == "event" or bool(getattr(record, "event_type", None))
+    return log_record_kind(record) == "event"

--- a/src/homesec/log_records.py
+++ b/src/homesec/log_records.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection
+
+STANDARD_LOGRECORD_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "message",
+        "asctime",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+    }
+)
+
+
+def extract_log_record_extras(
+    record: logging.LogRecord,
+    *,
+    exclude: Collection[str] = (),
+) -> dict[str, object]:
+    """Return caller-provided LogRecord extras after standard/promoted fields are removed."""
+    excluded = STANDARD_LOGRECORD_ATTRS | frozenset(exclude)
+    return {key: value for key, value in record.__dict__.items() if key not in excluded}
+
+
+def is_event_log_record(record: logging.LogRecord) -> bool:
+    """Return true when a log record should be treated as structured event telemetry."""
+    return getattr(record, "kind", None) == "event" or bool(getattr(record, "event_type", None))

--- a/src/homesec/logging_setup.py
+++ b/src/homesec/logging_setup.py
@@ -5,35 +5,11 @@ import logging
 import logging.config
 import os
 
+from homesec.log_records import extract_log_record_extras, is_event_log_record
 from homesec.telemetry.postgres_settings import PostgresConfig
 
 _CURRENT_CAMERA_NAME = "-"
 _CURRENT_RECORDING_ID: str | None = None
-_STANDARD_LOGRECORD_ATTRS = {
-    "name",
-    "msg",
-    "message",
-    "asctime",
-    "args",
-    "levelname",
-    "levelno",
-    "pathname",
-    "filename",
-    "module",
-    "exc_info",
-    "exc_text",
-    "stack_info",
-    "lineno",
-    "funcName",
-    "created",
-    "msecs",
-    "relativeCreated",
-    "thread",
-    "threadName",
-    "processName",
-    "process",
-    "taskName",
-}
 
 
 class _CameraNameFilter(logging.Filter):
@@ -56,7 +32,7 @@ class _DbLevelFilter(logging.Filter):
         self._min_level = min_level
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if getattr(record, "kind", None) == "event":
+        if is_event_log_record(record):
             return True
         return record.levelno >= logging.WARNING or record.levelno >= self._min_level
 
@@ -72,14 +48,7 @@ class _JsonExtraFormatter(logging.Formatter):
 
 
 def _extract_extras(record: logging.LogRecord) -> dict[str, object]:
-    extras: dict[str, object] = {}
-    for key, value in record.__dict__.items():
-        if key in _STANDARD_LOGRECORD_ATTRS:
-            continue
-        if key in {"camera_name", "recording_id"}:
-            continue
-        extras[key] = value
-    return extras
+    return extract_log_record_extras(record, exclude={"camera_name", "recording_id"})
 
 
 def set_camera_name(name: str | None) -> None:

--- a/src/homesec/telemetry/db_log_handler.py
+++ b/src/homesec/telemetry/db_log_handler.py
@@ -16,33 +16,12 @@ from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 import homesec.postgres_support as postgres_support
+from homesec.log_records import extract_log_record_extras
 from homesec.telemetry.db.log_table import logs
 from homesec.telemetry.db.log_table import metadata as db_metadata
 from homesec.telemetry.postgres_settings import PostgresConfig
 
-_STANDARD_LOGRECORD_ATTRS = {
-    "name",
-    "msg",
-    "args",
-    "levelname",
-    "levelno",
-    "pathname",
-    "filename",
-    "module",
-    "exc_info",
-    "exc_text",
-    "stack_info",
-    "lineno",
-    "funcName",
-    "created",
-    "msecs",
-    "relativeCreated",
-    "thread",
-    "threadName",
-    "processName",
-    "process",
-    "taskName",
-}
+_PROMOTED_PAYLOAD_ATTRS = frozenset({"camera_name", "recording_id", "event_type", "kind"})
 
 
 def _utc_iso(ts: float) -> str:
@@ -65,11 +44,7 @@ def _record_to_payload(record: logging.LogRecord) -> dict[str, Any]:
         msg_obj = record.msg
 
     fields: dict[str, Any] = {}
-    for k, v in record.__dict__.items():
-        if k in _STANDARD_LOGRECORD_ATTRS:
-            continue
-        if k in {"camera_name", "recording_id", "event_type", "kind"}:
-            continue
+    for k, v in extract_log_record_extras(record, exclude=_PROMOTED_PAYLOAD_ATTRS).items():
         try:
             json.dumps(v, default=str)
             fields[k] = v

--- a/src/homesec/telemetry/db_log_handler.py
+++ b/src/homesec/telemetry/db_log_handler.py
@@ -16,7 +16,7 @@ from sqlalchemy import insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 import homesec.postgres_support as postgres_support
-from homesec.log_records import extract_log_record_extras
+from homesec.log_records import extract_log_record_extras, log_record_kind
 from homesec.telemetry.db.log_table import logs
 from homesec.telemetry.db.log_table import metadata as db_metadata
 from homesec.telemetry.postgres_settings import PostgresConfig
@@ -35,7 +35,7 @@ def _record_to_payload(record: logging.LogRecord) -> dict[str, Any]:
         recording_id = None
 
     event_type = getattr(record, "event_type", None)
-    kind = getattr(record, "kind", None) or ("event" if event_type else "log")
+    kind = log_record_kind(record)
 
     msg_obj: Any
     if isinstance(record.msg, str):

--- a/tests/homesec/test_db_log_handler.py
+++ b/tests/homesec/test_db_log_handler.py
@@ -57,9 +57,9 @@ def test_record_to_payload_excludes_formatter_created_standard_fields() -> None:
     assert payload["fields"] == {"custom": "value"}
 
 
-def test_record_to_payload_treats_event_type_as_event_kind() -> None:
-    """DB payload should classify event_type-only records as event telemetry."""
-    # Given: A log record with event_type but no explicit kind
+def test_record_to_payload_treats_event_type_as_canonical_event_kind() -> None:
+    """DB payload should classify event_type records as event telemetry."""
+    # Given: A log record with event_type and a conflicting explicit kind
     record = logging.getLogger("homesec.test").makeRecord(
         "homesec.test",
         logging.INFO,
@@ -68,13 +68,13 @@ def test_record_to_payload_treats_event_type_as_event_kind() -> None:
         "usage",
         (),
         None,
-        extra={"event_type": "vlm_usage", "total_tokens": 12},
+        extra={"event_type": "vlm_usage", "kind": "log", "total_tokens": 12},
     )
 
     # When: Converting the record to a DB telemetry payload
     payload = _record_to_payload(record)
 
-    # Then: The payload is classified as an event and custom fields are preserved
+    # Then: The payload uses the same event classification as DB filtering
     assert payload["kind"] == "event"
     assert payload["event_type"] == "vlm_usage"
     assert payload["fields"] == {"total_tokens": 12}

--- a/tests/homesec/test_db_log_handler.py
+++ b/tests/homesec/test_db_log_handler.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import cast
 
-from homesec.telemetry.db_log_handler import AsyncPostgresJsonLogHandler
+from homesec.telemetry.db_log_handler import AsyncPostgresJsonLogHandler, _record_to_payload
 from homesec.telemetry.postgres_settings import PostgresConfig
 
 
@@ -21,6 +22,62 @@ class _FakeThread:
         assert timeout is not None
         self.join_calls.append(timeout)
         self._alive = False
+
+
+def test_record_to_payload_excludes_formatter_created_standard_fields() -> None:
+    """DB payload fields should only contain caller custom extras."""
+    # Given: A log record with custom extras that has already been formatted
+    record = logging.getLogger("homesec.test").makeRecord(
+        "homesec.test",
+        logging.INFO,
+        "/tmp/source.py",
+        42,
+        "hello %s",
+        ("world",),
+        None,
+        extra={
+            "camera_name": "front",
+            "recording_id": "clip-1.mp4",
+            "event_type": "recording_start",
+            "kind": "event",
+            "custom": "value",
+        },
+    )
+    logging.Formatter("%(asctime)s %(levelname)s %(message)s").format(record)
+
+    # When: Converting the record to a DB telemetry payload
+    payload = _record_to_payload(record)
+
+    # Then: Formatter-created and promoted fields do not leak into nested fields
+    assert payload["message"] == "hello world"
+    assert payload["camera_name"] == "front"
+    assert payload["recording_id"] == "clip-1.mp4"
+    assert payload["kind"] == "event"
+    assert payload["event_type"] == "recording_start"
+    assert payload["fields"] == {"custom": "value"}
+
+
+def test_record_to_payload_treats_event_type_as_event_kind() -> None:
+    """DB payload should classify event_type-only records as event telemetry."""
+    # Given: A log record with event_type but no explicit kind
+    record = logging.getLogger("homesec.test").makeRecord(
+        "homesec.test",
+        logging.INFO,
+        "/tmp/source.py",
+        42,
+        "usage",
+        (),
+        None,
+        extra={"event_type": "vlm_usage", "total_tokens": 12},
+    )
+
+    # When: Converting the record to a DB telemetry payload
+    payload = _record_to_payload(record)
+
+    # Then: The payload is classified as an event and custom fields are preserved
+    assert payload["kind"] == "event"
+    assert payload["event_type"] == "vlm_usage"
+    assert payload["fields"] == {"total_tokens": 12}
 
 
 def test_db_log_handler_close_joins_writer_thread_when_started() -> None:

--- a/tests/homesec/test_logging_setup.py
+++ b/tests/homesec/test_logging_setup.py
@@ -172,6 +172,7 @@ class TestDbHandlerFilter:
         logger = logging.getLogger()
         logger.debug("event", extra={"kind": "event"})
         logger.debug("event type", extra={"event_type": "vlm_usage"})
+        logger.debug("event type conflict", extra={"event_type": "vlm_usage", "kind": "log"})
         logger.debug("debug")
         logger.info("info")
 
@@ -179,6 +180,7 @@ class TestDbHandlerFilter:
         messages = [record.getMessage() for record in handler.records]
         assert "event" in messages
         assert "event type" in messages
+        assert "event type conflict" in messages
         assert "debug" not in messages
         assert "info" in messages
 

--- a/tests/homesec/test_logging_setup.py
+++ b/tests/homesec/test_logging_setup.py
@@ -168,15 +168,17 @@ class TestDbHandlerFilter:
         configure_logging(log_level="DEBUG")
         handler = _FakeDbHandler.instances[-1]
 
-        # When: Logging an event and a debug message
+        # When: Logging events and non-event messages
         logger = logging.getLogger()
         logger.debug("event", extra={"kind": "event"})
+        logger.debug("event type", extra={"event_type": "vlm_usage"})
         logger.debug("debug")
         logger.info("info")
 
-        # Then: Event debug passes, non-event debug is filtered
+        # Then: Event debug records pass, non-event debug is filtered
         messages = [record.getMessage() for record in handler.records]
         assert "event" in messages
+        assert "event type" in messages
         assert "debug" not in messages
         assert "info" in messages
 


### PR DESCRIPTION
## Summary
- Add a shared LogRecord helper for standard attribute filtering and event classification.
- Use the helper from console logging and Postgres telemetry payload shaping.
- Keep promoted telemetry fields top-level and prevent formatter-created `message` / `asctime` from leaking into DB `payload.fields`.
- Treat `event_type` alone as event telemetry for DB log filtering.

## Validation
- `uv run pytest tests/homesec/test_logging_setup.py tests/homesec/test_db_log_handler.py` passed (12 tests).
- `make lint` passed.
- `make typecheck` passed.
- `make test` was attempted but blocked by local Postgres credentials: `asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "homesec"` across DB-backed tests.

## Notes
- Notion ticket: https://www.notion.so/340d8336c59f8112ac1dd0bc115a5933
- Runtime context propagation redesign is intentionally out of scope for this PR.