### PR TITLE
feat: add phase 1 ONVIF talk protocol spike

### DIFF
--- a/dev/talk_tone.py
+++ b/dev/talk_tone.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Send a generated tone through an ONVIF RTSP audio backchannel.
+
+Example:
+    uv run python dev/talk_tone.py --rtsp-url rtsp://user:pass@camera/Streaming/Channels/101
+
+This is a Phase 1 manual probe utility: it bypasses HomeSec runtime/API/UI and
+exercises only the isolated RTSP/ONVIF backchannel protocol stack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import math
+import struct
+from collections.abc import Iterable
+
+from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
+from homesec.sources.rtsp.talk.onvif_backchannel import ONVIFBackchannelAdapter
+from homesec.sources.rtsp.talk.rtsp_auth import redact_rtsp_url
+
+_INPUT_SAMPLE_RATE = 16_000
+_FRAME_MS = 20
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Send a generated tone to an ONVIF RTSP backchannel"
+    )
+    url_group = parser.add_mutually_exclusive_group(required=True)
+    url_group.add_argument("--rtsp-url", help="RTSP URL for the camera talk/backchannel endpoint")
+    url_group.add_argument("--rtsp-url-env", help="Environment variable containing the RTSP URL")
+    parser.add_argument("--username", help="Optional RTSP username; URL userinfo also works")
+    parser.add_argument("--password", help="Optional RTSP password; URL userinfo also works")
+    parser.add_argument("--duration-s", type=float, default=2.0, help="Tone duration in seconds")
+    parser.add_argument("--frequency-hz", type=float, default=440.0, help="Tone frequency in Hz")
+    parser.add_argument("--amplitude", type=float, default=0.20, help="Tone amplitude, 0.0..1.0")
+    parser.add_argument(
+        "--camera-name", default="manual-tone", help="Label used in local session metadata"
+    )
+    return parser
+
+
+def _pcm_tone_frames(
+    *,
+    duration_s: float,
+    frequency_hz: float,
+    amplitude: float,
+) -> Iterable[bytes]:
+    if duration_s <= 0:
+        raise ValueError("duration-s must be positive")
+    if frequency_hz <= 0:
+        raise ValueError("frequency-hz must be positive")
+    if not 0.0 <= amplitude <= 1.0:
+        raise ValueError("amplitude must be between 0.0 and 1.0")
+
+    samples_per_frame = _INPUT_SAMPLE_RATE * _FRAME_MS // 1000
+    frame_count = max(1, math.ceil(duration_s * 1000 / _FRAME_MS))
+    max_value = int(32767 * amplitude)
+    sample_index = 0
+    for _ in range(frame_count):
+        samples: list[int] = []
+        for _sample in range(samples_per_frame):
+            phase = 2.0 * math.pi * frequency_hz * sample_index / _INPUT_SAMPLE_RATE
+            samples.append(int(max_value * math.sin(phase)))
+            sample_index += 1
+        yield struct.pack(f"<{len(samples)}h", *samples)
+
+
+async def _run(args: argparse.Namespace) -> None:
+    config = ONVIFBackchannelConfig(
+        rtsp_url=args.rtsp_url,
+        rtsp_url_env=args.rtsp_url_env,
+        username=args.username,
+        password=args.password,
+    )
+    adapter = ONVIFBackchannelAdapter(config, camera_name=args.camera_name)
+    redacted_url = redact_rtsp_url(config.resolve_rtsp_url())
+    print(f"Opening ONVIF RTSP backchannel to {redacted_url} ...")
+    session = await adapter.open_session(
+        session_id="manual-tone", input_sample_rate=_INPUT_SAMPLE_RATE
+    )
+    try:
+        print(f"Backchannel ready: codec={session.selected_codec}; sending tone ...")
+        for frame in _pcm_tone_frames(
+            duration_s=args.duration_s,
+            frequency_hz=args.frequency_hz,
+            amplitude=args.amplitude,
+        ):
+            await session.write_pcm_frame(frame)
+            await asyncio.sleep(_FRAME_MS / 1000)
+    finally:
+        await session.close()
+    print("Tone complete; RTSP session closed.")
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/homesec/sources/rtsp/talk/__init__.py
+++ b/src/homesec/sources/rtsp/talk/__init__.py
@@ -1,0 +1,7 @@
+"""RTSP/ONVIF push-to-talk support."""
+
+from homesec.sources.rtsp.talk.g711 import encode_pcmu
+from homesec.sources.rtsp.talk.rtp import RTPPacketizer
+from homesec.sources.rtsp.talk.sdp import select_audio_backchannel
+
+__all__ = ["RTPPacketizer", "encode_pcmu", "select_audio_backchannel"]

--- a/src/homesec/sources/rtsp/talk/errors.py
+++ b/src/homesec/sources/rtsp/talk/errors.py
@@ -1,0 +1,70 @@
+"""Push-to-talk RTSP/ONVIF error types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class TalkProtocolErrorCode(StrEnum):
+    """Machine-readable RTSP talk failure codes."""
+
+    CAMERA_BACKCHANNEL_UNSUPPORTED = "camera_backchannel_unsupported"
+    UNSUPPORTED_CODEC = "unsupported_codec"
+    CAMERA_REJECTED_SESSION = "camera_rejected_session"
+    CAMERA_STREAM_FAILED = "camera_stream_failed"
+    RTSP_AUTH_FAILED = "rtsp_auth_failed"
+    RTSP_PROTOCOL_ERROR = "rtsp_protocol_error"
+
+
+class TalkProtocolError(RuntimeError):
+    """Base class for RTSP talk failures safe to map at source/runtime boundaries."""
+
+    def __init__(self, message: str, *, code: TalkProtocolErrorCode) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CameraBackchannelUnsupportedError(TalkProtocolError):
+    """Raised when a camera does not advertise a usable ONVIF audio backchannel."""
+
+    def __init__(
+        self, message: str = "Camera does not advertise an ONVIF audio backchannel"
+    ) -> None:
+        super().__init__(message, code=TalkProtocolErrorCode.CAMERA_BACKCHANNEL_UNSUPPORTED)
+
+
+class UnsupportedTalkCodecError(TalkProtocolError):
+    """Raised when no advertised backchannel codec matches HomeSec's encoder set."""
+
+    def __init__(
+        self, message: str = "Camera backchannel does not advertise a supported codec"
+    ) -> None:
+        super().__init__(message, code=TalkProtocolErrorCode.UNSUPPORTED_CODEC)
+
+
+class CameraRejectedTalkSessionError(TalkProtocolError):
+    """Raised when RTSP SETUP/PLAY or another session command is rejected."""
+
+    def __init__(self, message: str = "Camera rejected the talk session") -> None:
+        super().__init__(message, code=TalkProtocolErrorCode.CAMERA_REJECTED_SESSION)
+
+
+class CameraTalkStreamFailedError(TalkProtocolError):
+    """Raised when RTP audio can no longer be sent to the camera."""
+
+    def __init__(self, message: str = "Camera talk stream failed") -> None:
+        super().__init__(message, code=TalkProtocolErrorCode.CAMERA_STREAM_FAILED)
+
+
+class RTSPAuthenticationError(TalkProtocolError):
+    """Raised when RTSP authentication cannot be satisfied."""
+
+    def __init__(self, message: str = "RTSP authentication failed") -> None:
+        super().__init__(message, code=TalkProtocolErrorCode.RTSP_AUTH_FAILED)
+
+
+class RTSPProtocolError(TalkProtocolError):
+    """Raised for malformed RTSP data or protocol-state violations."""
+
+    def __init__(self, message: str = "Malformed RTSP response") -> None:
+        super().__init__(message, code=TalkProtocolErrorCode.RTSP_PROTOCOL_ERROR)

--- a/src/homesec/sources/rtsp/talk/g711.py
+++ b/src/homesec/sources/rtsp/talk/g711.py
@@ -1,0 +1,54 @@
+"""G.711 audio codecs used by ONVIF RTSP audio backchannels."""
+
+from __future__ import annotations
+
+import struct
+
+_BIAS = 0x84
+_CLIP = 32635
+_SEG_END = (0xFF, 0x1FF, 0x3FF, 0x7FF, 0xFFF, 0x1FFF, 0x3FFF, 0x7FFF)
+
+
+def encode_pcmu(pcm_s16le: bytes) -> bytes:
+    """Encode little-endian signed 16-bit mono PCM to G.711 μ-law/PCMU bytes.
+
+    HomeSec's browser contract sends deterministic PCM S16LE frames. ONVIF
+    camera speakers commonly advertise PCMU/8000; each encoded byte represents
+    one 8 kHz sample.
+    """
+    return bytes(_linear_to_ulaw(sample) for sample in _iter_pcm16le(pcm_s16le))
+
+
+def _iter_pcm16le(pcm_s16le: bytes):  # type: ignore[no-untyped-def]
+    if len(pcm_s16le) % 2 != 0:
+        raise ValueError("PCM S16LE input length must be even")
+    for (sample,) in struct.iter_unpack("<h", pcm_s16le):
+        yield int(sample)
+
+
+def _linear_to_ulaw(sample: int) -> int:
+    """Convert one signed 16-bit PCM sample to ITU-T G.711 μ-law."""
+    if sample < 0:
+        # Match CPython audioop/standard lookup rounding: negative values are
+        # offset so -1..-8 map to the first negative code below zero.
+        pcm = _BIAS - sample + 3
+        mask = 0x7F
+    else:
+        pcm = sample + _BIAS
+        mask = 0xFF
+
+    if pcm > _CLIP + _BIAS:
+        pcm = _CLIP + _BIAS
+
+    segment = _search_segment(pcm)
+    if segment >= 8:
+        return 0x7F ^ mask
+    value = (segment << 4) | ((pcm >> (segment + 3)) & 0x0F)
+    return value ^ mask
+
+
+def _search_segment(value: int) -> int:
+    for index, end in enumerate(_SEG_END):
+        if value <= end:
+            return index
+    return len(_SEG_END)

--- a/src/homesec/sources/rtsp/talk/models.py
+++ b/src/homesec/sources/rtsp/talk/models.py
@@ -62,7 +62,6 @@ class ONVIFBackchannelConfig(BaseModel):
     connect_timeout_s: float = Field(default=5.0, gt=0.0, le=30.0)
     io_timeout_s: float = Field(default=5.0, gt=0.0, le=30.0)
     user_agent: str = "HomeSec/PushToTalk"
-    require_onvif_backchannel: bool = True
 
     @field_validator("preferred_codecs")
     @classmethod

