### PR TITLE
ci: keep uv lockfile synchronized

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,11 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-py3.14-${{ hashFiles('uv.lock') }}
 
+      - name: Check uv lockfile
+        run: uv lock --check
+
       - name: Sync dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --locked
 
       # Lint and typecheck run while Postgres boots
       - name: Lint
@@ -63,7 +66,7 @@ jobs:
           done
 
       - name: Run migrations
-        run: uv run alembic -c alembic.ini upgrade head
+        run: uv run --locked alembic -c alembic.ini upgrade head
 
       - name: Test with coverage
         run: make coverage

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install python-semantic-release
         run: pip install python-semantic-release
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - **Tests must use Given/When/Then comments**: Every test must include these comments and follow behavioral testing principles (see `TESTING.md`).
 - **Run `make check` before pushing code or opening/updating a PR**: Targeted checks are not enough for publish flow unless the user explicitly asks for a narrower validation scope.
 - **PR titles must satisfy repo CI**: Use semantic PR titles such as `fix: ...`, `refactor: ...`, or `docs: ...`. Do not use `[codex] ...` in this repository because CI rejects non-semantic PR titles.
+- **Respect `uv.lock`**: Validation commands run with `--locked`. If `uv` reports the lockfile is stale, run `uv lock`, inspect the diff, and commit the lockfile sync intentionally. Do not revert `uv.lock` churn without checking whether `pyproject.toml` or dependency metadata changed.
 - **Import from canonical source**: Import types from their defining module, not re-exports. For example, import `RiskLevel` from `models.enums`, not from `models.vlm`. Avoid creating re-exports in `__all__`.
 - **Postgres for state**: Use `clip_states` table with `clip_id` (primary key) + `data` (jsonb) for evolvable schema.
 - **Pydantic everywhere**: Validate config, DB payloads, VLM outputs, and MQTT payloads with Pydantic models.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -eu -o pipefail -c
 
-.PHONY: help up down docker-build docker-push run db test coverage typecheck lint check db-migrate db-migration publish ui-% fake-camera
+.PHONY: help up down docker-build docker-push run db test coverage typecheck lint lock-check check db-migrate db-migration publish ui-% fake-camera
 
 help:
 	@echo "Targets:"
@@ -19,6 +19,7 @@ help:
 	@echo "    make coverage      Run tests and generate HTML coverage report"
 	@echo "    make typecheck     Run mypy"
 	@echo "    make lint          Run ruff linter"
+	@echo "    make lock-check    Verify uv.lock is up to date"
 	@echo "    make check         Run lint + typecheck + test + ui-check"
 	@echo "    make fake-camera   Start a mock ONVIF + RTSP camera (requires ffmpeg, mediamtx)"
 	@echo ""
@@ -38,6 +39,7 @@ HOMESEC_LOG_LEVEL ?= INFO
 DOCKER_IMAGE ?= homesec
 DOCKER_TAG ?= latest
 DOCKERHUB_USER ?= $(shell echo $${DOCKERHUB_USER:-})
+UV_RUN ?= uv run --locked
 
 # Docker
 up:
@@ -62,31 +64,34 @@ docker-push: docker-build
 # Local dev
 run:
 	@echo "Running database migrations..."
-	@uv run alembic -c alembic.ini upgrade head
-	uv run python -m homesec.cli run --config $(HOMESEC_CONFIG) --log_level $(HOMESEC_LOG_LEVEL)
+	@$(UV_RUN) alembic -c alembic.ini upgrade head
+	$(UV_RUN) python -m homesec.cli run --config $(HOMESEC_CONFIG) --log_level $(HOMESEC_LOG_LEVEL)
 
 db:
 	docker compose up -d postgres
 
 test:
-	uv run pytest tests/homesec/ -v --cov=homesec --cov-report=term-missing
+	$(UV_RUN) pytest tests/homesec/ -v --cov=homesec --cov-report=term-missing
 
 coverage:
-	uv run pytest tests/homesec/ -v --cov=homesec --cov-report=html --cov-report=xml
+	$(UV_RUN) pytest tests/homesec/ -v --cov=homesec --cov-report=html --cov-report=xml
 	@echo "Coverage report: htmlcov/index.html"
 
 typecheck:
-	uv run mypy --package homesec --strict
+	$(UV_RUN) mypy --package homesec --strict
 
 lint:
-	uv run ruff check src tests
-	uv run ruff format --check src tests
+	$(UV_RUN) ruff check src tests
+	$(UV_RUN) ruff format --check src tests
 
 lint-fix:
-	uv run ruff check --fix src tests
-	uv run ruff format src tests
+	$(UV_RUN) ruff check --fix src tests
+	$(UV_RUN) ruff format src tests
 
-check: lint typecheck test ui-check
+lock-check:
+	uv lock --check
+
+check: lock-check lint typecheck test ui-check
 
 fake-camera:
 	@echo "Starting mock ONVIF server on port 8000..."
@@ -99,21 +104,21 @@ fake-camera:
 
 # Database
 db-migrate:
-	uv run --with alembic --with sqlalchemy --with asyncpg --with python-dotenv alembic -c alembic.ini upgrade head
+	$(UV_RUN) --with alembic --with sqlalchemy --with asyncpg --with python-dotenv alembic -c alembic.ini upgrade head
 
 db-migration:
 	@if [ -z "$(m)" ]; then \
 		echo "Error: message required. Run: make db-migration m=\"your description\""; \
 		exit 1; \
 	fi
-	uv run --with alembic --with sqlalchemy --with asyncpg --with python-dotenv alembic -c alembic.ini revision --autogenerate -m "$(m)"
+	$(UV_RUN) --with alembic --with sqlalchemy --with asyncpg --with python-dotenv alembic -c alembic.ini revision --autogenerate -m "$(m)"
 
 # Release
 publish: check
 	rm -rf dist build
-	uv run --with build python -m build
-	uv run --with twine python -m twine check dist/*
-	uv run --with twine python -m twine upload dist/*
+	$(UV_RUN) --with build python -m build
+	$(UV_RUN) --with twine python -m twine check dist/*
+	$(UV_RUN) --with twine python -m twine upload dist/*
 
 # Proxy any ui-* target to the UI Makefile (e.g., ui-api-generate -> make -C ui api-generate).
 ui-%:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,8 @@ ignore = [
 known-first-party = ["homesec"]
 
 [tool.semantic_release]
+assets = ["uv.lock"]
+build_command = "uv lock"
 version_toml = ["pyproject.toml:project.version"]
 version_source = "tag"
 commit_message = "chore(release): v{version}"

--- a/uv.lock
+++ b/uv.lock
@@ -1223,7 +1223,7 @@ wheels = [
 
 [[package]]
 name = "homesec"
-version = "1.8.0"
+version = "1.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Sync the editable homesec package version in `uv.lock` with `pyproject.toml` (`1.9.3`).
- Add locked-mode uv guardrails in CI and Makefile validation commands.
- Configure python-semantic-release to run `uv lock` before its release commit and include `uv.lock` as a release asset.
- Add AGENTS guidance for future lockfile churn.

## Validation
- `uv lock --check`
- `uv sync --group dev --locked --dry-run`
- `make lock-check`
- `make lint`
- `make typecheck`
- `uvx --from python-semantic-release semantic-release --noop version --print` (config parsed; no release on non-release branch)
- `make check` reached pytest and failed on local Postgres credentials: `asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "homesec"` across DB-backed tests. The new lock-check, locked ruff, and locked mypy steps passed before that failure.
