### PR TITLE
feat: add phase 0 generic talk configuration models

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -48,6 +48,14 @@ cameras:
           backoff_s: 1.0             # Backoff between reconnects
           max_attempts: 0            # 0 = retry forever
           detect_fallback_attempts: 3  # Switch detect stream to main after N failures
+    talk:
+      enabled: false
+      backend: onvif_rtsp_backchannel
+      config:
+        rtsp_url_env: FRONT_DOOR_RTSP_URL
+        preferred_codecs:
+          - PCMU/8000
+        transport: rtsp_tcp_interleaved
 
   # FTP server (receive uploads from cameras that support FTP)
   - name: ftp_camera
@@ -111,6 +119,21 @@ preview:
     audio_enabled: true
     audio_codec: auto
     video_codec: auto
+
+
+# =============================================================================
+# Talk - Push-to-talk configuration (MVP: PCM in, PCMU backchannel out)
+# =============================================================================
+talk:
+  enabled: false
+  token_ttl_s: 30
+  max_session_s: 60
+  idle_timeout_s: 2.0
+  input:
+    codec: pcm_s16le
+    sample_rate: 16000
+    channels: 1
+    frame_ms: 20
 
 # =============================================================================
 # Notifiers - How to send alerts

--- a/src/homesec/models/config.py
+++ b/src/homesec/models/config.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from homesec.models.filter import FilterConfig
+from homesec.models.talk import TalkInputFormat
 from homesec.models.vlm import VLMConfig
 
 
@@ -251,6 +252,35 @@ class PreviewConfig(BaseModel):
         return value
 
 