--- a/src/homesec/sources/rtsp/talk/models.py
+++ b/src/homesec/sources/rtsp/talk/models.py
@@ -1,0 +1,131 @@
+"""Models for RTSP/ONVIF push-to-talk adapters."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from homesec.sources.rtsp.talk.rtsp_auth import RTSPCredentials
+
+
+class TalkTransport(StrEnum):
+    """Supported camera talk RTP transport modes for MVP."""
+
+    RTSP_TCP_INTERLEAVED = "rtsp_tcp_interleaved"
+
+
+class TalkCodec(StrEnum):
+    """Supported camera speaker codecs for the Phase 1/MVP protocol path."""
+
+    PCMU_8000 = "PCMU/8000"
+
+
+class ONVIFBackchannelConfig(BaseModel):
+    """ONVIF RTSP audio-backchannel camera configuration."""
+
+    model_config = {"extra": "forbid"}
+
+    rtsp_url_env: str | None = Field(
+        default=None,
+        description="Environment variable containing the RTSP URL used for talk.",
+    )
+    rtsp_url: str | None = Field(
+        default=None,
+        description="RTSP URL used for talk. Credentials are redacted before logging.",
+    )
+    username_env: str | None = Field(
+        default=None,
+        description="Environment variable containing the RTSP username used for talk.",
+    )
+    password_env: str | None = Field(
+        default=None,
+        description="Environment variable containing the RTSP password used for talk.",
+    )
+    username: str | None = Field(
+        default=None,
+        description="RTSP username used for manual/probe sessions.",
+    )
+    password: str | None = Field(
+        default=None,
+        description="RTSP password used for manual/probe sessions.",
+    )
+    preferred_codecs: list[str] = Field(
+        default_factory=lambda: [TalkCodec.PCMU_8000.value],
+        min_length=1,
+        description="Ordered codec preference list using SDP names such as PCMU/8000.",
+    )
+    transport: Literal["rtsp_tcp_interleaved"] = "rtsp_tcp_interleaved"
+    connect_timeout_s: float = Field(default=5.0, gt=0.0, le=30.0)
+    io_timeout_s: float = Field(default=5.0, gt=0.0, le=30.0)
+    user_agent: str = "HomeSec/PushToTalk"
+    require_onvif_backchannel: bool = True
+
+    @field_validator("preferred_codecs")
+    @classmethod
+    def _require_mvp_codec(cls, value: list[str]) -> list[str]:
+        normalized = [_normalize_codec_name(item) for item in value]
+        unsupported = [item for item in normalized if item != TalkCodec.PCMU_8000.value]
+        if unsupported:
+            raise ValueError("Phase 1 ONVIF talk supports only PCMU/8000")
+        return normalized
+
+    @model_validator(mode="after")
+    def _require_rtsp_url_source(self) -> ONVIFBackchannelConfig:
+        if not (self.rtsp_url or self.rtsp_url_env):
+            raise ValueError("rtsp_url_env or rtsp_url required for ONVIF talk backchannel")
+        if (self.username is None) != (self.password is None):
+            raise ValueError("username and password must be configured together")
+        if (self.username_env is None) != (self.password_env is None):
+            raise ValueError("username_env and password_env must be configured together")
+        return self
+
+    def resolve_rtsp_url(self, environ: Mapping[str, str] | None = None) -> str:
+        """Resolve the configured RTSP URL without exposing credentials to callers."""
+        if self.rtsp_url is not None:
+            return self.rtsp_url
+        if self.rtsp_url_env is None:
+            raise ValueError("rtsp_url_env or rtsp_url required for ONVIF talk backchannel")
+        env = os.environ if environ is None else environ
+        try:
+            return env[self.rtsp_url_env]
+        except KeyError as exc:
+            raise ValueError(
+                f"RTSP URL environment variable is not set: {self.rtsp_url_env}"
+            ) from exc
+
+    def resolve_credentials(
+        self, environ: Mapping[str, str] | None = None
+    ) -> RTSPCredentials | None:
+        """Resolve optional RTSP credentials from explicit values or environment variables."""
+        if self.username is not None and self.password is not None:
+            return RTSPCredentials(username=self.username, password=self.password)
+        if self.username_env is None and self.password_env is None:
+            return None
+        if self.username_env is None or self.password_env is None:
+            raise ValueError("username_env and password_env must be configured together")
+        env = os.environ if environ is None else environ
+        try:
+            return RTSPCredentials(
+                username=env[self.username_env],
+                password=env[self.password_env],
+            )
+        except KeyError as exc:
+            raise ValueError(
+                f"RTSP credential environment variable is not set: {exc.args[0]}"
+            ) from exc
+
+
+def _normalize_codec_name(value: str) -> str:
+    parts = value.strip().split("/")
+    if len(parts) < 2:
+        return value.strip().upper()
+    encoding = parts[0].upper()
+    clock_rate = parts[1]
+    channels = parts[2] if len(parts) >= 3 else None
+    if channels in (None, "", "1"):
+        return f"{encoding}/{clock_rate}"
+    return f"{encoding}/{clock_rate}/{channels}"

--- a/src/homesec/sources/rtsp/talk/onvif_backchannel.py
+++ b/src/homesec/sources/rtsp/talk/onvif_backchannel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import suppress
 from dataclasses import dataclass
 
 from homesec.sources.rtsp.talk.errors import (
@@ -112,6 +113,7 @@ class ONVIFBackchannelAdapter:
                 io_timeout_s=self._config.io_timeout_s,
             )
         )
+        setup_completed = False
         await client.connect()
         try:
             describe = await client.describe(headers=_require_header())
@@ -123,10 +125,15 @@ class ONVIFBackchannelAdapter:
                 raise CameraRejectedTalkSessionError(
                     f"Camera rejected backchannel DESCRIBE with RTSP {describe.status_code}"
                 )
+            base_control_url = (
+                describe.header("content-base")
+                or describe.header("content-location")
+                or self._rtsp_url
+            )
             selected = select_audio_backchannel(
                 describe.body.decode("utf-8", errors="replace"),
                 preferred_codecs=self._config.preferred_codecs,
-                base_control_url=self._rtsp_url,
+                base_control_url=base_control_url,
             )
             setup = await client.setup_interleaved(
                 selected.control,
@@ -137,6 +144,11 @@ class ONVIFBackchannelAdapter:
                 raise CameraRejectedTalkSessionError(
                     f"Camera rejected backchannel SETUP with RTSP {setup.status_code}"
                 )
+            if not client.session_id:
+                raise CameraRejectedTalkSessionError(
+                    "Camera accepted backchannel SETUP without an RTSP Session header"
+                )
+            setup_completed = True
             rtp_channel = _rtp_channel_from_setup(setup.header("transport"))
             play = await client.play(headers=_require_header())
             if play.status_code != 200:
@@ -151,20 +163,20 @@ class ONVIFBackchannelAdapter:
                 input_sample_rate=input_sample_rate,
                 rtp_channel=rtp_channel,
             )
-        except (
-            CameraBackchannelUnsupportedError,
-            UnsupportedTalkCodecError,
-            CameraRejectedTalkSessionError,
-        ):
-            await client.close()
-            raise
         except Exception:
+            if setup_completed:
+                await _best_effort_teardown(client)
             await client.close()
             raise
 
 
 def _require_header() -> dict[str, str]:
     return {"Require": _ONVIF_BACKCHANNEL_REQUIRE}
+
+
+async def _best_effort_teardown(client: RTSPClient) -> None:
+    with suppress(Exception):
+        await client.teardown(headers=_require_header())
 
 
 def _rtp_channel_from_setup(transport_header: str | None) -> int:

--- a/src/homesec/sources/rtsp/talk/onvif_backchannel.py
+++ b/src/homesec/sources/rtsp/talk/onvif_backchannel.py
@@ -1,0 +1,183 @@
+"""ONVIF RTSP audio-backchannel session orchestration."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from homesec.sources.rtsp.talk.errors import (
+    CameraBackchannelUnsupportedError,
+    CameraRejectedTalkSessionError,
+    CameraTalkStreamFailedError,
+    UnsupportedTalkCodecError,
+)
+from homesec.sources.rtsp.talk.g711 import encode_pcmu
+from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
+from homesec.sources.rtsp.talk.resample import resample_pcm_s16le_mono
+from homesec.sources.rtsp.talk.rtp import RTPPacketizer
+from homesec.sources.rtsp.talk.rtsp_client import (
+    RTSPClient,
+    RTSPConnectionConfig,
+    parse_interleaved_channels,
+)
+from homesec.sources.rtsp.talk.sdp import SDPCodec, SelectedBackchannel, select_audio_backchannel
+
+logger = logging.getLogger(__name__)
+_ONVIF_BACKCHANNEL_REQUIRE = "www.onvif.org/ver20/backchannel"
+
+
+@dataclass(slots=True)
+class ONVIFTalkSession:
+    """Active ONVIF backchannel session for one camera talk stream."""
+
+    session_id: str
+    camera_name: str
+    client: RTSPClient
+    selected: SelectedBackchannel
+    input_sample_rate: int = 16000
+    rtp_channel: int = 0
+    packetizer: RTPPacketizer | None = None
+    _closed: bool = False
+
+    @property
+    def selected_codec(self) -> str:
+        return self.selected.selected_codec
+
+    async def write_pcm_frame(self, pcm_s16le: bytes) -> None:
+        """Encode and send one browser PCM frame to the camera speaker."""
+        if self._closed:
+            raise CameraTalkStreamFailedError("Cannot send audio on a closed talk session")
+        packetizer = self.packetizer
+        if packetizer is None:
+            packetizer = RTPPacketizer(
+                payload_type=self.selected.payload_type,
+                clock_rate=self.selected.codec.clock_rate,
+            )
+            self.packetizer = packetizer
+
+        pcm_for_camera = resample_pcm_s16le_mono(
+            pcm_s16le,
+            input_rate=self.input_sample_rate,
+            output_rate=self.selected.codec.clock_rate,
+        )
+        payload = _encode_for_codec(pcm_for_camera, self.selected.codec)
+        rtp_packet = packetizer.packetize(payload, timestamp_increment=len(payload))
+        try:
+            await self.client.send_interleaved_frame(self.rtp_channel, rtp_packet)
+        except Exception as exc:
+            raise CameraTalkStreamFailedError(str(exc)) from exc
+
+    async def close(self) -> None:
+        """Tear down the RTSP talk session best-effort and close its TCP socket."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self.client.session_id is not None:
+                await self.client.teardown(headers=_require_header())
+        except Exception as exc:
+            logger.warning("RTSP talk TEARDOWN failed: %s", exc)
+        finally:
+            await self.client.close()
+
+
+class ONVIFBackchannelAdapter:
+    """Open ONVIF RTSP audio-backchannel sessions for one source."""
+
+    def __init__(
+        self,
+        config: ONVIFBackchannelConfig,
+        *,
+        camera_name: str,
+        rtsp_url: str | None = None,
+    ) -> None:
+        self._config = config
+        self._rtsp_url = rtsp_url or config.resolve_rtsp_url()
+        self._credentials = config.resolve_credentials()
+        self._camera_name = camera_name
+
+    async def open_session(
+        self,
+        *,
+        session_id: str,
+        input_sample_rate: int = 16000,
+    ) -> ONVIFTalkSession:
+        """Negotiate DESCRIBE/SETUP/PLAY and return a ready talk session."""
+        client = RTSPClient(
+            RTSPConnectionConfig(
+                url=self._rtsp_url,
+                credentials=self._credentials,
+                user_agent=self._config.user_agent,
+                connect_timeout_s=self._config.connect_timeout_s,
+                io_timeout_s=self._config.io_timeout_s,
+            )
+        )
+        await client.connect()
+        try:
+            describe = await client.describe(headers=_require_header())
+            if describe.status_code == 551:
+                raise CameraBackchannelUnsupportedError(
+                    f"Camera rejected backchannel DESCRIBE with RTSP {describe.status_code}"
+                )
+            if describe.status_code != 200:
+                raise CameraRejectedTalkSessionError(
+                    f"Camera rejected backchannel DESCRIBE with RTSP {describe.status_code}"
+                )
+            selected = select_audio_backchannel(
+                describe.body.decode("utf-8", errors="replace"),
+                preferred_codecs=self._config.preferred_codecs,
+                base_control_url=self._rtsp_url,
+            )
+            setup = await client.setup_interleaved(
+                selected.control,
+                rtp_channel=0,
+                headers=_require_header(),
+            )
+            if setup.status_code != 200:
+                raise CameraRejectedTalkSessionError(
+                    f"Camera rejected backchannel SETUP with RTSP {setup.status_code}"
+                )
+            rtp_channel = _rtp_channel_from_setup(setup.header("transport"))
+            play = await client.play(headers=_require_header())
+            if play.status_code != 200:
+                raise CameraRejectedTalkSessionError(
+                    f"Camera rejected backchannel PLAY with RTSP {play.status_code}"
+                )
+            return ONVIFTalkSession(
+                session_id=session_id,
+                camera_name=self._camera_name,
+                client=client,
+                selected=selected,
+                input_sample_rate=input_sample_rate,
+                rtp_channel=rtp_channel,
+            )
+        except (
+            CameraBackchannelUnsupportedError,
+            UnsupportedTalkCodecError,
+            CameraRejectedTalkSessionError,
+        ):
+            await client.close()
+            raise
+        except Exception:
+            await client.close()
+            raise
+
+
+def _require_header() -> dict[str, str]:
+    return {"Require": _ONVIF_BACKCHANNEL_REQUIRE}
+
+
+def _rtp_channel_from_setup(transport_header: str | None) -> int:
+    if transport_header is None:
+        return 0
+    channels = parse_interleaved_channels(transport_header)
+    if channels is None:
+        return 0
+    return channels[0]
+
+
+def _encode_for_codec(pcm_s16le: bytes, codec: SDPCodec) -> bytes:
+    normalized = codec.normalized_name.upper()
+    if normalized == "PCMU/8000":
+        return encode_pcmu(pcm_s16le)
+    raise UnsupportedTalkCodecError(f"Unsupported talk codec selected: {codec.normalized_name}")

--- a/src/homesec/sources/rtsp/talk/resample.py
+++ b/src/homesec/sources/rtsp/talk/resample.py
@@ -1,0 +1,56 @@
+"""Small PCM resampling helpers for push-to-talk audio."""
+
+from __future__ import annotations
+
+import struct
+
+_MIN_PCM16 = -32768
+_MAX_PCM16 = 32767
+
+
+def resample_pcm_s16le_mono(
+    pcm_s16le: bytes,
+    *,
+    input_rate: int,
+    output_rate: int,
+) -> bytes:
+    """Resample signed little-endian mono PCM without external media components.
+
+    The browser sends 16 kHz mono PCM for the MVP. Most ONVIF backchannels speak
+    G.711 at 8 kHz, so this function primarily down-samples 16 kHz -> 8 kHz.
+    Integer downsampling uses box averaging; other ratios use linear
+    interpolation to keep the implementation deterministic and dependency-free.
+    """
+    if input_rate <= 0 or output_rate <= 0:
+        raise ValueError("sample rates must be positive")
+    if len(pcm_s16le) % 2 != 0:
+        raise ValueError("PCM S16LE input length must be even")
+    if input_rate == output_rate or not pcm_s16le:
+        return pcm_s16le
+
+    samples = [sample for (sample,) in struct.iter_unpack("<h", pcm_s16le)]
+    if input_rate > output_rate and input_rate % output_rate == 0:
+        factor = input_rate // output_rate
+        out = []
+        for start in range(0, len(samples) - factor + 1, factor):
+            out.append(_clamp(round(sum(samples[start : start + factor]) / factor)))
+        return struct.pack(f"<{len(out)}h", *out) if out else b""
+
+    output_count = int(round(len(samples) * output_rate / input_rate))
+    if output_count <= 0:
+        return b""
+    out = []
+    for index in range(output_count):
+        pos = index * input_rate / output_rate
+        left = int(pos)
+        if left >= len(samples) - 1:
+            out.append(samples[-1])
+            continue
+        frac = pos - left
+        value = samples[left] * (1.0 - frac) + samples[left + 1] * frac
+        out.append(_clamp(round(value)))
+    return struct.pack(f"<{len(out)}h", *out)
+
+
+def _clamp(value: int) -> int:
+    return max(_MIN_PCM16, min(_MAX_PCM16, value))

--- a/src/homesec/sources/rtsp/talk/rtp.py
+++ b/src/homesec/sources/rtsp/talk/rtp.py
@@ -1,0 +1,86 @@
+"""RTP packetization helpers for camera talk backchannels."""
+
+from __future__ import annotations
+
+import secrets
+import struct
+from dataclasses import dataclass
+
+_RTP_VERSION = 2
+_RTP_FIXED_HEADER_LEN = 12
+
+
+@dataclass(slots=True)
+class RTPPacketizer:
+    """Build sequential RTP packets for one audio payload stream."""
+
+    payload_type: int
+    clock_rate: int = 8000
+    sequence_number: int | None = None
+    timestamp: int | None = None
+    ssrc: int | None = None
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.payload_type <= 127:
+            raise ValueError("RTP payload type must be in range 0..127")
+        if self.clock_rate <= 0:
+            raise ValueError("RTP clock_rate must be positive")
+        if self.sequence_number is None:
+            self.sequence_number = secrets.randbits(16)
+        if self.timestamp is None:
+            self.timestamp = secrets.randbits(32)
+        if self.ssrc is None:
+            self.ssrc = secrets.randbits(32)
+        self.sequence_number &= 0xFFFF
+        self.timestamp &= 0xFFFFFFFF
+        self.ssrc &= 0xFFFFFFFF
+
+    def packetize(
+        self,
+        payload: bytes,
+        *,
+        timestamp_increment: int | None = None,
+        marker: bool = False,
+    ) -> bytes:
+        """Return an RTP packet and advance sequence/timestamp counters."""
+        if timestamp_increment is None:
+            timestamp_increment = len(payload)
+        if timestamp_increment < 0:
+            raise ValueError("timestamp_increment must be non-negative")
+
+        assert self.sequence_number is not None
+        assert self.timestamp is not None
+        assert self.ssrc is not None
+
+        first = (_RTP_VERSION << 6) & 0xC0
+        second = self.payload_type | (0x80 if marker else 0)
+        header = struct.pack(
+            "!BBHII",
+            first,
+            second,
+            self.sequence_number,
+            self.timestamp,
+            self.ssrc,
+        )
+        packet = header + payload
+        self.sequence_number = (self.sequence_number + 1) & 0xFFFF
+        self.timestamp = (self.timestamp + timestamp_increment) & 0xFFFFFFFF
+        return packet
+
+
+def parse_rtp_header(packet: bytes) -> dict[str, int | bool]:
+    """Parse the fixed RTP header fields used by tests and fake camera capture."""
+    if len(packet) < _RTP_FIXED_HEADER_LEN:
+        raise ValueError("RTP packet shorter than fixed header")
+    first, second, sequence, timestamp, ssrc = struct.unpack("!BBHII", packet[:12])
+    return {
+        "version": first >> 6,
+        "padding": bool(first & 0x20),
+        "extension": bool(first & 0x10),
+        "csrc_count": first & 0x0F,
+        "marker": bool(second & 0x80),
+        "payload_type": second & 0x7F,
+        "sequence_number": sequence,
+        "timestamp": timestamp,
+        "ssrc": ssrc,
+    }

--- a/src/homesec/sources/rtsp/talk/rtsp_auth.py
+++ b/src/homesec/sources/rtsp/talk/rtsp_auth.py
@@ -1,0 +1,190 @@
+"""RTSP authentication helpers with credential-safe formatting."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from dataclasses import dataclass
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
+
+
+@dataclass(frozen=True, slots=True)
+class RTSPCredentials:
+    """Username/password credentials extracted from configuration or URL userinfo."""
+
+    username: str
+    password: str
+
+
+@dataclass(frozen=True, slots=True)
+class RTSPAuthChallenge:
+    """Parsed WWW-Authenticate challenge."""
+
+    scheme: str
+    params: dict[str, str]
+
+    @property
+    def realm(self) -> str | None:
+        return self.params.get("realm")
+
+
+def parse_www_authenticate(header: str) -> RTSPAuthChallenge:
+    """Parse a Basic or Digest WWW-Authenticate challenge."""
+    stripped = header.strip()
+    scheme, separator, rest = stripped.partition(" ")
+    if not separator:
+        return RTSPAuthChallenge(scheme=stripped.lower(), params={})
+    return RTSPAuthChallenge(scheme=scheme.lower(), params=_parse_auth_params(rest))
+
+
+def build_authorization_header(
+    *,
+    challenge: RTSPAuthChallenge,
+    method: str,
+    uri: str,
+    credentials: RTSPCredentials,
+    nonce_count: int = 1,
+    cnonce: str = "homesec",
+) -> str:
+    """Build an Authorization header for Basic or Digest RTSP auth."""
+    if challenge.scheme == "basic":
+        raw = f"{credentials.username}:{credentials.password}".encode()
+        return "Basic " + base64.b64encode(raw).decode("ascii")
+    if challenge.scheme == "digest":
+        return _build_digest_authorization_header(
+            challenge=challenge,
+            method=method,
+            uri=uri,
+            credentials=credentials,
+            nonce_count=nonce_count,
+            cnonce=cnonce,
+        )
+    raise ValueError(f"Unsupported RTSP auth scheme: {challenge.scheme}")
+
+
+def redact_rtsp_url(url: str) -> str:
+    """Return an RTSP URL with username/password redacted."""
+    parsed = urlsplit(url)
+    if parsed.username is None and parsed.password is None:
+        return url
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+
+
+def split_rtsp_url_credentials(url: str) -> tuple[str, RTSPCredentials | None]:
+    """Remove userinfo from a URL and return extracted credentials if present."""
+    parsed = urlsplit(url)
+    if parsed.username is None:
+        return url, None
+    password = unquote(parsed.password or "")
+    credentials = RTSPCredentials(username=unquote(parsed.username), password=password)
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    clean = urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+    return clean, credentials
+
+
+def request_uri_without_credentials(url: str) -> str:
+    """Normalize an RTSP request URI so credentials never cross logs/wire userinfo."""
+    clean, _credentials = split_rtsp_url_credentials(url)
+    return clean
+
+
+def quote_digest_value(value: str) -> str:
+    """Quote a Digest auth value for deterministic tests."""
+    return quote(value, safe="")
+
+
+def _build_digest_authorization_header(
+    *,
+    challenge: RTSPAuthChallenge,
+    method: str,
+    uri: str,
+    credentials: RTSPCredentials,
+    nonce_count: int,
+    cnonce: str,
+) -> str:
+    params = challenge.params
+    realm = params.get("realm")
+    nonce = params.get("nonce")
+    if not realm or not nonce:
+        raise ValueError("Digest challenge requires realm and nonce")
+
+    algorithm = params.get("algorithm", "MD5")
+    if algorithm.upper() not in {"MD5", "MD5-SESS"}:
+        raise ValueError(f"Unsupported Digest algorithm: {algorithm}")
+
+    username = credentials.username
+    ha1 = _md5_hex(f"{username}:{realm}:{credentials.password}")
+    if algorithm.upper() == "MD5-SESS":
+        ha1 = _md5_hex(f"{ha1}:{nonce}:{cnonce}")
+    ha2 = _md5_hex(f"{method}:{uri}")
+
+    qop = _select_qop(params.get("qop"))
+    nc_value = f"{nonce_count:08x}"
+    if qop:
+        response = _md5_hex(f"{ha1}:{nonce}:{nc_value}:{cnonce}:{qop}:{ha2}")
+    else:
+        response = _md5_hex(f"{ha1}:{nonce}:{ha2}")
+
+    items: list[tuple[str, str, bool]] = [
+        ("username", username, True),
+        ("realm", realm, True),
+        ("nonce", nonce, True),
+        ("uri", uri, True),
+        ("response", response, True),
+        ("algorithm", algorithm, False),
+    ]
+    opaque = params.get("opaque")
+    if opaque is not None:
+        items.append(("opaque", opaque, True))
+    if qop:
+        items.extend(
+            [
+                ("qop", qop, False),
+                ("nc", nc_value, False),
+                ("cnonce", cnonce, True),
+            ]
+        )
+
+    rendered = []
+    for key, value, should_quote in items:
+        if should_quote:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            rendered.append(f'{key}="{escaped}"')
+        else:
+            rendered.append(f"{key}={value}")
+    return "Digest " + ", ".join(rendered)
+
+
+def _parse_auth_params(value: str) -> dict[str, str]:
+    params: dict[str, str] = {}
+    for match in re.finditer(r'(\w+)\s*=\s*("(?:[^"\\]|\\.)*"|[^,]+)', value):
+        key = match.group(1).lower()
+        raw = match.group(2).strip()
+        if raw.startswith('"') and raw.endswith('"'):
+            raw = raw[1:-1]
+            raw = raw.replace('\\"', '"').replace("\\\\", "\\")
+        params[key] = raw
+    return params
+
+
+def _select_qop(qop_value: str | None) -> str | None:
+    if not qop_value:
+        return None
+    options = [item.strip().lower() for item in qop_value.split(",")]
+    if "auth" in options:
+        return "auth"
+    return None
+
+
+def _md5_hex(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()

--- a/src/homesec/sources/rtsp/talk/rtsp_client.py
+++ b/src/homesec/sources/rtsp/talk/rtsp_client.py
@@ -1,0 +1,284 @@
+"""Small async RTSP client primitives for ONVIF audio backchannel sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import secrets
+from dataclasses import dataclass, field
+from urllib.parse import urlsplit
+
+from homesec.sources.rtsp.talk.errors import RTSPAuthenticationError, RTSPProtocolError
+from homesec.sources.rtsp.talk.rtsp_auth import (
+    RTSPAuthChallenge,
+    RTSPCredentials,
+    build_authorization_header,
+    parse_www_authenticate,
+    request_uri_without_credentials,
+    split_rtsp_url_credentials,
+)
+
+_CRLF = "\r\n"
+_HEADER_SEPARATOR = b"\r\n\r\n"
+
+
+@dataclass(slots=True, frozen=True)
+class RTSPResponse:
+    """Parsed RTSP response."""
+
+    status_code: int
+    reason: str
+    headers: dict[str, str] = field(default_factory=dict)
+    body: bytes = b""
+
+    @classmethod
+    def parse(cls, raw: bytes) -> RTSPResponse:
+        """Parse a full RTSP response byte string."""
+        head, separator, body = raw.partition(_HEADER_SEPARATOR)
+        if not separator:
+            raise RTSPProtocolError("RTSP response missing header terminator")
+        lines = head.decode("iso-8859-1").split(_CRLF)
+        if not lines:
+            raise RTSPProtocolError("Empty RTSP response")
+        match = re.match(r"RTSP/\d\.\d\s+(\d{3})(?:\s+(.*))?$", lines[0])
+        if match is None:
+            raise RTSPProtocolError(f"Invalid RTSP status line: {lines[0]!r}")
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            if not line:
+                continue
+            name, sep, value = line.partition(":")
+            if not sep:
+                raise RTSPProtocolError(f"Invalid RTSP header line: {line!r}")
+            key = name.strip().lower()
+            if key in headers:
+                headers[key] = f"{headers[key]}, {value.strip()}"
+            else:
+                headers[key] = value.strip()
+        content_length = int(headers.get("content-length", "0") or "0")
+        if content_length and len(body) < content_length:
+            raise RTSPProtocolError("RTSP response body shorter than Content-Length")
+        if content_length:
+            body = body[:content_length]
+        return cls(
+            status_code=int(match.group(1)),
+            reason=(match.group(2) or "").strip(),
+            headers=headers,
+            body=body,
+        )
+
+    def header(self, name: str) -> str | None:
+        """Return a case-insensitive header value."""
+        return self.headers.get(name.lower())
+
+
+@dataclass(slots=True)
+class RTSPConnectionConfig:
+    """Connection configuration for the minimal RTSP client."""
+
+    url: str
+    credentials: RTSPCredentials | None = None
+    user_agent: str = "HomeSec/PushToTalk"
+    connect_timeout_s: float = 5.0
+    io_timeout_s: float = 5.0
+
+
+class RTSPClient:
+    """Async RTSP control client with Basic/Digest retry support."""
+
+    def __init__(self, config: RTSPConnectionConfig) -> None:
+        clean_url, url_credentials = split_rtsp_url_credentials(config.url)
+        self._url = clean_url
+        self._credentials = config.credentials or url_credentials
+        self._user_agent = config.user_agent
+        self._connect_timeout_s = config.connect_timeout_s
+        self._io_timeout_s = config.io_timeout_s
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._cseq = 1
+        self.session_id: str | None = None
+        self._auth_challenge: RTSPAuthChallenge | None = None
+        self._auth_nonce_count = 0
+        self._auth_cnonce = ""
+
+    async def connect(self) -> None:
+        """Open the RTSP TCP connection."""
+        parsed = urlsplit(self._url)
+        if parsed.scheme.lower() != "rtsp":
+            raise ValueError("RTSP URL must use rtsp://")
+        host = parsed.hostname
+        if host is None:
+            raise ValueError("RTSP URL must include a host")
+        port = parsed.port or 554
+        self._reader, self._writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=self._connect_timeout_s,
+        )
+
+    async def close(self) -> None:
+        """Close the RTSP TCP connection."""
+        writer = self._writer
+        self._reader = None
+        self._writer = None
+        if writer is None:
+            return
+        writer.close()
+        await writer.wait_closed()
+
+    async def request(
+        self,
+        method: str,
+        uri: str | None = None,
+        *,
+        headers: dict[str, str] | None = None,
+        body: bytes = b"",
+        retry_auth: bool = True,
+    ) -> RTSPResponse:
+        """Send an RTSP request and return the parsed response."""
+        request_uri = request_uri_without_credentials(uri or self._url)
+        response = await self._request_once(method, request_uri, headers=headers, body=body)
+        if response.status_code != 401 or not retry_auth:
+            return response
+        www_authenticate = response.header("www-authenticate")
+        if www_authenticate is None or self._credentials is None:
+            raise RTSPAuthenticationError(
+                "Camera requested RTSP authentication but no credentials are configured"
+            )
+        self._auth_challenge = parse_www_authenticate(www_authenticate)
+        self._auth_nonce_count = 0
+        self._auth_cnonce = secrets.token_hex(8)
+        retry_response = await self._request_once(method, request_uri, headers=headers, body=body)
+        if retry_response.status_code == 401:
+            raise RTSPAuthenticationError("RTSP authentication was rejected by the camera")
+        return retry_response
+
+    async def describe(self, *, headers: dict[str, str] | None = None) -> RTSPResponse:
+        """Send DESCRIBE for the aggregate RTSP URL."""
+        merged = {"Accept": "application/sdp"}
+        if headers:
+            merged.update(headers)
+        return await self.request("DESCRIBE", self._url, headers=merged)
+
+    async def setup_interleaved(
+        self,
+        control_url: str,
+        *,
+        rtp_channel: int = 0,
+        headers: dict[str, str] | None = None,
+    ) -> RTSPResponse:
+        """SETUP a TCP-interleaved RTP channel."""
+        merged = {"Transport": f"RTP/AVP/TCP;unicast;interleaved={rtp_channel}-{rtp_channel + 1}"}
+        if headers:
+            merged.update(headers)
+        response = await self.request("SETUP", control_url, headers=merged)
+        if response.status_code == 200:
+            session_header = response.header("session")
+            if session_header:
+                self.session_id = session_header.split(";", maxsplit=1)[0].strip()
+        return response
+
+    async def play(self, *, headers: dict[str, str] | None = None) -> RTSPResponse:
+        """Send PLAY for the aggregate RTSP URL."""
+        return await self.request("PLAY", self._url, headers=headers)
+
+    async def teardown(self, *, headers: dict[str, str] | None = None) -> RTSPResponse:
+        """Send TEARDOWN for the aggregate RTSP URL."""
+        return await self.request("TEARDOWN", self._url, headers=headers, retry_auth=False)
+
+    async def send_interleaved_frame(self, channel: int, payload: bytes) -> None:
+        """Send one RTSP TCP-interleaved binary frame."""
+        if not 0 <= channel <= 255:
+            raise ValueError("interleaved channel must be in range 0..255")
+        if len(payload) > 0xFFFF:
+            raise ValueError("interleaved payload exceeds 65535 bytes")
+        writer = self._require_writer()
+        writer.write(b"$" + bytes([channel]) + len(payload).to_bytes(2, "big") + payload)
+        await asyncio.wait_for(writer.drain(), timeout=self._io_timeout_s)
+
+    async def _request_once(
+        self,
+        method: str,
+        uri: str,
+        *,
+        headers: dict[str, str] | None,
+        body: bytes,
+    ) -> RTSPResponse:
+        writer = self._require_writer()
+        request_headers = self._build_headers(method, uri, headers=headers, body=body)
+        lines = [f"{method} {uri} RTSP/1.0"]
+        lines.extend(f"{name}: {value}" for name, value in request_headers.items())
+        raw = (_CRLF.join(lines) + _CRLF * 2).encode("iso-8859-1") + body
+        writer.write(raw)
+        await asyncio.wait_for(writer.drain(), timeout=self._io_timeout_s)
+        return await self._read_response()
+
+    def _build_headers(
+        self,
+        method: str,
+        uri: str,
+        *,
+        headers: dict[str, str] | None,
+        body: bytes,
+    ) -> dict[str, str]:
+        result: dict[str, str] = {
+            "CSeq": str(self._cseq),
+            "User-Agent": self._user_agent,
+        }
+        self._cseq += 1
+        if self.session_id is not None and method.upper() not in {"DESCRIBE", "SETUP"}:
+            result["Session"] = self.session_id
+        if body:
+            result["Content-Length"] = str(len(body))
+        if headers:
+            result.update(headers)
+        if self._auth_challenge is not None and self._credentials is not None:
+            self._auth_nonce_count += 1
+            result["Authorization"] = build_authorization_header(
+                challenge=self._auth_challenge,
+                method=method,
+                uri=uri,
+                credentials=self._credentials,
+                nonce_count=self._auth_nonce_count,
+                cnonce=self._auth_cnonce,
+            )
+        return result
+
+    async def _read_response(self) -> RTSPResponse:
+        reader = self._require_reader()
+        head = await asyncio.wait_for(
+            reader.readuntil(_HEADER_SEPARATOR), timeout=self._io_timeout_s
+        )
+        header_text = head.decode("iso-8859-1")
+        content_length = _content_length_from_header_text(header_text)
+        body = b""
+        if content_length:
+            body = await asyncio.wait_for(
+                reader.readexactly(content_length), timeout=self._io_timeout_s
+            )
+        return RTSPResponse.parse(head + body)
+
+    def _require_reader(self) -> asyncio.StreamReader:
+        if self._reader is None:
+            raise RuntimeError("RTSP client is not connected")
+        return self._reader
+
+    def _require_writer(self) -> asyncio.StreamWriter:
+        if self._writer is None:
+            raise RuntimeError("RTSP client is not connected")
+        return self._writer
+
+
+def parse_interleaved_channels(transport_header: str) -> tuple[int, int] | None:
+    """Parse interleaved RTP/RTCP channels from an RTSP Transport header."""
+    match = re.search(r"(?:^|;)\s*interleaved\s*=\s*(\d+)\s*-\s*(\d+)", transport_header, re.I)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _content_length_from_header_text(header_text: str) -> int:
+    for line in header_text.split(_CRLF):
+        name, sep, value = line.partition(":")
+        if sep and name.lower() == "content-length":
+            return int(value.strip() or "0")
+    return 0

--- a/src/homesec/sources/rtsp/talk/rtsp_client.py
+++ b/src/homesec/sources/rtsp/talk/rtsp_client.py
@@ -245,17 +245,29 @@ class RTSPClient:
 
     async def _read_response(self) -> RTSPResponse:
         reader = self._require_reader()
-        head = await asyncio.wait_for(
-            reader.readuntil(_HEADER_SEPARATOR), timeout=self._io_timeout_s
-        )
-        header_text = head.decode("iso-8859-1")
-        content_length = _content_length_from_header_text(header_text)
-        body = b""
-        if content_length:
-            body = await asyncio.wait_for(
-                reader.readexactly(content_length), timeout=self._io_timeout_s
+        while True:
+            first = await asyncio.wait_for(reader.readexactly(1), timeout=self._io_timeout_s)
+            if first == b"$":
+                await self._read_interleaved_frame(reader)
+                continue
+
+            head = first + await asyncio.wait_for(
+                reader.readuntil(_HEADER_SEPARATOR), timeout=self._io_timeout_s
             )
-        return RTSPResponse.parse(head + body)
+            header_text = head.decode("iso-8859-1")
+            content_length = _content_length_from_header_text(header_text)
+            body = b""
+            if content_length:
+                body = await asyncio.wait_for(
+                    reader.readexactly(content_length), timeout=self._io_timeout_s
+                )
+            return RTSPResponse.parse(head + body)
+
+    async def _read_interleaved_frame(self, reader: asyncio.StreamReader) -> bytes:
+        _channel = await asyncio.wait_for(reader.readexactly(1), timeout=self._io_timeout_s)
+        length_bytes = await asyncio.wait_for(reader.readexactly(2), timeout=self._io_timeout_s)
+        length = int.from_bytes(length_bytes, "big")
+        return await asyncio.wait_for(reader.readexactly(length), timeout=self._io_timeout_s)
 
     def _require_reader(self) -> asyncio.StreamReader:
         if self._reader is None:

--- a/src/homesec/sources/rtsp/talk/sdp.py
+++ b/src/homesec/sources/rtsp/talk/sdp.py
@@ -177,7 +177,7 @@ def select_audio_backchannel(
                 if _normalize_codec_name(codec.normalized_name) != preference:
                     continue
                 control = media.control or description.session_control or "*"
-                if base_control_url is not None and control != "*":
+                if base_control_url is not None:
                     control = _join_control_url(base_control_url, control)
                 return SelectedBackchannel(
                     control=control,

--- a/src/homesec/sources/rtsp/talk/sdp.py
+++ b/src/homesec/sources/rtsp/talk/sdp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from urllib.parse import urlsplit, urlunsplit
 
 from homesec.sources.rtsp.talk.errors import (
     CameraBackchannelUnsupportedError,
@@ -176,9 +177,11 @@ def select_audio_backchannel(
                     continue
                 if _normalize_codec_name(codec.normalized_name) != preference:
                     continue
-                control = media.control or description.session_control or "*"
-                if base_control_url is not None:
-                    control = _join_control_url(base_control_url, control)
+                control = _resolve_control_url(
+                    description=description,
+                    media=media,
+                    base_control_url=base_control_url,
+                )
                 return SelectedBackchannel(
                     control=control,
                     payload_type=payload_type,
@@ -233,6 +236,21 @@ def _apply_fmtp(media: SDPMediaDescription, attr: str) -> None:
     )
 
 
+def _resolve_control_url(
+    *,
+    description: SDPDescription,
+    media: SDPMediaDescription,
+    base_control_url: str | None,
+) -> str:
+    control = media.control or description.session_control or "*"
+    if base_control_url is None:
+        return control
+    if media.control is not None and description.session_control:
+        session_base = _join_control_url(base_control_url, description.session_control)
+        return _join_control_url(session_base, media.control)
+    return _join_control_url(base_control_url, control)
+
+
 def _normalize_codec_name(value: str) -> str:
     parts = value.strip().split("/")
     if len(parts) < 2:
@@ -246,9 +264,38 @@ def _normalize_codec_name(value: str) -> str:
 
 
 def _join_control_url(base_url: str, control: str) -> str:
+    control = control.strip()
     if "://" in control:
         return control
     if control == "*":
         return base_url
-    separator = "" if base_url.endswith("/") else "/"
-    return f"{base_url}{separator}{control}"
+
+    base = urlsplit(base_url)
+    control_parts = urlsplit(control)
+    if control.startswith("/"):
+        return urlunsplit(
+            (
+                base.scheme,
+                base.netloc,
+                control_parts.path,
+                control_parts.query,
+                control_parts.fragment,
+            )
+        )
+
+    base_path = base.path or ""
+    if not base_path:
+        joined_path = f"/{control_parts.path}"
+    elif base_path.endswith("/"):
+        joined_path = f"{base_path}{control_parts.path}"
+    else:
+        joined_path = f"{base_path}/{control_parts.path}"
+    return urlunsplit(
+        (
+            base.scheme,
+            base.netloc,
+            joined_path,
+            control_parts.query,
+            control_parts.fragment,
+        )
+    )

--- a/src/homesec/sources/rtsp/talk/sdp.py
+++ b/src/homesec/sources/rtsp/talk/sdp.py
@@ -1,0 +1,254 @@
+"""Minimal SDP parser for ONVIF RTSP audio backchannel negotiation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from homesec.sources.rtsp.talk.errors import (
+    CameraBackchannelUnsupportedError,
+    UnsupportedTalkCodecError,
+)
+
+_DIRECTION_ATTRIBUTES = {"sendonly", "recvonly", "sendrecv", "inactive"}
+_STATIC_RTPMAP: dict[int, tuple[str, int, int]] = {
+    0: ("PCMU", 8000, 1),
+    8: ("PCMA", 8000, 1),
+}
+
+
+@dataclass(slots=True, frozen=True)
+class SDPCodec:
+    """RTP codec advertised in an SDP media description."""
+
+    payload_type: int
+    encoding_name: str
+    clock_rate: int
+    channels: int = 1
+    fmtp: str | None = None
+
+    @property
+    def normalized_name(self) -> str:
+        base = f"{self.encoding_name.upper()}/{self.clock_rate}"
+        if self.channels != 1:
+            return f"{base}/{self.channels}"
+        return base
+
+
+@dataclass(slots=True)
+class SDPMediaDescription:
+    """One SDP m= section."""
+
+    media: str
+    port: int
+    proto: str
+    payload_types: list[int]
+    direction: str | None = None
+    control: str | None = None
+    codecs: dict[int, SDPCodec] = field(default_factory=dict)
+    attributes: dict[str, list[str | None]] = field(default_factory=dict)
+
+    def codec_for_payload(self, payload_type: int) -> SDPCodec | None:
+        codec = self.codecs.get(payload_type)
+        if codec is not None:
+            return codec
+        static = _STATIC_RTPMAP.get(payload_type)
+        if static is None:
+            return None
+        encoding, clock_rate, channels = static
+        return SDPCodec(
+            payload_type=payload_type,
+            encoding_name=encoding,
+            clock_rate=clock_rate,
+            channels=channels,
+        )
+
+
+@dataclass(slots=True)
+class SDPDescription:
+    """Parsed SDP session with media sections."""
+
+    session_direction: str | None = None
+    session_control: str | None = None
+    media: list[SDPMediaDescription] = field(default_factory=list)
+
+
+@dataclass(slots=True, frozen=True)
+class SelectedBackchannel:
+    """Selected audio backchannel stream and codec."""
+
+    control: str
+    payload_type: int
+    codec: SDPCodec
+    media: SDPMediaDescription
+
+    @property
+    def selected_codec(self) -> str:
+        return self.codec.normalized_name
+
+
+def parse_sdp(sdp: str) -> SDPDescription:
+    """Parse enough SDP to discover ONVIF sendonly audio backchannel streams."""
+    description = SDPDescription()
+    current: SDPMediaDescription | None = None
+
+    for raw_line in sdp.replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        line = raw_line.strip()
+        if not line or len(line) < 2 or line[1] != "=":
+            continue
+        prefix = line[0]
+        value = line[2:].strip()
+
+        if prefix == "m":
+            parts = value.split()
+            if len(parts) < 4:
+                continue
+            try:
+                port = int(parts[1])
+                payload_types = [int(item) for item in parts[3:]]
+            except ValueError:
+                continue
+            current = SDPMediaDescription(
+                media=parts[0].lower(),
+                port=port,
+                proto=parts[2],
+                payload_types=payload_types,
+            )
+            description.media.append(current)
+            continue
+
+        if prefix != "a":
+            continue
+
+        name, separator, attr_value = value.partition(":")
+        name = name.strip().lower()
+        attr = attr_value.strip() if separator else None
+
+        if current is None:
+            if name in _DIRECTION_ATTRIBUTES:
+                description.session_direction = name
+            elif name == "control" and attr:
+                description.session_control = attr
+            continue
+
+        current.attributes.setdefault(name, []).append(attr)
+        if name in _DIRECTION_ATTRIBUTES:
+            current.direction = name
+        elif name == "control" and attr:
+            current.control = attr
+        elif name == "rtpmap" and attr:
+            codec = _parse_rtpmap(attr)
+            if codec is not None:
+                current.codecs[codec.payload_type] = codec
+        elif name == "fmtp" and attr:
+            _apply_fmtp(current, attr)
+
+    return description
+
+
+def select_audio_backchannel(
+    sdp: str | SDPDescription,
+    *,
+    preferred_codecs: list[str],
+    base_control_url: str | None = None,
+) -> SelectedBackchannel:
+    """Select the first sendonly audio stream matching the preferred codecs.
+
+    Raises specific errors so the runtime/source layer can return a stable status
+    without leaking raw camera protocol details to API callers.
+    """
+    description = parse_sdp(sdp) if isinstance(sdp, str) else sdp
+    preferences = [_normalize_codec_name(item) for item in preferred_codecs]
+    candidates: list[SDPMediaDescription] = []
+
+    for media in description.media:
+        direction = media.direction or description.session_direction
+        if media.media == "audio" and direction == "sendonly":
+            candidates.append(media)
+
+    if not candidates:
+        raise CameraBackchannelUnsupportedError("SDP has no sendonly audio backchannel")
+
+    for preference in preferences:
+        for media in candidates:
+            for payload_type in media.payload_types:
+                codec = media.codec_for_payload(payload_type)
+                if codec is None:
+                    continue
+                if _normalize_codec_name(codec.normalized_name) != preference:
+                    continue
+                control = media.control or description.session_control or "*"
+                if base_control_url is not None and control != "*":
+                    control = _join_control_url(base_control_url, control)
+                return SelectedBackchannel(
+                    control=control,
+                    payload_type=payload_type,
+                    codec=codec,
+                    media=media,
+                )
+
+    raise UnsupportedTalkCodecError("SDP sendonly audio has no preferred codec")
+
+
+def _parse_rtpmap(attr: str) -> SDPCodec | None:
+    payload_text, separator, encoding_text = attr.partition(" ")
+    if not separator:
+        return None
+    try:
+        payload_type = int(payload_text)
+    except ValueError:
+        return None
+    codec_parts = encoding_text.strip().split("/")
+    if len(codec_parts) < 2:
+        return None
+    try:
+        clock_rate = int(codec_parts[1])
+        channels = int(codec_parts[2]) if len(codec_parts) >= 3 else 1
+    except ValueError:
+        return None
+    return SDPCodec(
+        payload_type=payload_type,
+        encoding_name=codec_parts[0].upper(),
+        clock_rate=clock_rate,
+        channels=channels,
+    )
+
+
+def _apply_fmtp(media: SDPMediaDescription, attr: str) -> None:
+    payload_text, separator, fmtp = attr.partition(" ")
+    if not separator:
+        return
+    try:
+        payload_type = int(payload_text)
+    except ValueError:
+        return
+    codec = media.codecs.get(payload_type)
+    if codec is None:
+        return
+    media.codecs[payload_type] = SDPCodec(
+        payload_type=codec.payload_type,
+        encoding_name=codec.encoding_name,
+        clock_rate=codec.clock_rate,
+        channels=codec.channels,
+        fmtp=fmtp.strip(),
+    )
+
+
+def _normalize_codec_name(value: str) -> str:
+    parts = value.strip().split("/")
+    if len(parts) < 2:
+        return value.strip().upper()
+    encoding = parts[0].upper()
+    clock = parts[1]
+    channels = parts[2] if len(parts) >= 3 else None
+    if channels in (None, "", "1"):
+        return f"{encoding}/{clock}"
+    return f"{encoding}/{clock}/{channels}"
+
+
+def _join_control_url(base_url: str, control: str) -> str:
+    if "://" in control:
+        return control
+    if control == "*":
+        return base_url
+    separator = "" if base_url.endswith("/") else "/"
+    return f"{base_url}{separator}{control}"

--- a/tests/homesec/rtsp/talk/test_audio_packetization.py
+++ b/tests/homesec/rtsp/talk/test_audio_packetization.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from homesec.sources.rtsp.talk.g711 import encode_pcmu
+from homesec.sources.rtsp.talk.resample import resample_pcm_s16le_mono
+from homesec.sources.rtsp.talk.rtp import RTPPacketizer, parse_rtp_header
+
+
+def _pcm(*samples: int) -> bytes:
+    return struct.pack(f"<{len(samples)}h", *samples)
+
+
+def test_pcmu_encode_known_vectors() -> None:
+    samples = (-32768, -32124, -1, 0, 1, 32124, 32767)
+
+    assert encode_pcmu(_pcm(*samples)) == bytes([0x00, 0x00, 0x7E, 0xFF, 0xFF, 0x80, 0x80])
+
+
+def test_g711_rejects_odd_pcm_input() -> None:
+    with pytest.raises(ValueError, match="even"):
+        encode_pcmu(b"\x00")
+
+
+def test_resample_16khz_to_8khz_uses_box_averaging() -> None:
+    resampled = resample_pcm_s16le_mono(
+        _pcm(0, 2, 10, 12, -4, -2, 100, 104),
+        input_rate=16000,
+        output_rate=8000,
+    )
+
+    assert struct.unpack("<4h", resampled) == (1, 11, -3, 102)
+
+
+def test_rtp_packetizer_header_fields_and_timestamp_increments() -> None:
+    packetizer = RTPPacketizer(
+        payload_type=0,
+        sequence_number=0xFFFF,
+        timestamp=1000,
+        ssrc=0x01020304,
+    )
+
+    packet = packetizer.packetize(b"\xff" * 160, timestamp_increment=160, marker=True)
+
+    header = parse_rtp_header(packet)
+    assert header == {
+        "version": 2,
+        "padding": False,
+        "extension": False,
+        "csrc_count": 0,
+        "marker": True,
+        "payload_type": 0,
+        "sequence_number": 0xFFFF,
+        "timestamp": 1000,
+        "ssrc": 0x01020304,
+    }
+    assert packet[12:] == b"\xff" * 160
+    assert packetizer.sequence_number == 0
+    assert packetizer.timestamp == 1160
+
+    next_packet = packetizer.packetize(b"\x7f" * 160, timestamp_increment=160)
+    assert parse_rtp_header(next_packet)["sequence_number"] == 0
+    assert parse_rtp_header(next_packet)["timestamp"] == 1160

--- a/tests/homesec/rtsp/talk/test_audio_packetization.py
+++ b/tests/homesec/rtsp/talk/test_audio_packetization.py
@@ -19,6 +19,10 @@ def test_pcmu_encode_known_vectors() -> None:
     assert encode_pcmu(_pcm(*samples)) == bytes([0x00, 0x00, 0x7E, 0xFF, 0xFF, 0x80, 0x80])
 
 
+def test_pcmu_encode_clips_out_of_range_extremes() -> None:
+    assert encode_pcmu(_pcm(-32768, 32767)) == bytes([0x00, 0x80])
+
+
 def test_g711_rejects_odd_pcm_input() -> None:
     with pytest.raises(ValueError, match="even"):
         encode_pcmu(b"\x00")
@@ -32,6 +36,38 @@ def test_resample_16khz_to_8khz_uses_box_averaging() -> None:
     )
 
     assert struct.unpack("<4h", resampled) == (1, 11, -3, 102)
+
+
+def test_resample_same_rate_and_empty_input_are_passthrough() -> None:
+    pcm = _pcm(1, -2, 3)
+
+    assert resample_pcm_s16le_mono(pcm, input_rate=8000, output_rate=8000) == pcm
+    assert resample_pcm_s16le_mono(b"", input_rate=16000, output_rate=8000) == b""
+
+
+def test_resample_rejects_invalid_rates_and_odd_input() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        resample_pcm_s16le_mono(_pcm(1), input_rate=0, output_rate=8000)
+
+    with pytest.raises(ValueError, match="positive"):
+        resample_pcm_s16le_mono(_pcm(1), input_rate=16000, output_rate=-1)
+
+    with pytest.raises(ValueError, match="even"):
+        resample_pcm_s16le_mono(b"\x00", input_rate=16000, output_rate=8000)
+
+
+def test_resample_non_integer_ratio_uses_linear_interpolation() -> None:
+    resampled = resample_pcm_s16le_mono(
+        _pcm(0, 100, 200),
+        input_rate=2,
+        output_rate=3,
+    )
+
+    assert struct.unpack("<4h", resampled) == (0, 67, 133, 200)
+
+
+def test_resample_returns_empty_when_integer_downsample_has_too_few_samples() -> None:
+    assert resample_pcm_s16le_mono(_pcm(10), input_rate=16000, output_rate=8000) == b""
 
 
 def test_rtp_packetizer_header_fields_and_timestamp_increments() -> None:
@@ -63,3 +99,32 @@ def test_rtp_packetizer_header_fields_and_timestamp_increments() -> None:
     next_packet = packetizer.packetize(b"\x7f" * 160, timestamp_increment=160)
     assert parse_rtp_header(next_packet)["sequence_number"] == 0
     assert parse_rtp_header(next_packet)["timestamp"] == 1160
+
+
+def test_rtp_packetizer_defaults_timestamp_increment_to_payload_length() -> None:
+    packetizer = RTPPacketizer(
+        payload_type=0,
+        sequence_number=1,
+        timestamp=10,
+        ssrc=1,
+    )
+
+    packetizer.packetize(b"12345")
+
+    assert packetizer.timestamp == 15
+
+
+def test_rtp_packetizer_validates_configuration_and_increment() -> None:
+    with pytest.raises(ValueError, match="payload type"):
+        RTPPacketizer(payload_type=128)
+
+    with pytest.raises(ValueError, match="clock_rate"):
+        RTPPacketizer(payload_type=0, clock_rate=0)
+
+    with pytest.raises(ValueError, match="timestamp_increment"):
+        RTPPacketizer(payload_type=0).packetize(b"payload", timestamp_increment=-1)
+
+
+def test_parse_rtp_header_rejects_short_packets() -> None:
+    with pytest.raises(ValueError, match="shorter"):
+        parse_rtp_header(b"\x80")