+class TalkConfig(BaseModel):
+    """Top-level push-to-talk feature configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = False
+    token_ttl_s: int = Field(default=30, ge=1, le=300)
+    max_session_s: int = Field(default=60, ge=1, le=300)
+    idle_timeout_s: float = Field(default=2.0, ge=0.1, le=30.0)
+    input: TalkInputFormat = Field(default_factory=TalkInputFormat)
+
+
+class CameraTalkConfig(BaseModel):
+    """Per-camera talk backend configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    enabled: bool = False
+    backend: str = "onvif_rtsp_backchannel"
+    config: dict[str, Any] | BaseModel = Field(default_factory=dict)
+
+    @field_validator("backend", mode="before")
+    @classmethod
+    def _normalize_backend(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+
 class FastAPIServerConfig(BaseModel):
     """Configuration for the FastAPI server."""
 
@@ -314,6 +344,7 @@ class CameraConfig(BaseModel):
     name: str
     enabled: bool = True
     source: CameraSourceConfig
+    talk: CameraTalkConfig = Field(default_factory=CameraTalkConfig)
 
 
 class Config(BaseModel):
@@ -332,6 +363,7 @@ class Config(BaseModel):
     retry: RetryConfig = Field(default_factory=RetryConfig)
     server: FastAPIServerConfig = Field(default_factory=FastAPIServerConfig)
     preview: PreviewConfig = Field(default_factory=PreviewConfig)
+    talk: TalkConfig = Field(default_factory=TalkConfig)
     filter: FilterConfig
     vlm: VLMConfig
     alert_policy: AlertPolicyConfig

--- a/src/homesec/models/config.py
+++ b/src/homesec/models/config.py
@@ -270,7 +270,7 @@ class CameraTalkConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
     enabled: bool = False
-    backend: str = "onvif_rtsp_backchannel"
+    backend: Literal["onvif_rtsp_backchannel"] = "onvif_rtsp_backchannel"
     config: dict[str, Any] | BaseModel = Field(default_factory=dict)
 
     @field_validator("backend", mode="before")

--- a/src/homesec/models/talk.py
+++ b/src/homesec/models/talk.py
@@ -1,0 +1,66 @@
+"""Generic talk/session models shared across runtime and API boundaries."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class TalkState(StrEnum):
+    """Current talk capability/session state for a camera."""
+
+    DISABLED = "disabled"
+    UNSUPPORTED = "unsupported"
+    IDLE = "idle"
+    STARTING = "starting"
+    ACTIVE = "active"
+    STOPPING = "stopping"
+    ERROR = "error"
+    TEMPORARILY_UNAVAILABLE = "temporarily_unavailable"
+
+
+class TalkRefusalReason(StrEnum):
+    """Canonical reasons a talk session request may be refused."""
+
+    CAMERA_NOT_FOUND = "camera_not_found"
+    TALK_DISABLED = "talk_disabled"
+    SOURCE_NOT_TALK_CAPABLE = "source_not_talk_capable"
+    SESSION_ALREADY_ACTIVE = "session_already_active"
+    SESSION_BUDGET_EXHAUSTED = "session_budget_exhausted"
+    UNSUPPORTED_CAMERA = "unsupported_camera"
+    UNSUPPORTED_CODEC = "unsupported_codec"
+    CAMERA_BACKCHANNEL_FAILED = "camera_backchannel_failed"
+    RUNTIME_UNAVAILABLE = "runtime_unavailable"
+    INVALID_AUDIO_FRAME = "invalid_audio_frame"
+    BACKPRESSURE = "backpressure"
+
+
+class TalkInputFormat(BaseModel):
+    """Browser input frame format contract for push-to-talk."""
+
+    model_config = {"extra": "forbid"}
+
+    codec: str = "pcm_s16le"
+    sample_rate: int = Field(default=16000, ge=8000, le=48000)
+    channels: int = Field(default=1, ge=1, le=1)
+    frame_ms: int = Field(default=20, ge=10, le=60)
+
+    @property
+    def expected_bytes_per_frame(self) -> int:
+        """Expected byte size for one PCM S16LE frame."""
+        return int(self.sample_rate * self.frame_ms / 1000) * self.channels * 2
+
+
+class CameraTalkStatus(BaseModel):
+    """Current talk status returned by runtime/application APIs."""
+
+    model_config = {"extra": "forbid"}
+
+    camera_name: str
+    enabled: bool
+    state: TalkState
+    active_session_id: str | None = None
+    supported_codecs: list[str] = Field(default_factory=list)
+    selected_codec: str | None = None
+    last_error: str | None = None

--- a/src/homesec/models/talk.py
+++ b/src/homesec/models/talk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -41,7 +42,7 @@ class TalkInputFormat(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    codec: str = "pcm_s16le"
+    codec: Literal["pcm_s16le"] = "pcm_s16le"
     sample_rate: int = Field(default=16000, ge=8000, le=48000)
     channels: int = Field(default=1, ge=1, le=1)
     frame_ms: int = Field(default=20, ge=10, le=60)

--- a/tests/homesec/test_config.py
+++ b/tests/homesec/test_config.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from homesec.config import (
     ConfigError,
@@ -854,3 +854,54 @@ def test_preview_rejects_v2_and_legacy_extra_fields() -> None:
     assert exc_info.value.code is ConfigErrorCode.VALIDATION_FAILED
     assert "mode" in str(exc_info.value)
     assert "publish_rtsp_base_url" in str(exc_info.value)
+
+
+def test_talk_config_defaults() -> None:
+    """Talk config defaults should be disabled and frame-sized for 20ms PCM16 mono."""
+    # Given: A minimal config without talk settings
+    data = minimal_config()
+
+    # When: Parsing config
+    config = Config.model_validate(data)
+
+    # Then: Talk defaults are applied
+    assert config.talk.enabled is False
+    assert config.talk.token_ttl_s == 30
+    assert config.talk.max_session_s == 60
+    assert config.talk.input.codec == "pcm_s16le"
+    assert config.talk.input.expected_bytes_per_frame == 640
+
+
+def test_camera_talk_backend_normalized() -> None:
+    """Camera talk backend names should normalize to lowercase."""
+    # Given: A config with uppercase talk backend
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {"enabled": True, "backend": "ONVIF_RTSP_BACKCHANNEL", "config": {}}
+
+    # When: Parsing config
+    config = Config.model_validate(data)
+
+    # Then: backend is normalized
+    assert config.cameras[0].talk.backend == "onvif_rtsp_backchannel"
+
+
+def test_talk_input_forbids_extra_fields() -> None:
+    """Talk input format should reject unknown fields."""
+    # Given: A config with extra talk input fields
+    data = minimal_config()
+    data["talk"] = {
+        "enabled": True,
+        "input": {
+            "codec": "pcm_s16le",
+            "sample_rate": 16000,
+            "channels": 1,
+            "frame_ms": 20,
+            "unexpected": "value",
+        },
+    }
+
+    # When / Then: Validation rejects extra fields
+    with pytest.raises(ValidationError):
+        Config.model_validate(data)

--- a/tests/homesec/test_config.py
+++ b/tests/homesec/test_config.py
@@ -905,3 +905,39 @@ def test_talk_input_forbids_extra_fields() -> None:
     # When / Then: Validation rejects extra fields
     with pytest.raises(ValidationError):
         Config.model_validate(data)
+
+
+def test_talk_input_rejects_unsupported_codec() -> None:
+    """Talk input format should only accept the browser PCM16 contract."""
+    # Given: A config with a deferred/unsupported browser input codec
+    data = minimal_config()
+    data["talk"] = {
+        "enabled": True,
+        "input": {
+            "codec": "opus",
+            "sample_rate": 16000,
+            "channels": 1,
+            "frame_ms": 20,
+        },
+    }
+
+    # When / Then: Validation rejects unsupported codecs in the v1 contract
+    with pytest.raises(ValidationError) as exc_info:
+        Config.model_validate(data)
+
+    assert "pcm_s16le" in str(exc_info.value)
+
+
+def test_camera_talk_rejects_unsupported_backend() -> None:
+    """Camera talk config should reject deferred backends in the v1 contract."""
+    # Given: A config using a backend that is intentionally out of scope for MVP
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {"enabled": True, "backend": "mediamtx", "config": {}}
+
+    # When / Then: Validation rejects unsupported per-camera talk backends
+    with pytest.raises(ValidationError) as exc_info:
+        Config.model_validate(data)
+
+    assert "onvif_rtsp_backchannel" in str(exc_info.value)

--- a/ui/src/api/generated/openapi.json
+++ b/ui/src/api/generated/openapi.json
@@ -198,6 +198,7 @@
         "description": "Per-camera talk backend configuration.",
         "properties": {
           "backend": {
+            "const": "onvif_rtsp_backchannel",
             "default": "onvif_rtsp_backchannel",
             "title": "Backend",
             "type": "string"

--- a/ui/src/api/generated/openapi.json
+++ b/ui/src/api/generated/openapi.json
@@ -49,6 +49,9 @@
           },
           "source": {
             "$ref": "#/components/schemas/CameraSourceConfig"
+          },
+          "talk": {
+            "$ref": "#/components/schemas/CameraTalkConfig"
           }
         },
         "required": [
@@ -188,6 +191,36 @@
           "last_heartbeat"
         ],
         "title": "CameraStatus",
+        "type": "object"
+      },
+      "CameraTalkConfig": {
+        "additionalProperties": false,
+        "description": "Per-camera talk backend configuration.",
+        "properties": {
+          "backend": {
+            "default": "onvif_rtsp_backchannel",
+            "title": "Backend",
+            "type": "string"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "$ref": "#/components/schemas/BaseModel"
+              }
+            ],
+            "title": "Config"
+          },
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          }
+        },
+        "title": "CameraTalkConfig",
         "type": "object"
       },
       "CameraUpdate": {

--- a/ui/src/api/generated/schema.ts
+++ b/ui/src/api/generated/schema.ts
@@ -530,6 +530,7 @@ export interface components {
             /** Name */
             name: string;
             source: components["schemas"]["CameraSourceConfig"];
+            talk?: components["schemas"]["CameraTalkConfig"];
         };
         /** CameraCreate */
         CameraCreate: {
@@ -584,6 +585,26 @@ export interface components {
             healthy: boolean;
             /** Last Heartbeat */
             last_heartbeat: number | null;
+        };
+        /**
+         * CameraTalkConfig
+         * @description Per-camera talk backend configuration.
+         */
+        CameraTalkConfig: {
+            /**
+             * Backend
+             * @default onvif_rtsp_backchannel
+             */
+            backend: string;
+            /** Config */
+            config?: {
+                [key: string]: unknown;
+            } | components["schemas"]["BaseModel"];
+            /**
+             * Enabled
+             * @default false
+             */
+            enabled: boolean;
         };
         /** CameraUpdate */
         CameraUpdate: {

--- a/ui/src/api/generated/schema.ts
+++ b/ui/src/api/generated/schema.ts
@@ -594,8 +594,9 @@ export interface components {
             /**
              * Backend
              * @default onvif_rtsp_backchannel
+             * @constant
              */
-            backend: string;
+            backend: "onvif_rtsp_backchannel";
             /** Config */
             config?: {
                 [key: string]: unknown;


### PR DESCRIPTION
### Motivation
- Provide Phase 0 typed foundation for push-to-talk (talk) support so later phases can implement runtime, API, RTSP, and UI without changing core contracts.
- Keep talk-specific protocol/config details out of core models by treating per-camera `talk.config` as an opaque mapping.
- Enforce strict validation and safe defaults for client audio framing to prevent unbounded buffering and codec/size mismatches early.

### Description
- Added `src/homesec/models/talk.py` introducing `TalkState`, `TalkRefusalReason`, `TalkInputFormat`, and `CameraTalkStatus` with `extra="forbid"` and computed `expected_bytes_per_frame` on `TalkInputFormat`.
- Extended `src/homesec/models/config.py` with top-level `TalkConfig` and per-camera `CameraTalkConfig`, wired into `Config` and `CameraConfig` while keeping `CameraTalkConfig.config` opaque (`dict | BaseModel`).
- Updated `config/example.yaml` with global and per-camera talk examples (MVP defaults: `pcm_s16le`, 16k mono, 20ms frames).
- Added unit tests in `tests/homesec/test_config.py` covering talk defaults, backend normalization, and strict input validation for extra fields.

### Testing
- Ran `make typecheck` (`mypy --strict`) and it completed successfully with no issues.
- Ran lint/format steps (`ruff check` and `ruff format`) and applied required formatting fixes; lint checks passed after fixes.
- Attempted `make check`/`pytest`, but test run failed to import test harness due to an environment-level missing system library (`libGL.so.1`) required by OpenCV causing an `ImportError` during pytest collection; added unit tests are present but could not be executed in this environment because of that dependency.
- All added code follows repository validation rules (`pydantic` models with `extra="forbid"` and backend config left opaque) and is limited to Phase 0 surface-area only (no runtime/API/RTSP/UI wiring).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25b8eaec8833098576fc37c18b864)