--- a/tests/homesec/rtsp/talk/test_errors.py
+++ b/tests/homesec/rtsp/talk/test_errors.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from homesec.sources.rtsp.talk.errors import (
+    CameraBackchannelUnsupportedError,
+    CameraRejectedTalkSessionError,
+    CameraTalkStreamFailedError,
+    RTSPAuthenticationError,
+    RTSPProtocolError,
+    TalkProtocolError,
+    TalkProtocolErrorCode,
+    UnsupportedTalkCodecError,
+)
+
+
+@pytest.mark.parametrize(
+    ("error", "code"),
+    [
+        (
+            CameraBackchannelUnsupportedError(),
+            TalkProtocolErrorCode.CAMERA_BACKCHANNEL_UNSUPPORTED,
+        ),
+        (UnsupportedTalkCodecError(), TalkProtocolErrorCode.UNSUPPORTED_CODEC),
+        (CameraRejectedTalkSessionError(), TalkProtocolErrorCode.CAMERA_REJECTED_SESSION),
+        (CameraTalkStreamFailedError(), TalkProtocolErrorCode.CAMERA_STREAM_FAILED),
+        (RTSPAuthenticationError(), TalkProtocolErrorCode.RTSP_AUTH_FAILED),
+        (RTSPProtocolError(), TalkProtocolErrorCode.RTSP_PROTOCOL_ERROR),
+    ],
+)
+def test_protocol_errors_expose_stable_machine_codes(
+    error: TalkProtocolError,
+    code: TalkProtocolErrorCode,
+) -> None:
+    assert error.code == code
+    assert str(error)

--- a/tests/homesec/rtsp/talk/test_models.py
+++ b/tests/homesec/rtsp/talk/test_models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
+from homesec.sources.rtsp.talk.rtsp_auth import RTSPCredentials
+
+
+def test_onvif_backchannel_config_resolves_url_and_credentials_from_env() -> None:
+    config = ONVIFBackchannelConfig(
+        rtsp_url_env="TALK_RTSP_URL",
+        username_env="TALK_RTSP_USER",
+        password_env="TALK_RTSP_PASSWORD",
+    )
+    environ = {
+        "TALK_RTSP_URL": "rtsp://camera.local/talk",
+        "TALK_RTSP_USER": "alice",
+        "TALK_RTSP_PASSWORD": "secret",
+    }
+
+    assert config.resolve_rtsp_url(environ) == "rtsp://camera.local/talk"
+    assert config.resolve_credentials(environ) == RTSPCredentials(
+        username="alice", password="secret"
+    )
+
+
+def test_onvif_backchannel_config_requires_credential_pairs() -> None:
+    with pytest.raises(ValidationError, match="username and password"):
+        ONVIFBackchannelConfig(rtsp_url="rtsp://camera.local/talk", username="alice")
+
+    with pytest.raises(ValidationError, match="username_env and password_env"):
+        ONVIFBackchannelConfig(rtsp_url="rtsp://camera.local/talk", username_env="USER")
+
+
+def test_onvif_backchannel_config_rejects_deferred_codecs() -> None:
+    with pytest.raises(ValidationError, match="PCMU/8000"):
+        ONVIFBackchannelConfig(
+            rtsp_url="rtsp://camera.local/talk",
+            preferred_codecs=["PCMA/8000"],
+        )

--- a/tests/homesec/rtsp/talk/test_models.py
+++ b/tests/homesec/rtsp/talk/test_models.py
@@ -25,6 +25,32 @@ def test_onvif_backchannel_config_resolves_url_and_credentials_from_env() -> Non
     )
 
 
+def test_onvif_backchannel_config_prefers_explicit_url_and_credentials() -> None:
+    config = ONVIFBackchannelConfig(
+        rtsp_url="rtsp://camera.local/explicit",
+        rtsp_url_env="TALK_RTSP_URL",
+        username="direct-user",
+        password="direct-pass",
+        username_env="TALK_RTSP_USER",
+        password_env="TALK_RTSP_PASSWORD",
+    )
+    environ = {
+        "TALK_RTSP_URL": "rtsp://camera.local/env",
+        "TALK_RTSP_USER": "env-user",
+        "TALK_RTSP_PASSWORD": "env-pass",
+    }
+
+    assert config.resolve_rtsp_url(environ) == "rtsp://camera.local/explicit"
+    assert config.resolve_credentials(environ) == RTSPCredentials(
+        username="direct-user", password="direct-pass"
+    )
+
+
+def test_onvif_backchannel_config_requires_rtsp_url_source() -> None:
+    with pytest.raises(ValidationError, match="rtsp_url_env or rtsp_url"):
+        ONVIFBackchannelConfig()
+
+
 def test_onvif_backchannel_config_requires_credential_pairs() -> None:
     with pytest.raises(ValidationError, match="username and password"):
         ONVIFBackchannelConfig(rtsp_url="rtsp://camera.local/talk", username="alice")
@@ -39,3 +65,46 @@ def test_onvif_backchannel_config_rejects_deferred_codecs() -> None:
             rtsp_url="rtsp://camera.local/talk",
             preferred_codecs=["PCMA/8000"],
         )
+
+
+def test_onvif_backchannel_config_normalizes_supported_codec_names() -> None:
+    config = ONVIFBackchannelConfig(
+        rtsp_url="rtsp://camera.local/talk",
+        preferred_codecs=["pcmu/8000/1"],
+    )
+
+    assert config.preferred_codecs == ["PCMU/8000"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("transport", "udp", "rtsp_tcp_interleaved"),
+        ("connect_timeout_s", 0, "greater than 0"),
+        ("io_timeout_s", 31, "less than or equal to 30"),
+        ("extra_field", True, "Extra inputs"),
+    ],
+)
+def test_onvif_backchannel_config_rejects_invalid_shape(
+    field: str,
+    value: object,
+    match: str,
+) -> None:
+    kwargs: dict[str, object] = {"rtsp_url": "rtsp://camera.local/talk", field: value}
+
+    with pytest.raises(ValidationError, match=match):
+        ONVIFBackchannelConfig(**kwargs)
+
+
+def test_onvif_backchannel_config_reports_missing_env_values() -> None:
+    config = ONVIFBackchannelConfig(
+        rtsp_url_env="TALK_RTSP_URL",
+        username_env="TALK_RTSP_USER",
+        password_env="TALK_RTSP_PASSWORD",
+    )
+
+    with pytest.raises(ValueError, match="TALK_RTSP_URL"):
+        config.resolve_rtsp_url({})
+
+    with pytest.raises(ValueError, match="TALK_RTSP_USER"):
+        config.resolve_credentials({"TALK_RTSP_URL": "rtsp://camera.local/talk"})

--- a/tests/homesec/rtsp/talk/test_models.py
+++ b/tests/homesec/rtsp/talk/test_models.py
@@ -82,6 +82,7 @@ def test_onvif_backchannel_config_normalizes_supported_codec_names() -> None:
         ("transport", "udp", "rtsp_tcp_interleaved"),
         ("connect_timeout_s", 0, "greater than 0"),
         ("io_timeout_s", 31, "less than or equal to 30"),
+        ("require_onvif_backchannel", False, "Extra inputs"),
         ("extra_field", True, "Extra inputs"),
     ],
 )

--- a/tests/homesec/rtsp/talk/test_onvif_backchannel.py
+++ b/tests/homesec/rtsp/talk/test_onvif_backchannel.py
@@ -10,10 +10,14 @@ import pytest
 from homesec.sources.rtsp.talk.errors import (
     CameraBackchannelUnsupportedError,
     CameraRejectedTalkSessionError,
+    CameraTalkStreamFailedError,
+    RTSPAuthenticationError,
+    UnsupportedTalkCodecError,
 )
 from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
-from homesec.sources.rtsp.talk.onvif_backchannel import ONVIFBackchannelAdapter
+from homesec.sources.rtsp.talk.onvif_backchannel import ONVIFBackchannelAdapter, ONVIFTalkSession
 from homesec.sources.rtsp.talk.rtp import parse_rtp_header
+from homesec.sources.rtsp.talk.sdp import SDPCodec, SDPMediaDescription, SelectedBackchannel
 
 _BACKCHANNEL_SDP = """v=0\r
 o=- 0 0 IN IP4 127.0.0.1\r
@@ -42,7 +46,12 @@ class _FakeRTSPBackchannelServer:
     describe_status: int = 200
     setup_status: int = 200
     play_status: int = 200
+    teardown_status: int = 200
     require_basic_auth: bool = False
+    basic_username: str = "alice"
+    basic_password: str = "s3cr@t"
+    transport_header: str = "RTP/AVP/TCP;unicast;interleaved=0-1"
+    sdp_body: bytes = field(default_factory=lambda: _BACKCHANNEL_SDP.encode())
     requests: list[_RTSPRequest] = field(default_factory=list)
     interleaved_before_play: list[tuple[int, bytes]] = field(default_factory=list)
     interleaved_after_play: list[tuple[int, bytes]] = field(default_factory=list)
@@ -127,13 +136,17 @@ class _FakeRTSPBackchannelServer:
     def _response_for(self, request: _RTSPRequest) -> bytes:
         cseq = request.headers.get("cseq", "1")
         if request.method == "DESCRIBE":
-            if self.require_basic_auth and "authorization" not in request.headers:
-                return _rtsp_response(
-                    cseq=cseq,
-                    status=401,
-                    reason="Unauthorized",
-                    headers={"WWW-Authenticate": 'Basic realm="homesec-fake"'},
-                )
+            if self.require_basic_auth:
+                expected = base64.b64encode(
+                    f"{self.basic_username}:{self.basic_password}".encode()
+                ).decode("ascii")
+                if request.headers.get("authorization") != f"Basic {expected}":
+                    return _rtsp_response(
+                        cseq=cseq,
+                        status=401,
+                        reason="Unauthorized",
+                        headers={"WWW-Authenticate": 'Basic realm="homesec-fake"'},
+                    )
             if self.describe_status != 200:
                 return _rtsp_response(
                     cseq=cseq, status=self.describe_status, reason="Option Not Supported"
@@ -141,7 +154,7 @@ class _FakeRTSPBackchannelServer:
             return _rtsp_response(
                 cseq=cseq,
                 headers={"Content-Type": "application/sdp"},
-                body=_BACKCHANNEL_SDP.encode(),
+                body=self.sdp_body,
             )
         if request.method == "SETUP":
             if self.setup_status != 200:
@@ -149,7 +162,7 @@ class _FakeRTSPBackchannelServer:
             return _rtsp_response(
                 cseq=cseq,
                 headers={
-                    "Transport": "RTP/AVP/TCP;unicast;interleaved=0-1",
+                    "Transport": self.transport_header,
                     "Session": "homesec-talk;timeout=60",
                 },
             )
@@ -158,8 +171,41 @@ class _FakeRTSPBackchannelServer:
                 return _rtsp_response(cseq=cseq, headers={"Session": "homesec-talk"})
             return _rtsp_response(cseq=cseq, status=self.play_status, reason="Play Failed")
         if request.method == "TEARDOWN":
-            return _rtsp_response(cseq=cseq, headers={"Session": "homesec-talk"})
+            return _rtsp_response(
+                cseq=cseq,
+                status=self.teardown_status,
+                reason="Teardown Failed" if self.teardown_status != 200 else "OK",
+                headers={"Session": "homesec-talk"},
+            )
         return _rtsp_response(cseq=cseq, status=405, reason="Method Not Allowed")
+
+
+class _NoopTalkClient:
+    def __init__(self, *, session_id: str | None = None) -> None:
+        self.session_id = session_id
+        self.sent: list[tuple[int, bytes]] = []
+        self.teardown_calls = 0
+        self.close_calls = 0
+
+    async def send_interleaved_frame(self, channel: int, payload: bytes) -> None:
+        self.sent.append((channel, payload))
+
+    async def teardown(self, *, headers: dict[str, str] | None = None) -> None:
+        self.teardown_calls += 1
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _FailingSendTalkClient(_NoopTalkClient):
+    async def send_interleaved_frame(self, channel: int, payload: bytes) -> None:
+        raise OSError("broken pipe")
+
+
+class _FailingTeardownTalkClient(_NoopTalkClient):
+    async def teardown(self, *, headers: dict[str, str] | None = None) -> None:
+        self.teardown_calls += 1
+        raise RuntimeError("teardown failed")
 
 
 def _rtsp_response(
@@ -181,6 +227,26 @@ def _rtsp_response(
 def _pcm_frame_16khz_20ms() -> bytes:
     samples = [0, 1200] * 160
     return struct.pack(f"<{len(samples)}h", *samples)
+
+
+def _selected(codec_name: str = "PCMU", payload_type: int = 0) -> SelectedBackchannel:
+    media = SDPMediaDescription(
+        media="audio",
+        port=0,
+        proto="RTP/AVP",
+        payload_types=[payload_type],
+    )
+    codec = SDPCodec(
+        payload_type=payload_type,
+        encoding_name=codec_name,
+        clock_rate=8000,
+    )
+    return SelectedBackchannel(
+        control="rtsp://camera.local/talk",
+        payload_type=payload_type,
+        codec=codec,
+        media=media,
+    )
 
 
 @pytest.mark.asyncio
@@ -220,6 +286,28 @@ async def test_onvif_backchannel_sends_no_rtp_before_play_200_ok() -> None:
 
 
 @pytest.mark.asyncio
+async def test_onvif_backchannel_uses_camera_selected_interleaved_channel() -> None:
+    server = _FakeRTSPBackchannelServer(
+        transport_header="RTP/AVP/TCP;unicast;interleaved=2-3",
+    )
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        session = await adapter.open_session(session_id="talk-1")
+        await session.write_pcm_frame(_pcm_frame_16khz_20ms())
+        await session.close()
+    finally:
+        await server.stop()
+
+    setup_request = next(request for request in server.requests if request.method == "SETUP")
+    assert setup_request.headers["transport"] == "RTP/AVP/TCP;unicast;interleaved=0-1"
+    assert server.interleaved_after_play[0][0] == 2
+
+
+@pytest.mark.asyncio
 async def test_onvif_backchannel_maps_describe_551_to_unsupported() -> None:
     server = _FakeRTSPBackchannelServer(describe_status=551)
     await server.start()
@@ -229,6 +317,25 @@ async def test_onvif_backchannel_maps_describe_551_to_unsupported() -> None:
             camera_name="front_door",
         )
         with pytest.raises(CameraBackchannelUnsupportedError):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_maps_describe_non_551_failure_to_rejected() -> None:
+    server = _FakeRTSPBackchannelServer(describe_status=403)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        with pytest.raises(CameraRejectedTalkSessionError):
             await adapter.open_session(session_id="talk-1")
     finally:
         await server.stop()
@@ -269,6 +376,45 @@ async def test_onvif_backchannel_retries_basic_auth_from_url_credentials() -> No
 
 
 @pytest.mark.asyncio
+async def test_onvif_backchannel_fails_auth_when_credentials_are_missing() -> None:
+    server = _FakeRTSPBackchannelServer(require_basic_auth=True)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        with pytest.raises(RTSPAuthenticationError, match="no credentials"):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_fails_auth_when_camera_rejects_retry() -> None:
+    server = _FakeRTSPBackchannelServer(require_basic_auth=True)
+    await server.start()
+    try:
+        credentialed_url = server.url.replace("rtsp://", "rtsp://alice:wrong@", 1)
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=credentialed_url),
+            camera_name="front_door",
+        )
+        with pytest.raises(RTSPAuthenticationError, match="rejected"):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE", "DESCRIBE"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
 async def test_onvif_backchannel_rejects_setup_failure_before_audio() -> None:
     server = _FakeRTSPBackchannelServer(setup_status=454)
     await server.start()
@@ -304,3 +450,63 @@ async def test_onvif_backchannel_rejects_play_failure_before_audio() -> None:
     assert [request.method for request in server.requests] == ["DESCRIBE", "SETUP", "PLAY"]
     assert server.interleaved_before_play == []
     assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_session_rejects_writes_after_close() -> None:
+    client = _NoopTalkClient()
+    session = ONVIFTalkSession(
+        session_id="talk-1",
+        camera_name="front_door",
+        client=client,  # type: ignore[arg-type]
+        selected=_selected(),
+    )
+
+    await session.close()
+
+    with pytest.raises(CameraTalkStreamFailedError, match="closed"):
+        await session.write_pcm_frame(_pcm_frame_16khz_20ms())
+    assert client.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_onvif_session_wraps_interleaved_send_failures() -> None:
+    session = ONVIFTalkSession(
+        session_id="talk-1",
+        camera_name="front_door",
+        client=_FailingSendTalkClient(),  # type: ignore[arg-type]
+        selected=_selected(),
+    )
+
+    with pytest.raises(CameraTalkStreamFailedError, match="broken pipe"):
+        await session.write_pcm_frame(_pcm_frame_16khz_20ms())
+
+
+@pytest.mark.asyncio
+async def test_onvif_session_rejects_selected_codecs_without_encoder() -> None:
+    session = ONVIFTalkSession(
+        session_id="talk-1",
+        camera_name="front_door",
+        client=_NoopTalkClient(),  # type: ignore[arg-type]
+        selected=_selected(codec_name="PCMA", payload_type=8),
+    )
+
+    with pytest.raises(UnsupportedTalkCodecError, match="PCMA/8000"):
+        await session.write_pcm_frame(_pcm_frame_16khz_20ms())
+
+
+@pytest.mark.asyncio
+async def test_onvif_session_close_is_idempotent_and_teardown_is_best_effort() -> None:
+    client = _FailingTeardownTalkClient(session_id="homesec-talk")
+    session = ONVIFTalkSession(
+        session_id="talk-1",
+        camera_name="front_door",
+        client=client,  # type: ignore[arg-type]
+        selected=_selected(),
+    )
+
+    await session.close()
+    await session.close()
+
+    assert client.teardown_calls == 1
+    assert client.close_calls == 1

--- a/tests/homesec/rtsp/talk/test_onvif_backchannel.py
+++ b/tests/homesec/rtsp/talk/test_onvif_backchannel.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import struct
+from dataclasses import dataclass, field
+
+import pytest
+
+from homesec.sources.rtsp.talk.errors import (
+    CameraBackchannelUnsupportedError,
+    CameraRejectedTalkSessionError,
+)
+from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
+from homesec.sources.rtsp.talk.onvif_backchannel import ONVIFBackchannelAdapter
+from homesec.sources.rtsp.talk.rtp import parse_rtp_header
+
+_BACKCHANNEL_SDP = """v=0\r
+o=- 0 0 IN IP4 127.0.0.1\r
+s=HomeSec fake backchannel camera\r
+t=0 0\r
+m=video 0 RTP/AVP 96\r
+a=recvonly\r
+a=rtpmap:96 H264/90000\r
+a=control:trackID=video\r
+m=audio 0 RTP/AVP 0\r
+a=sendonly\r
+a=rtpmap:0 PCMU/8000\r
+a=control:trackID=backchannel\r
+"""
+
+
+@dataclass(slots=True)
+class _RTSPRequest:
+    method: str
+    uri: str
+    headers: dict[str, str]
+
+
+@dataclass(slots=True)
+class _FakeRTSPBackchannelServer:
+    describe_status: int = 200
+    setup_status: int = 200
+    play_status: int = 200
+    require_basic_auth: bool = False
+    requests: list[_RTSPRequest] = field(default_factory=list)
+    interleaved_before_play: list[tuple[int, bytes]] = field(default_factory=list)
+    interleaved_after_play: list[tuple[int, bytes]] = field(default_factory=list)
+    _play_seen: bool = False
+    _server: asyncio.AbstractServer | None = None
+    _port: int | None = None
+
+    @property
+    def url(self) -> str:
+        assert self._port is not None
+        return f"rtsp://127.0.0.1:{self._port}/Streaming/Channels/101"
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle_client, "127.0.0.1", 0)
+        socket = self._server.sockets[0]
+        host, port = socket.getsockname()[:2]
+        assert host == "127.0.0.1"
+        self._port = int(port)
+
+    async def stop(self) -> None:
+        server = self._server
+        if server is None:
+            return
+        server.close()
+        await server.wait_closed()
+        self._server = None
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            while True:
+                first = await reader.readexactly(1)
+                if first == b"$":
+                    channel = (await reader.readexactly(1))[0]
+                    length = int.from_bytes(await reader.readexactly(2), "big")
+                    payload = await reader.readexactly(length)
+                    target = (
+                        self.interleaved_after_play
+                        if self._play_seen
+                        else self.interleaved_before_play
+                    )
+                    target.append((channel, payload))
+                    continue
+
+                request = await self._read_request(first, reader)
+                self.requests.append(request)
+                response = self._response_for(request)
+                writer.write(response)
+                await writer.drain()
+                if request.method == "PLAY" and self.play_status == 200:
+                    self._play_seen = True
+                if request.method == "TEARDOWN":
+                    break
+        except asyncio.IncompleteReadError:
+            pass
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def _read_request(
+        self,
+        first: bytes,
+        reader: asyncio.StreamReader,
+    ) -> _RTSPRequest:
+        head = first + await reader.readuntil(b"\r\n\r\n")
+        text = head.decode("iso-8859-1")
+        lines = text.split("\r\n")
+        method, uri, _version = lines[0].split(" ", maxsplit=2)
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            name, separator, value = line.partition(":")
+            if separator:
+                headers[name.lower()] = value.strip()
+        content_length = int(headers.get("content-length", "0") or "0")
+        if content_length:
+            await reader.readexactly(content_length)
+        return _RTSPRequest(method=method, uri=uri, headers=headers)
+
+    def _response_for(self, request: _RTSPRequest) -> bytes:
+        cseq = request.headers.get("cseq", "1")
+        if request.method == "DESCRIBE":
+            if self.require_basic_auth and "authorization" not in request.headers:
+                return _rtsp_response(
+                    cseq=cseq,
+                    status=401,
+                    reason="Unauthorized",
+                    headers={"WWW-Authenticate": 'Basic realm="homesec-fake"'},
+                )
+            if self.describe_status != 200:
+                return _rtsp_response(
+                    cseq=cseq, status=self.describe_status, reason="Option Not Supported"
+                )
+            return _rtsp_response(
+                cseq=cseq,
+                headers={"Content-Type": "application/sdp"},
+                body=_BACKCHANNEL_SDP.encode(),
+            )
+        if request.method == "SETUP":
+            if self.setup_status != 200:
+                return _rtsp_response(cseq=cseq, status=self.setup_status, reason="Setup Failed")
+            return _rtsp_response(
+                cseq=cseq,
+                headers={
+                    "Transport": "RTP/AVP/TCP;unicast;interleaved=0-1",
+                    "Session": "homesec-talk;timeout=60",
+                },
+            )
+        if request.method == "PLAY":
+            if self.play_status == 200:
+                return _rtsp_response(cseq=cseq, headers={"Session": "homesec-talk"})
+            return _rtsp_response(cseq=cseq, status=self.play_status, reason="Play Failed")
+        if request.method == "TEARDOWN":
+            return _rtsp_response(cseq=cseq, headers={"Session": "homesec-talk"})
+        return _rtsp_response(cseq=cseq, status=405, reason="Method Not Allowed")
+
+
+def _rtsp_response(
+    *,
+    cseq: str,
+    status: int = 200,
+    reason: str = "OK",
+    headers: dict[str, str] | None = None,
+    body: bytes = b"",
+) -> bytes:
+    merged = {"CSeq": cseq, "Content-Length": str(len(body))}
+    if headers:
+        merged.update(headers)
+    lines = [f"RTSP/1.0 {status} {reason}"]
+    lines.extend(f"{name}: {value}" for name, value in merged.items())
+    return ("\r\n".join(lines) + "\r\n\r\n").encode("iso-8859-1") + body
+
+
+def _pcm_frame_16khz_20ms() -> bytes:
+    samples = [0, 1200] * 160
+    return struct.pack(f"<{len(samples)}h", *samples)
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_sends_no_rtp_before_play_200_ok() -> None:
+    server = _FakeRTSPBackchannelServer()
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        session = await adapter.open_session(session_id="talk-1")
+        await session.write_pcm_frame(_pcm_frame_16khz_20ms())
+        await session.close()
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == [
+        "DESCRIBE",
+        "SETUP",
+        "PLAY",
+        "TEARDOWN",
+    ]
+    assert all(
+        request.headers.get("require") == "www.onvif.org/ver20/backchannel"
+        for request in server.requests[:3]
+    )
+    assert server.interleaved_before_play == []
+    assert len(server.interleaved_after_play) == 1
+
+    channel, packet = server.interleaved_after_play[0]
+    assert channel == 0
+    header = parse_rtp_header(packet)
+    assert header["version"] == 2
+    assert header["payload_type"] == 0
+    assert packet[12:]
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_maps_describe_551_to_unsupported() -> None:
+    server = _FakeRTSPBackchannelServer(describe_status=551)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        with pytest.raises(CameraBackchannelUnsupportedError):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_retries_basic_auth_from_url_credentials() -> None:
+    server = _FakeRTSPBackchannelServer(require_basic_auth=True)
+    await server.start()
+    try:
+        credentialed_url = server.url.replace("rtsp://", "rtsp://alice:s3cr%40t@", 1)
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=credentialed_url),
+            camera_name="front_door",
+        )
+        session = await adapter.open_session(session_id="talk-1")
+        await session.close()
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == [
+        "DESCRIBE",
+        "DESCRIBE",
+        "SETUP",
+        "PLAY",
+        "TEARDOWN",
+    ]
+    authorization = server.requests[1].headers["authorization"]
+    expected = base64.b64encode(b"alice:s3cr@t").decode("ascii")
+    assert authorization == f"Basic {expected}"
+    assert "@" not in server.requests[1].uri
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_rejects_setup_failure_before_audio() -> None:
+    server = _FakeRTSPBackchannelServer(setup_status=454)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        with pytest.raises(CameraRejectedTalkSessionError):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE", "SETUP"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_rejects_play_failure_before_audio() -> None:
+    server = _FakeRTSPBackchannelServer(play_status=454)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        with pytest.raises(CameraRejectedTalkSessionError):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE", "SETUP", "PLAY"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []

--- a/tests/homesec/rtsp/talk/test_onvif_backchannel.py
+++ b/tests/homesec/rtsp/talk/test_onvif_backchannel.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import re
 import struct
 from dataclasses import dataclass, field
 
@@ -48,9 +50,15 @@ class _FakeRTSPBackchannelServer:
     play_status: int = 200
     teardown_status: int = 200
     require_basic_auth: bool = False
+    require_digest_auth: bool = False
+    digest_qop: str | None = "auth"
     basic_username: str = "alice"
     basic_password: str = "s3cr@t"
     transport_header: str = "RTP/AVP/TCP;unicast;interleaved=0-1"
+    setup_session_header: str | None = "homesec-talk;timeout=60"
+    content_base_header: str | None = None
+    content_location_header: str | None = None
+    interleaved_before_response_methods: set[str] = field(default_factory=set)
     sdp_body: bytes = field(default_factory=lambda: _BACKCHANNEL_SDP.encode())
     requests: list[_RTSPRequest] = field(default_factory=list)
     interleaved_before_play: list[tuple[int, bytes]] = field(default_factory=list)
@@ -102,6 +110,8 @@ class _FakeRTSPBackchannelServer:
                 request = await self._read_request(first, reader)
                 self.requests.append(request)
                 response = self._response_for(request)
+                if request.method in self.interleaved_before_response_methods:
+                    writer.write(_interleaved_frame(channel=1, payload=b"rtcp"))
                 writer.write(response)
                 await writer.drain()
                 if request.method == "PLAY" and self.play_status == 200:
@@ -133,6 +143,12 @@ class _FakeRTSPBackchannelServer:
             await reader.readexactly(content_length)
         return _RTSPRequest(method=method, uri=uri, headers=headers)
 
+    def _digest_challenge_header(self) -> str:
+        parts = ['Digest realm="homesec-fake"', 'nonce="digest-nonce"']
+        if self.digest_qop is not None:
+            parts.append(f'qop="{self.digest_qop}"')
+        return ", ".join(parts)
+
     def _response_for(self, request: _RTSPRequest) -> bytes:
         cseq = request.headers.get("cseq", "1")
         if request.method == "DESCRIBE":
@@ -147,24 +163,36 @@ class _FakeRTSPBackchannelServer:
                         reason="Unauthorized",
                         headers={"WWW-Authenticate": 'Basic realm="homesec-fake"'},
                     )
+            if self.require_digest_auth and not _digest_authorization_matches(request, self):
+                return _rtsp_response(
+                    cseq=cseq,
+                    status=401,
+                    reason="Unauthorized",
+                    headers={"WWW-Authenticate": self._digest_challenge_header()},
+                )
             if self.describe_status != 200:
                 return _rtsp_response(
                     cseq=cseq, status=self.describe_status, reason="Option Not Supported"
                 )
+            headers = {"Content-Type": "application/sdp"}
+            if self.content_base_header is not None:
+                headers["Content-Base"] = self.content_base_header
+            if self.content_location_header is not None:
+                headers["Content-Location"] = self.content_location_header
             return _rtsp_response(
                 cseq=cseq,
-                headers={"Content-Type": "application/sdp"},
+                headers=headers,
                 body=self.sdp_body,
             )
         if request.method == "SETUP":
             if self.setup_status != 200:
                 return _rtsp_response(cseq=cseq, status=self.setup_status, reason="Setup Failed")
+            headers = {"Transport": self.transport_header}
+            if self.setup_session_header is not None:
+                headers["Session"] = self.setup_session_header
             return _rtsp_response(
                 cseq=cseq,
-                headers={
-                    "Transport": self.transport_header,
-                    "Session": "homesec-talk;timeout=60",
-                },
+                headers=headers,
             )
         if request.method == "PLAY":
             if self.play_status == 200:
@@ -222,6 +250,52 @@ def _rtsp_response(
     lines = [f"RTSP/1.0 {status} {reason}"]
     lines.extend(f"{name}: {value}" for name, value in merged.items())
     return ("\r\n".join(lines) + "\r\n\r\n").encode("iso-8859-1") + body
+
+
+def _interleaved_frame(*, channel: int, payload: bytes) -> bytes:
+    return b"$" + bytes([channel]) + len(payload).to_bytes(2, "big") + payload
+
+
+def _digest_authorization_matches(
+    request: _RTSPRequest,
+    server: _FakeRTSPBackchannelServer,
+) -> bool:
+    authorization = request.headers.get("authorization")
+    if authorization is None or not authorization.startswith("Digest "):
+        return False
+    values = _parse_digest_values(authorization.removeprefix("Digest "))
+    if values.get("username") != server.basic_username:
+        return False
+    if values.get("realm") != "homesec-fake" or values.get("nonce") != "digest-nonce":
+        return False
+    if values.get("uri") != request.uri:
+        return False
+
+    algorithm = values.get("algorithm", "MD5")
+    if algorithm.upper() != "MD5":
+        return False
+    ha1 = _md5(f"{server.basic_username}:homesec-fake:{server.basic_password}")
+    ha2 = _md5(f"{request.method}:{request.uri}")
+    qop = values.get("qop")
+    if qop:
+        expected = _md5(f"{ha1}:digest-nonce:{values.get('nc')}:{values.get('cnonce')}:{qop}:{ha2}")
+    else:
+        expected = _md5(f"{ha1}:digest-nonce:{ha2}")
+    return values.get("response") == expected
+
+
+def _parse_digest_values(value: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for match in re.finditer(r'(\w+)=("(?:[^"\\]|\\.)*"|[^,]+)', value):
+        raw = match.group(2).strip()
+        if raw.startswith('"') and raw.endswith('"'):
+            raw = raw[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+        result[match.group(1).lower()] = raw
+    return result
+
+
+def _md5(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def _pcm_frame_16khz_20ms() -> bytes:
@@ -308,6 +382,52 @@ async def test_onvif_backchannel_uses_camera_selected_interleaved_channel() -> N
 
 
 @pytest.mark.asyncio
+async def test_onvif_backchannel_skips_interleaved_frames_before_control_response() -> None:
+    server = _FakeRTSPBackchannelServer(interleaved_before_response_methods={"PLAY"})
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        session = await adapter.open_session(session_id="talk-1")
+        await session.close()
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == [
+        "DESCRIBE",
+        "SETUP",
+        "PLAY",
+        "TEARDOWN",
+    ]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.parametrize("header_attr", ["content_base_header", "content_location_header"])
+@pytest.mark.asyncio
+async def test_onvif_backchannel_uses_response_base_for_relative_controls(
+    header_attr: str,
+) -> None:
+    server = _FakeRTSPBackchannelServer()
+    await server.start()
+    setattr(server, header_attr, f"{server.url}/response-base/")
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        session = await adapter.open_session(session_id="talk-1")
+        await session.close()
+    finally:
+        await server.stop()
+
+    setup_request = next(request for request in server.requests if request.method == "SETUP")
+    assert setup_request.uri == f"{server.url}/response-base/trackID=backchannel"
+
+
+@pytest.mark.asyncio
 async def test_onvif_backchannel_maps_describe_551_to_unsupported() -> None:
     server = _FakeRTSPBackchannelServer(describe_status=551)
     await server.start()
@@ -375,6 +495,40 @@ async def test_onvif_backchannel_retries_basic_auth_from_url_credentials() -> No
     assert server.interleaved_after_play == []
 
 
+@pytest.mark.parametrize("digest_qop", [None, "auth"])
+@pytest.mark.asyncio
+async def test_onvif_backchannel_retries_digest_auth_from_config_credentials(
+    digest_qop: str | None,
+) -> None:
+    server = _FakeRTSPBackchannelServer(require_digest_auth=True, digest_qop=digest_qop)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(
+                rtsp_url=server.url,
+                username="alice",
+                password="s3cr@t",
+            ),
+            camera_name="front_door",
+        )
+        session = await adapter.open_session(session_id="talk-1")
+        await session.close()
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == [
+        "DESCRIBE",
+        "DESCRIBE",
+        "SETUP",
+        "PLAY",
+        "TEARDOWN",
+    ]
+    assert server.requests[1].headers["authorization"].startswith("Digest ")
+    assert "@" not in server.requests[1].uri
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
 @pytest.mark.asyncio
 async def test_onvif_backchannel_fails_auth_when_credentials_are_missing() -> None:
     server = _FakeRTSPBackchannelServer(require_basic_auth=True)
@@ -415,6 +569,29 @@ async def test_onvif_backchannel_fails_auth_when_camera_rejects_retry() -> None:
 
 
 @pytest.mark.asyncio
+async def test_onvif_backchannel_fails_digest_auth_when_camera_rejects_retry() -> None:
+    server = _FakeRTSPBackchannelServer(require_digest_auth=True)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(
+                rtsp_url=server.url,
+                username="alice",
+                password="wrong",
+            ),
+            camera_name="front_door",
+        )
+        with pytest.raises(RTSPAuthenticationError, match="rejected"):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE", "DESCRIBE"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
 async def test_onvif_backchannel_rejects_setup_failure_before_audio() -> None:
     server = _FakeRTSPBackchannelServer(setup_status=454)
     await server.start()
@@ -424,6 +601,25 @@ async def test_onvif_backchannel_rejects_setup_failure_before_audio() -> None:
             camera_name="front_door",
         )
         with pytest.raises(CameraRejectedTalkSessionError):
+            await adapter.open_session(session_id="talk-1")
+    finally:
+        await server.stop()
+
+    assert [request.method for request in server.requests] == ["DESCRIBE", "SETUP"]
+    assert server.interleaved_before_play == []
+    assert server.interleaved_after_play == []
+
+
+@pytest.mark.asyncio
+async def test_onvif_backchannel_rejects_setup_200_without_session_before_play() -> None:
+    server = _FakeRTSPBackchannelServer(setup_session_header=None)
+    await server.start()
+    try:
+        adapter = ONVIFBackchannelAdapter(
+            ONVIFBackchannelConfig(rtsp_url=server.url),
+            camera_name="front_door",
+        )
+        with pytest.raises(CameraRejectedTalkSessionError, match="Session"):
             await adapter.open_session(session_id="talk-1")
     finally:
         await server.stop()
@@ -447,7 +643,12 @@ async def test_onvif_backchannel_rejects_play_failure_before_audio() -> None:
     finally:
         await server.stop()
 
-    assert [request.method for request in server.requests] == ["DESCRIBE", "SETUP", "PLAY"]
+    assert [request.method for request in server.requests] == [
+        "DESCRIBE",
+        "SETUP",
+        "PLAY",
+        "TEARDOWN",
+    ]
     assert server.interleaved_before_play == []
     assert server.interleaved_after_play == []
 

--- a/tests/homesec/rtsp/talk/test_rtsp_auth_client.py
+++ b/tests/homesec/rtsp/talk/test_rtsp_auth_client.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import base64
+
+from homesec.sources.rtsp.talk.rtsp_auth import (
+    RTSPCredentials,
+    build_authorization_header,
+    parse_www_authenticate,
+    redact_rtsp_url,
+    split_rtsp_url_credentials,
+)
+from homesec.sources.rtsp.talk.rtsp_client import RTSPResponse, parse_interleaved_channels
+
+
+def test_basic_auth_header() -> None:
+    challenge = parse_www_authenticate('Basic realm="camera"')
+
+    header = build_authorization_header(
+        challenge=challenge,
+        method="DESCRIBE",
+        uri="rtsp://camera.local/stream",
+        credentials=RTSPCredentials(username="user", password="pass"),
+    )
+
+    assert header == "Basic " + base64.b64encode(b"user:pass").decode("ascii")
+
+
+def test_digest_auth_matches_rfc_2617_vector() -> None:
+    challenge = parse_www_authenticate(
+        'Digest realm="testrealm@host.com", '
+        'qop="auth,auth-int", '
+        'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", '
+        'opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+    )
+
+    header = build_authorization_header(
+        challenge=challenge,
+        method="GET",
+        uri="/dir/index.html",
+        credentials=RTSPCredentials(username="Mufasa", password="Circle Of Life"),
+        nonce_count=1,
+        cnonce="0a4f113b",
+    )
+
+    assert 'response="6629fae49393a05397450978507c4ef1"' in header
+    assert "qop=auth" in header
+    assert "nc=00000001" in header
+
+
+def test_rtsp_url_credentials_are_split_and_redacted() -> None:
+    clean, credentials = split_rtsp_url_credentials("rtsp://alice:s3cr%40t@camera.local:8554/live")
+
+    assert clean == "rtsp://camera.local:8554/live"
+    assert credentials == RTSPCredentials(username="alice", password="s3cr@t")
+    assert redact_rtsp_url("rtsp://alice:s3cr%40t@camera.local:8554/live") == (
+        "rtsp://camera.local:8554/live"
+    )
+
+
+def test_rtsp_response_parser_handles_headers_and_body() -> None:
+    raw = (
+        b"RTSP/1.0 200 OK\r\n"
+        b"CSeq: 3\r\n"
+        b"Session: abc;timeout=60\r\n"
+        b"Content-Length: 4\r\n"
+        b"\r\n"
+        b"testextra"
+    )
+
+    response = RTSPResponse.parse(raw)
+
+    assert response.status_code == 200
+    assert response.reason == "OK"
+    assert response.header("session") == "abc;timeout=60"
+    assert response.body == b"test"
+
+
+def test_parse_interleaved_channels() -> None:
+    assert parse_interleaved_channels("RTP/AVP/TCP;unicast;interleaved=2-3") == (2, 3)
+    assert parse_interleaved_channels("RTP/AVP;unicast;client_port=10-11") is None

--- a/tests/homesec/rtsp/talk/test_rtsp_auth_client.py
+++ b/tests/homesec/rtsp/talk/test_rtsp_auth_client.py
@@ -1,15 +1,29 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 
+import pytest
+
+from homesec.sources.rtsp.talk.errors import RTSPProtocolError
 from homesec.sources.rtsp.talk.rtsp_auth import (
     RTSPCredentials,
     build_authorization_header,
     parse_www_authenticate,
     redact_rtsp_url,
+    request_uri_without_credentials,
     split_rtsp_url_credentials,
 )
-from homesec.sources.rtsp.talk.rtsp_client import RTSPResponse, parse_interleaved_channels
+from homesec.sources.rtsp.talk.rtsp_client import (
+    RTSPClient,
+    RTSPConnectionConfig,
+    RTSPResponse,
+    parse_interleaved_channels,
+)
+
+
+def _md5(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 def test_basic_auth_header() -> None:
@@ -43,8 +57,89 @@ def test_digest_auth_matches_rfc_2617_vector() -> None:
     )
 
     assert 'response="6629fae49393a05397450978507c4ef1"' in header
+    assert 'opaque="5ccc069c403ebaf9f0171e9517f40e41"' in header
     assert "qop=auth" in header
     assert "nc=00000001" in header
+
+
+def test_digest_auth_supports_md5_sess() -> None:
+    challenge = parse_www_authenticate(
+        'Digest realm="camera", nonce="abc", algorithm=MD5-sess, qop="auth"'
+    )
+    method = "ANNOUNCE"
+    uri = "rtsp://camera.local/talk"
+    credentials = RTSPCredentials(username="alice", password="secret")
+    ha1 = _md5(f"{credentials.username}:camera:{credentials.password}")
+    ha1_sess = _md5(f"{ha1}:abc:clientnonce")
+    ha2 = _md5(f"{method}:{uri}")
+    expected = _md5(f"{ha1_sess}:abc:00000002:clientnonce:auth:{ha2}")
+
+    header = build_authorization_header(
+        challenge=challenge,
+        method=method,
+        uri=uri,
+        credentials=credentials,
+        nonce_count=2,
+        cnonce="clientnonce",
+    )
+
+    assert "algorithm=MD5-sess" in header
+    assert f'response="{expected}"' in header
+    assert "nc=00000002" in header
+
+
+def test_digest_auth_supports_no_qop_challenge() -> None:
+    challenge = parse_www_authenticate('Digest realm="camera", nonce="abc"')
+    method = "DESCRIBE"
+    uri = "rtsp://camera.local/live"
+    credentials = RTSPCredentials(username="alice", password="secret")
+    expected = _md5(
+        f"{_md5(f'{credentials.username}:camera:{credentials.password}')}:abc:{_md5(f'{method}:{uri}')}"
+    )
+
+    header = build_authorization_header(
+        challenge=challenge,
+        method=method,
+        uri=uri,
+        credentials=credentials,
+    )
+
+    assert f'response="{expected}"' in header
+    assert "qop=" not in header
+    assert "nc=" not in header
+    assert "cnonce=" not in header
+
+
+@pytest.mark.parametrize(
+    ("header", "match"),
+    [
+        ('Bearer realm="camera"', "Unsupported RTSP auth scheme"),
+        ('Digest nonce="abc"', "realm and nonce"),
+        ('Digest realm="camera"', "realm and nonce"),
+        ('Digest realm="camera", nonce="abc", algorithm=SHA-256', "algorithm"),
+    ],
+)
+def test_authorization_rejects_unsupported_or_incomplete_challenges(
+    header: str,
+    match: str,
+) -> None:
+    challenge = parse_www_authenticate(header)
+
+    with pytest.raises(ValueError, match=match):
+        build_authorization_header(
+            challenge=challenge,
+            method="DESCRIBE",
+            uri="rtsp://camera.local/live",
+            credentials=RTSPCredentials(username="alice", password="secret"),
+        )
+
+
+def test_parse_authenticate_without_parameters() -> None:
+    challenge = parse_www_authenticate("Negotiate")
+
+    assert challenge.scheme == "negotiate"
+    assert challenge.params == {}
+    assert challenge.realm is None
 
 
 def test_rtsp_url_credentials_are_split_and_redacted() -> None:
@@ -55,6 +150,26 @@ def test_rtsp_url_credentials_are_split_and_redacted() -> None:
     assert redact_rtsp_url("rtsp://alice:s3cr%40t@camera.local:8554/live") == (
         "rtsp://camera.local:8554/live"
     )
+    assert request_uri_without_credentials("rtsp://alice:pw@camera.local/live") == (
+        "rtsp://camera.local/live"
+    )
+
+
+def test_rtsp_url_helpers_preserve_ipv6_hosts() -> None:
+    url = "rtsp://alice:p%40ss@[2001:db8::1]:8554/live?profile=main"
+
+    clean, credentials = split_rtsp_url_credentials(url)
+
+    assert clean == "rtsp://[2001:db8::1]:8554/live?profile=main"
+    assert credentials == RTSPCredentials(username="alice", password="p@ss")
+    assert redact_rtsp_url(url) == "rtsp://[2001:db8::1]:8554/live?profile=main"
+
+
+def test_rtsp_url_helpers_allow_urls_without_credentials() -> None:
+    url = "rtsp://camera.local/live"
+
+    assert split_rtsp_url_credentials(url) == (url, None)
+    assert redact_rtsp_url(url) == url
 
 
 def test_rtsp_response_parser_handles_headers_and_body() -> None:
@@ -75,6 +190,62 @@ def test_rtsp_response_parser_handles_headers_and_body() -> None:
     assert response.body == b"test"
 
 
+def test_rtsp_response_parser_combines_duplicate_headers() -> None:
+    raw = b"RTSP/1.0 200 OK\r\nX-Test: one\r\nX-Test: two\r\n\r\n"
+
+    response = RTSPResponse.parse(raw)
+
+    assert response.header("X-Test") == "one, two"
+
+
+@pytest.mark.parametrize(
+    ("raw", "match"),
+    [
+        (b"RTSP/1.0 200 OK\r\n", "header terminator"),
+        (b"HTTP/1.1 200 OK\r\n\r\n", "status line"),
+        (b"RTSP/1.0 200 OK\r\nnot-a-header\r\n\r\n", "header line"),
+        (b"RTSP/1.0 200 OK\r\nContent-Length: 4\r\n\r\na", "shorter"),
+    ],
+)
+def test_rtsp_response_parser_rejects_malformed_responses(raw: bytes, match: str) -> None:
+    with pytest.raises(RTSPProtocolError, match=match):
+        RTSPResponse.parse(raw)
+
+
 def test_parse_interleaved_channels() -> None:
     assert parse_interleaved_channels("RTP/AVP/TCP;unicast;interleaved=2-3") == (2, 3)
+    assert parse_interleaved_channels("RTP/AVP/TCP; interleaved = 10 - 11") == (10, 11)
     assert parse_interleaved_channels("RTP/AVP;unicast;client_port=10-11") is None
+
+
+@pytest.mark.asyncio
+async def test_rtsp_client_connect_rejects_invalid_urls() -> None:
+    with pytest.raises(ValueError, match="rtsp://"):
+        await RTSPClient(RTSPConnectionConfig(url="http://camera.local/live")).connect()
+
+    with pytest.raises(ValueError, match="host"):
+        await RTSPClient(RTSPConnectionConfig(url="rtsp:///live")).connect()
+
+
+@pytest.mark.asyncio
+async def test_rtsp_client_requires_connection_before_requests_or_frames() -> None:
+    client = RTSPClient(RTSPConnectionConfig(url="rtsp://camera.local/live"))
+
+    with pytest.raises(RuntimeError, match="not connected"):
+        await client.describe()
+
+    with pytest.raises(RuntimeError, match="not connected"):
+        await client.send_interleaved_frame(0, b"payload")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_rtsp_client_validates_interleaved_frame_shape_before_write() -> None:
+    client = RTSPClient(RTSPConnectionConfig(url="rtsp://camera.local/live"))
+
+    with pytest.raises(ValueError, match="range"):
+        await client.send_interleaved_frame(-1, b"payload")
+
+    with pytest.raises(ValueError, match="65535"):
+        await client.send_interleaved_frame(0, b"x" * 0x10000)

--- a/tests/homesec/rtsp/talk/test_sdp.py
+++ b/tests/homesec/rtsp/talk/test_sdp.py
@@ -47,6 +47,101 @@ def test_select_audio_backchannel_honors_codec_order_and_control_url() -> None:
     assert selected.control == "rtsp://camera.example/Streaming/Channels/101/trackID=backchannel"
 
 
+def test_select_audio_backchannel_uses_session_level_sendonly() -> None:
+    sdp = """v=0
+s=session-level direction
+
+a=sendonly
+a=control:rtsp://camera.example/base
+m=audio 0 RTP/AVP 0
+a=control:trackID=backchannel
+"""
+
+    selected = select_audio_backchannel(
+        sdp,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/base",
+    )
+
+    assert selected.payload_type == 0
+    assert selected.control == "rtsp://camera.example/base/trackID=backchannel"
+
+
+def test_select_audio_backchannel_uses_static_payload_type_without_rtpmap() -> None:
+    sdp = """v=0
+s=static payload
+m=audio 0 RTP/AVP 0
+a=sendonly
+a=control:backchannel
+"""
+
+    selected = select_audio_backchannel(
+        sdp,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/live",
+    )
+
+    assert selected.selected_codec == "PCMU/8000"
+    assert selected.control == "rtsp://camera.example/live/backchannel"
+
+
+def test_select_audio_backchannel_preserves_absolute_control_url() -> None:
+    sdp = _BACKCHANNEL_SDP.replace(
+        "a=control:trackID=backchannel",
+        "a=control:rtsp://media.example/talk",
+    )
+
+    selected = select_audio_backchannel(
+        sdp,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/live",
+    )
+
+    assert selected.control == "rtsp://media.example/talk"
+
+
+def test_select_audio_backchannel_maps_aggregate_control_to_base_url() -> None:
+    sdp = _BACKCHANNEL_SDP.replace("a=control:trackID=backchannel", "a=control:*")
+
+    selected = select_audio_backchannel(
+        sdp,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/live",
+    )
+
+    assert selected.control == "rtsp://camera.example/live"
+
+
+def test_parse_sdp_ignores_malformed_lines_and_applies_fmtp_to_known_codec() -> None:
+    sdp = """v=0
+s=malformed resilience
+m=audio nope RTP/AVP 0
+m=audio 0 RTP/AVP nope
+m=audio 0 RTP/AVP 99 98 0
+a=sendonly
+a=rtpmap:bad
+a=rtpmap:nope PCMU/8000
+a=rtpmap:97 BROKEN
+a=rtpmap:96 PCMU/nope
+a=rtpmap:98 PCMU/8000/2
+a=fmtp:bad
+a=fmtp:nope mode=ignore
+a=fmtp:99 orphan=true
+a=fmtp:98 mode=probe
+a=control:talk
+"""
+
+    description = parse_sdp(sdp)
+
+    assert len(description.media) == 1
+    audio = description.media[0]
+    assert audio.payload_types == [99, 98, 0]
+    assert audio.codec_for_payload(99) is None
+    assert audio.codec_for_payload(98).normalized_name == "PCMU/8000/2"  # type: ignore[union-attr]
+    assert audio.codec_for_payload(98).fmtp == "mode=probe"  # type: ignore[union-attr]
+    assert audio.codec_for_payload(0).normalized_name == "PCMU/8000"  # type: ignore[union-attr]
+
+
 def test_select_audio_backchannel_rejects_missing_sendonly_audio() -> None:
     sdp = _BACKCHANNEL_SDP.replace("a=sendonly", "a=recvonly")
 
@@ -57,3 +152,15 @@ def test_select_audio_backchannel_rejects_missing_sendonly_audio() -> None:
 def test_select_audio_backchannel_rejects_unsupported_codec() -> None:
     with pytest.raises(UnsupportedTalkCodecError):
         select_audio_backchannel(_BACKCHANNEL_SDP, preferred_codecs=["OPUS/48000"])
+
+
+def test_select_audio_backchannel_rejects_payloads_without_codec_mapping() -> None:
+    sdp = """v=0
+s=unknown dynamic payload
+m=audio 0 RTP/AVP 121
+a=sendonly
+a=control:talk
+"""
+
+    with pytest.raises(UnsupportedTalkCodecError):
+        select_audio_backchannel(sdp, preferred_codecs=["PCMU/8000"])

--- a/tests/homesec/rtsp/talk/test_sdp.py
+++ b/tests/homesec/rtsp/talk/test_sdp.py
@@ -112,6 +112,49 @@ def test_select_audio_backchannel_maps_aggregate_control_to_base_url() -> None:
     assert selected.control == "rtsp://camera.example/live"
 
 
+def test_select_audio_backchannel_handles_leading_slash_control_path() -> None:
+    sdp = _BACKCHANNEL_SDP.replace(
+        "a=control:trackID=backchannel",
+        "a=control:/Streaming/Channels/101/trackID=backchannel",
+    )
+
+    selected = select_audio_backchannel(
+        sdp,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/live?profile=main",
+    )
+
+    assert selected.control == "rtsp://camera.example/Streaming/Channels/101/trackID=backchannel"
+
+
+def test_select_audio_backchannel_appends_relative_control_before_base_query() -> None:
+    selected = select_audio_backchannel(
+        _BACKCHANNEL_SDP,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/live?profile=main",
+    )
+
+    assert selected.control == "rtsp://camera.example/live/trackID=backchannel"
+
+
+def test_select_audio_backchannel_uses_session_control_as_base_for_media_control() -> None:
+    sdp = """v=0
+s=session control base
+a=sendonly
+a=control:rtsp://camera.example/base/
+m=audio 0 RTP/AVP 0
+a=control:trackID=backchannel
+"""
+
+    selected = select_audio_backchannel(
+        sdp,
+        preferred_codecs=["PCMU/8000"],
+        base_control_url="rtsp://camera.example/fallback",
+    )
+
+    assert selected.control == "rtsp://camera.example/base/trackID=backchannel"
+
+
 def test_parse_sdp_ignores_malformed_lines_and_applies_fmtp_to_known_codec() -> None:
     sdp = """v=0
 s=malformed resilience

--- a/tests/homesec/rtsp/talk/test_sdp.py
+++ b/tests/homesec/rtsp/talk/test_sdp.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from homesec.sources.rtsp.talk.errors import (
+    CameraBackchannelUnsupportedError,
+    UnsupportedTalkCodecError,
+)
+from homesec.sources.rtsp.talk.sdp import parse_sdp, select_audio_backchannel
+
+_BACKCHANNEL_SDP = """v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=HomeSec fake camera
+t=0 0
+m=video 0 RTP/AVP 96
+a=recvonly
+a=rtpmap:96 H264/90000
+a=control:trackID=video
+m=audio 0 RTP/AVP 0 8
+a=sendonly
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=control:trackID=backchannel
+"""
+
+
+def test_parse_sdp_collects_sendonly_audio_codecs() -> None:
+    description = parse_sdp(_BACKCHANNEL_SDP)
+
+    audio = description.media[1]
+    assert audio.media == "audio"
+    assert audio.direction == "sendonly"
+    assert audio.payload_types == [0, 8]
+    assert audio.codec_for_payload(0).normalized_name == "PCMU/8000"  # type: ignore[union-attr]
+    assert audio.codec_for_payload(8).normalized_name == "PCMA/8000"  # type: ignore[union-attr]
+
+
+def test_select_audio_backchannel_honors_codec_order_and_control_url() -> None:
+    selected = select_audio_backchannel(
+        _BACKCHANNEL_SDP,
+        preferred_codecs=["PCMA/8000", "PCMU/8000"],
+        base_control_url="rtsp://camera.example/Streaming/Channels/101",
+    )
+
+    assert selected.payload_type == 8
+    assert selected.selected_codec == "PCMA/8000"
+    assert selected.control == "rtsp://camera.example/Streaming/Channels/101/trackID=backchannel"
+
+
+def test_select_audio_backchannel_rejects_missing_sendonly_audio() -> None:
+    sdp = _BACKCHANNEL_SDP.replace("a=sendonly", "a=recvonly")
+
+    with pytest.raises(CameraBackchannelUnsupportedError):
+        select_audio_backchannel(sdp, preferred_codecs=["PCMU/8000"])
+
+
+def test_select_audio_backchannel_rejects_unsupported_codec() -> None:
+    with pytest.raises(UnsupportedTalkCodecError):
+        select_audio_backchannel(_BACKCHANNEL_SDP, preferred_codecs=["OPUS/48000"])


### PR DESCRIPTION
## Summary

- Adds isolated ONVIF RTSP audio-backchannel protocol support under `src/homesec/sources/rtsp/talk/`.
- Adds SDP backchannel selection, RTSP Basic/Digest auth, TCP-interleaved RTP sending, RTP packetization, deterministic PCM resampling, and PCMU/G.711 μ-law encoding.
- Adds a fake RTSP backchannel test server covering success, no RTP before `PLAY 200 OK`, unsupported DESCRIBE, Basic/Digest auth retry/failure, setup failure, play failure, RTP packetization, SDP selection, and config validation.
- Adds broader Phase 1 coverage for resampler edge cases, malformed/variant SDP, RTSP response parser failures, auth variants, URL redaction, ONVIF session close/send failure behavior, and stable protocol error codes.
- Hardens review-flagged protocol edges: best-effort `TEARDOWN` after failed `PLAY`, rejection of `SETUP 200` without `Session`, Content-Base/Content-Location and session/media SDP control URL resolution, `$` interleaved frame skipping while waiting for responses, and removal of unused `require_onvif_backchannel` config.
- Adds `dev/talk_tone.py` as a manual Phase 1 real-camera probe that sends a generated tone through the protocol stack.

## Scope

Protocol spike only. No API, runtime IPC/worker, source integration, or UI wiring in this PR.

## Validation

- `uv run pytest tests/homesec/rtsp/talk -q` → 85 passed
- `uv run coverage run --source=src/homesec/sources/rtsp/talk -m pytest tests/homesec/rtsp/talk -q && uv run coverage report -m src/homesec/sources/rtsp/talk/*.py` → 97% focused package coverage
- `uv run pytest tests/homesec/test_config.py tests/homesec/rtsp/talk -q` → 122 passed
- `make typecheck` → passed
- `make lint` → passed
- `uv run python dev/talk_tone.py --help` → passed

Note: local full `make test` still requires a Postgres service on `127.0.0.1:5432`; latest local attempt reached 985 passing tests before 38 Postgres-backed tests errored with connection refused.

## Risks / follow-ups

- Real-camera confirmation still required for Phase 1 exit criteria.
- MVP intentionally restricts camera output codec to `PCMU/8000`; PCMA/G726 remain follow-ups.
- Next phase should wire this through RTSP source/runtime ownership without importing protocol details into API/UI.