### PR TITLE
feat: add phase 3 push-to-talk API contract

### DIFF
--- a/src/homesec/api/routes/talk.py
+++ b/src/homesec/api/routes/talk.py
@@ -84,10 +84,10 @@ class TalkWebSocketStartMessage(BaseModel):
     model_config = {"extra": "forbid"}
 
     type: Literal["start"]
-    codec: Literal["pcm_s16le"] = "pcm_s16le"
-    sample_rate: int = Field(default=16000, ge=8000, le=48000)
-    channels: int = Field(default=1, ge=1, le=1)
-    frame_ms: int = Field(default=20, ge=10, le=60)
+    codec: Literal["pcm_s16le"]
+    sample_rate: int = Field(ge=8000, le=48000)
+    channels: int = Field(ge=1, le=1)
+    frame_ms: int = Field(ge=10, le=60)
 
     def input_format(self) -> TalkInputFormat:
         return TalkInputFormat(
@@ -308,7 +308,6 @@ async def stream_talk_audio(
 
     await websocket.accept()
     if not await _authorize_talk_websocket(websocket, app, camera_name, session_id):
-        await _stop_talk_session_best_effort(app, camera_name, session_id)
         return
 
     input_format = await _receive_talk_start_message(websocket)

--- a/src/homesec/api/routes/talk.py
+++ b/src/homesec/api/routes/talk.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import secrets
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 from urllib.parse import quote, urlencode
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, status
@@ -36,8 +37,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _SESSION_ID_PATTERN = r"^[A-Za-z0-9._:-]+$"
+_TALK_WS_START_TYPE: Literal["start"] = "start"
 _TALK_WS_READY_TYPE = "ready"
-_TALK_WS_STOP_TYPE = "stop"
 
 control_router = APIRouter(tags=["talk"])
 stream_router = APIRouter(tags=["talk"])
@@ -69,11 +70,40 @@ class TalkSessionResponse(BaseModel):
     session_id: str
     state: TalkState
     input: TalkInputFormat
+    websocket_url: str
     stream_url: str
     token: str | None = None
     token_expires_at: datetime | None = None
     max_session_s: int
     idle_timeout_s: float
+
+
+class TalkWebSocketStartMessage(BaseModel):
+    """Client control message that starts a prepared talk stream."""
+
+    model_config = {"extra": "forbid"}
+
+    type: Literal["start"]
+    codec: Literal["pcm_s16le"] = "pcm_s16le"
+    sample_rate: int = Field(default=16000, ge=8000, le=48000)
+    channels: int = Field(default=1, ge=1, le=1)
+    frame_ms: int = Field(default=20, ge=10, le=60)
+
+    def input_format(self) -> TalkInputFormat:
+        return TalkInputFormat(
+            codec=self.codec,
+            sample_rate=self.sample_rate,
+            channels=self.channels,
+            frame_ms=self.frame_ms,
+        )
+
+
+class TalkWebSocketStopMessage(BaseModel):
+    """Client control message that ends a talk stream."""
+
+    model_config = {"extra": "forbid"}
+
+    type: Literal["stop"]
 
 
 class TalkStopResponse(BaseModel):
@@ -97,22 +127,15 @@ def _stream_url(
     camera_name: str,
     session_id: str,
     *,
-    input_format: TalkInputFormat,
     token: str | None = None,
 ) -> str:
     path = (
         f"/api/v1/talk/cameras/{quote(camera_name, safe='')}"
         f"/sessions/{quote(session_id, safe='')}/stream"
     )
-    query: dict[str, str] = {
-        "codec": input_format.codec,
-        "sample_rate": str(input_format.sample_rate),
-        "channels": str(input_format.channels),
-        "frame_ms": str(input_format.frame_ms),
-    }
-    if token is not None:
-        query["token"] = token
-    return f"{path}?{urlencode(query)}"
+    if token is None:
+        return path
+    return f"{path}?{urlencode({'token': token})}"
 
 
 def _new_session_id() -> str:
@@ -232,17 +255,18 @@ async def prepare_talk_session(
             ttl_s=talk_config.token_ttl_s,
         )
 
+    websocket_url = _stream_url(
+        camera_name,
+        outcome.session_id,
+        token=token,
+    )
     return TalkSessionResponse(
         camera_name=outcome.camera_name,
         session_id=outcome.session_id,
         state=TalkState.STARTING,
         input=outcome.input,
-        stream_url=_stream_url(
-            camera_name,
-            outcome.session_id,
-            input_format=outcome.input,
-            token=token,
-        ),
+        websocket_url=websocket_url,
+        stream_url=websocket_url,
         token=token,
         token_expires_at=expires_at,
         max_session_s=talk_config.max_session_s,
@@ -281,14 +305,17 @@ async def stream_talk_audio(
     app = await _get_websocket_app(websocket)
     if app is None:
         return
+
+    await websocket.accept()
     if not await _authorize_talk_websocket(websocket, app, camera_name, session_id):
+        await _stop_talk_session_best_effort(app, camera_name, session_id)
         return
-    input_format = await _talk_input_from_websocket(websocket, app)
+
+    input_format = await _receive_talk_start_message(websocket)
     if input_format is None:
         await _stop_talk_session_best_effort(app, camera_name, session_id)
         return
 
-    await websocket.accept()
     stream: RuntimeTalkStream | None = None
     stop_best_effort = True
     try:
@@ -336,6 +363,7 @@ async def stream_talk_audio(
                 "camera_name": camera_name,
                 "session_id": session_id,
                 "input": input_format.model_dump(mode="json"),
+                "camera_codec": stream.selected_codec,
             }
         )
         await _forward_websocket_frames(websocket, stream, input_format)
@@ -436,38 +464,59 @@ def _parse_websocket_bearer_token(websocket: WebSocket) -> str | None:
     return auth_header.removeprefix("Bearer ").strip()
 
 
-async def _talk_input_from_websocket(
-    websocket: WebSocket,
-    app: Application,
-) -> TalkInputFormat | None:
-    raw_query = websocket.query_params
-    payload: dict[str, Any] = {}
-    if (codec := raw_query.get("codec")) is not None:
-        payload["codec"] = codec
-    for name in ("sample_rate", "channels", "frame_ms"):
-        raw_value = raw_query.get(name)
-        if raw_value is None:
-            continue
-        try:
-            payload[name] = int(raw_value)
-        except ValueError:
-            await websocket.close(
-                code=status.WS_1008_POLICY_VIOLATION,
-                reason="Invalid talk input format",
-            )
-            return None
+async def _receive_talk_start_message(websocket: WebSocket) -> TalkInputFormat | None:
+    try:
+        message = await websocket.receive()
+    except WebSocketDisconnect:
+        return None
+    if message.get("type") == "websocket.disconnect":
+        return None
 
-    if not payload:
-        return app.config.talk.input
+    text_payload = message.get("text")
+    if text_payload is None:
+        await websocket.close(
+            code=status.WS_1003_UNSUPPORTED_DATA,
+            reason="Talk start message required",
+        )
+        return None
+
+    payload = _decode_talk_control_payload(text_payload)
+    if payload is None:
+        await websocket.close(
+            code=status.WS_1008_POLICY_VIOLATION,
+            reason="Invalid talk start message",
+        )
+        return None
 
     try:
-        return TalkInputFormat.model_validate(payload)
+        return TalkWebSocketStartMessage.model_validate(payload).input_format()
     except ValidationError:
         await websocket.close(
             code=status.WS_1008_POLICY_VIOLATION,
-            reason="Invalid talk input format",
+            reason="Invalid talk start message",
         )
         return None
+
+
+def _decode_talk_control_payload(text_payload: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(text_payload)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _is_talk_stop_message(text_payload: str) -> bool:
+    payload = _decode_talk_control_payload(text_payload)
+    if payload is None:
+        return False
+    try:
+        TalkWebSocketStopMessage.model_validate(payload)
+    except ValidationError:
+        return False
+    return True
 
 
 async def _forward_websocket_frames(
@@ -504,7 +553,7 @@ async def _forward_websocket_frames(
             continue
 
         text_payload = message.get("text")
-        if text_payload == _TALK_WS_STOP_TYPE:
+        if text_payload is not None and _is_talk_stop_message(text_payload):
             await websocket.close(code=status.WS_1000_NORMAL_CLOSURE, reason="Talk stopped")
             return
         await websocket.close(

--- a/src/homesec/runtime/models.py
+++ b/src/homesec/runtime/models.py
@@ -146,6 +146,7 @@ class RuntimeTalkStream:
     input: TalkInputFormat
     reader: asyncio.StreamReader
     writer: asyncio.StreamWriter
+    selected_codec: str | None = None
 
 
 @dataclass(slots=True)

--- a/src/homesec/runtime/subprocess_controller.py
+++ b/src/homesec/runtime/subprocess_controller.py
@@ -773,6 +773,9 @@ class SubprocessRuntimeController(RuntimeController):
                 raise TalkRuntimeUnavailableError(
                     result.error_message or f"Runtime talk command failed: {result.error_code}"
                 )
+            selected_codec = (
+                result.talk_status.selected_codec if result.talk_status is not None else None
+            )
             close_writer = False
             return RuntimeTalkStream(
                 camera_name=camera_name,
@@ -780,6 +783,7 @@ class SubprocessRuntimeController(RuntimeController):
                 input=input_format,
                 reader=reader,
                 writer=writer,
+                selected_codec=selected_codec,
             )
         except TalkRuntimeUnavailableError:
             raise

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -673,6 +673,7 @@ def test_talk_websocket_cleans_up_reserved_session_on_invalid_start_message() ->
         (b"not json", 1003),
         ("not json", 1008),
         (json.dumps(["not", "an", "object"]), 1008),
+        (json.dumps({"type": "start"}), 1008),
         (json.dumps({"type": "start", "unexpected": True}), 1008),
     ],
 )
@@ -933,6 +934,30 @@ def test_talk_websocket_accepts_bearer_api_key_when_auth_enabled(
     assert app.open_calls == [("front", "session-1", TalkInputFormat())]
 
 
+def test_talk_websocket_rejects_wrong_bearer_api_key_without_runtime_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wrong bearer credentials should fail auth without stopping a reserved session."""
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret")
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    client = _client(app)
+
+    with (
+        client.websocket_connect(
+            "/api/v1/talk/cameras/front/sessions/session-1/stream",
+            headers={"Authorization": "Bearer wrong-secret"},
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
+    ):
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1008
+    assert app.open_calls == []
+    assert app.stop_calls == []
+
+
 def test_talk_websocket_rejects_auth_when_api_key_missing() -> None:
     """Auth-enabled WebSockets should not fall back open if the API key is absent."""
     app = _StubTalkApp(
@@ -953,7 +978,7 @@ def test_talk_websocket_rejects_auth_when_api_key_missing() -> None:
 
     assert disconnect.value.code == 1011
     assert app.open_calls == []
-    assert app.stop_calls == [("front", "session-1")]
+    assert app.stop_calls == []
 
 
 def test_talk_websocket_rejects_missing_token_when_auth_enabled(
@@ -976,7 +1001,7 @@ def test_talk_websocket_rejects_missing_token_when_auth_enabled(
 
     assert disconnect.value.code == 1008
     assert app.open_calls == []
-    assert app.stop_calls == [("front", "session-1")]
+    assert app.stop_calls == []
 
 
 def test_talk_websocket_rejects_expired_token_when_auth_enabled(
@@ -1006,7 +1031,7 @@ def test_talk_websocket_rejects_expired_token_when_auth_enabled(
 
     assert disconnect.value.code == 1008
     assert app.open_calls == []
-    assert app.stop_calls == [("front", "session-1")]
+    assert app.stop_calls == []
 
 
 def test_talk_websocket_rejects_wrong_purpose_token_when_auth_enabled(
@@ -1045,4 +1070,4 @@ def test_talk_websocket_rejects_wrong_purpose_token_when_auth_enabled(
 
     assert disconnect.value.code == 1008
     assert app.open_calls == []
-    assert app.stop_calls == [("front", "session-1")]
+    assert app.stop_calls == []

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import cast
 from urllib.parse import parse_qs, urlparse
@@ -11,8 +13,9 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+import homesec.api.talk_tokens as talk_tokens
 from homesec.api.server import create_app
-from homesec.api.talk_tokens import validate_camera_talk_token
+from homesec.api.talk_tokens import issue_camera_talk_token, validate_camera_talk_token
 from homesec.models.config import FastAPIServerConfig, TalkConfig
 from homesec.models.talk import CameraTalkStatus, TalkInputFormat, TalkRefusalReason, TalkState
 from homesec.runtime.errors import (
@@ -149,6 +152,7 @@ class _StubTalkApp:
             input=input_format,
             reader=cast(asyncio.StreamReader, object()),
             writer=cast(asyncio.StreamWriter, self.stream_writer),
+            selected_codec=self._status.selected_codec or "PCMU/8000",
         )
 
     async def stop_camera_talk_session(
@@ -165,6 +169,14 @@ class _StubTalkApp:
 
 def _client(app: _StubTalkApp) -> TestClient:
     return TestClient(create_app(app))
+
+
+def _start_message(input_format: TalkInputFormat) -> str:
+    return json.dumps({"type": "start", **input_format.model_dump(mode="json")})
+
+
+def _stop_message() -> str:
+    return json.dumps({"type": "stop"})
 
 
 def test_get_talk_status_returns_runtime_status() -> None:
@@ -197,7 +209,51 @@ def test_get_talk_status_returns_runtime_status() -> None:
     }
 
 
-def test_prepare_talk_session_returns_stream_url_and_runtime_contract() -> None:
+def test_get_talk_status_returns_disabled_camera_status() -> None:
+    """Disabled talk status should be reported without opening a session."""
+    app = _StubTalkApp(
+        status=CameraTalkStatus(
+            camera_name="front",
+            enabled=False,
+            state=TalkState.DISABLED,
+            supported_codecs=[],
+            selected_codec=None,
+            last_error=None,
+        )
+    )
+    client = _client(app)
+
+    response = client.get("/api/v1/talk/cameras/front")
+
+    assert response.status_code == 200
+    assert response.json()["enabled"] is False
+    assert response.json()["state"] == "disabled"
+    assert app.open_calls == []
+
+
+def test_get_talk_status_returns_unsupported_source_status() -> None:
+    """Unsupported sources should surface as talk status rather than session opens."""
+    app = _StubTalkApp(
+        status=CameraTalkStatus(
+            camera_name="front",
+            enabled=True,
+            state=TalkState.UNSUPPORTED,
+            supported_codecs=[],
+            selected_codec=None,
+            last_error="Source does not support talk",
+        )
+    )
+    client = _client(app)
+
+    response = client.get("/api/v1/talk/cameras/front")
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "unsupported"
+    assert response.json()["last_error"] == "Source does not support talk"
+    assert app.open_calls == []
+
+
+def test_prepare_talk_session_returns_websocket_url_and_runtime_contract() -> None:
     """POST /talk/cameras/{camera_name}/sessions should reserve and describe a stream."""
     input_format = TalkInputFormat(sample_rate=8000, frame_ms=20)
     app = _StubTalkApp(
@@ -225,14 +281,10 @@ def test_prepare_talk_session_returns_stream_url_and_runtime_contract() -> None:
     assert payload["token_expires_at"] is None
     assert payload["max_session_s"] == 45
     assert payload["idle_timeout_s"] == 1.5
-    parsed = urlparse(payload["stream_url"])
+    assert payload["websocket_url"] == payload["stream_url"]
+    parsed = urlparse(payload["websocket_url"])
     assert parsed.path == "/api/v1/talk/cameras/front/sessions/custom-session/stream"
-    assert parse_qs(parsed.query) == {
-        "codec": ["pcm_s16le"],
-        "sample_rate": ["8000"],
-        "channels": ["1"],
-        "frame_ms": ["20"],
-    }
+    assert parse_qs(parsed.query) == {}
     assert app.prepare_calls == [("front", "custom-session", input_format)]
 
 
@@ -263,7 +315,8 @@ def test_prepare_talk_session_mints_short_lived_stream_token_when_auth_enabled(
     token = payload["token"]
     assert isinstance(token, str)
     assert payload["token_expires_at"] is not None
-    assert parse_qs(urlparse(payload["stream_url"]).query)["token"] == [token]
+    assert payload["websocket_url"] == payload["stream_url"]
+    assert parse_qs(urlparse(payload["websocket_url"]).query)["token"] == [token]
     decoded = validate_camera_talk_token(
         api_key="secret",
         token=token,
@@ -288,6 +341,23 @@ def test_talk_control_routes_require_api_key_when_auth_enabled(
 
     assert response.status_code == 401
     assert response.json()["error_code"] == "UNAUTHORIZED"
+
+
+def test_prepare_talk_session_requires_api_key_when_auth_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The session-creation route should require normal API authentication."""
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret")
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    client = _client(app)
+
+    response = client.post("/api/v1/talk/cameras/front/sessions", json={"session_id": "s1"})
+
+    assert response.status_code == 401
+    assert response.json()["error_code"] == "UNAUTHORIZED"
+    assert app.prepare_calls == []
 
 
 def test_prepare_talk_session_maps_runtime_refusal_to_api_error() -> None:
@@ -353,16 +423,17 @@ def test_talk_websocket_forwards_binary_frames_to_runtime_stream() -> None:
 
     with client.websocket_connect(
         "/api/v1/talk/cameras/front/sessions/session-1/stream"
-        "?codec=pcm_s16le&sample_rate=8000&channels=1&frame_ms=10"
     ) as websocket:
+        websocket.send_text(_start_message(input_format))
         assert websocket.receive_json() == {
             "type": "ready",
             "camera_name": "front",
             "session_id": "session-1",
             "input": input_format.model_dump(mode="json"),
+            "camera_codec": "PCMU/8000",
         }
         websocket.send_bytes(frame)
-        websocket.send_text("stop")
+        websocket.send_text(_stop_message())
         with pytest.raises(WebSocketDisconnect):
             websocket.receive_text()
 
@@ -388,12 +459,12 @@ def test_talk_websocket_forwards_multiple_binary_frames_to_runtime_stream() -> N
 
     with client.websocket_connect(
         "/api/v1/talk/cameras/front/sessions/session-1/stream"
-        "?codec=pcm_s16le&sample_rate=8000&channels=1&frame_ms=10"
     ) as websocket:
+        websocket.send_text(_start_message(input_format))
         websocket.receive_json()
         websocket.send_bytes(first_frame)
         websocket.send_bytes(second_frame)
-        websocket.send_text("stop")
+        websocket.send_text(_stop_message())
         with pytest.raises(WebSocketDisconnect):
             websocket.receive_text()
 
@@ -418,8 +489,8 @@ def test_talk_websocket_rejects_invalid_audio_frame_length() -> None:
 
     with client.websocket_connect(
         "/api/v1/talk/cameras/front/sessions/session-1/stream"
-        "?codec=pcm_s16le&sample_rate=8000&channels=1&frame_ms=10"
     ) as websocket:
+        websocket.send_text(_start_message(input_format))
         websocket.receive_json()
         websocket.send_bytes(b"too short")
         with pytest.raises(WebSocketDisconnect):
@@ -429,19 +500,36 @@ def test_talk_websocket_rejects_invalid_audio_frame_length() -> None:
     assert app.stop_calls == [("front", "session-1")]
 
 
-def test_talk_websocket_cleans_up_reserved_session_on_invalid_input_query() -> None:
-    """Invalid attach parameters should not leave a reserved talk slot behind."""
+def test_talk_websocket_cleans_up_reserved_session_on_invalid_start_message() -> None:
+    """Invalid start control messages should not leave a reserved talk slot behind."""
     app = _StubTalkApp()
     client = _client(app)
 
-    with (
-        pytest.raises(WebSocketDisconnect),
-        client.websocket_connect(
-            "/api/v1/talk/cameras/front/sessions/session-1/stream?sample_rate=not-an-int"
-        ),
-    ):
-        pass
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream"
+    ) as websocket:
+        websocket.send_text(json.dumps({"type": "start", "sample_rate": "not-an-int"}))
+        with pytest.raises(WebSocketDisconnect) as disconnect:
+            websocket.receive_text()
 
+    assert disconnect.value.code == 1008
+    assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_rejects_start_message_without_type() -> None:
+    """Start control messages must be explicit, not inferred from defaults."""
+    app = _StubTalkApp()
+    client = _client(app)
+
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream"
+    ) as websocket:
+        websocket.send_text(json.dumps({"codec": "pcm_s16le", "sample_rate": 16000}))
+        with pytest.raises(WebSocketDisconnect) as disconnect:
+            websocket.receive_text()
+
+    assert disconnect.value.code == 1008
     assert app.open_calls == []
     assert app.stop_calls == [("front", "session-1")]
 
@@ -457,6 +545,7 @@ def test_talk_websocket_cleans_up_when_runtime_stream_open_fails() -> None:
         ) as websocket,
         pytest.raises(WebSocketDisconnect),
     ):
+        websocket.send_text(_start_message(TalkInputFormat()))
         websocket.receive_text()
 
     assert app.open_calls == []
@@ -479,6 +568,7 @@ def test_talk_websocket_maps_typed_stream_open_refusal_to_policy_close() -> None
         ) as websocket,
         pytest.raises(WebSocketDisconnect) as disconnect,
     ):
+        websocket.send_text(_start_message(TalkInputFormat()))
         websocket.receive_text()
 
     assert disconnect.value.code == 1008
@@ -493,6 +583,7 @@ def test_talk_websocket_accepts_short_lived_token_when_auth_enabled(
     """Browser WebSocket streams should authorize via the token returned by prepare."""
     monkeypatch.setenv("HOMESEC_API_KEY", "secret")
     input_format = TalkInputFormat(sample_rate=8000, frame_ms=10)
+    writer = _MemoryTalkWriter()
     app = _StubTalkApp(
         server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY"),
         talk_config=TalkConfig(enabled=True, input=input_format),
@@ -501,6 +592,7 @@ def test_talk_websocket_accepts_short_lived_token_when_auth_enabled(
             session_id="session-1",
             input=input_format,
         ),
+        stream_writer=writer,
     )
     client = _client(app)
     prepare = client.post(
@@ -508,16 +600,21 @@ def test_talk_websocket_accepts_short_lived_token_when_auth_enabled(
         headers={"Authorization": "Bearer secret"},
         json={"session_id": "session-1", "input": input_format.model_dump(mode="json")},
     )
-    stream_url = prepare.json()["stream_url"]
+    stream_url = prepare.json()["websocket_url"]
+    frame = b"\x33" * input_format.expected_bytes_per_frame
 
     with client.websocket_connect(stream_url) as websocket:
+        websocket.send_text(_start_message(input_format))
         ready = websocket.receive_json()
-        websocket.send_text("stop")
+        websocket.send_bytes(frame)
+        websocket.send_text(_stop_message())
         with pytest.raises(WebSocketDisconnect):
             websocket.receive_text()
 
     assert ready["type"] == "ready"
     assert app.open_calls == [("front", "session-1", input_format)]
+    assert bytes(writer.data[:4]) == len(frame).to_bytes(4, "big")
+    assert bytes(writer.data[4:]) == frame
 
 
 def test_talk_websocket_rejects_missing_token_when_auth_enabled(
@@ -531,8 +628,82 @@ def test_talk_websocket_rejects_missing_token_when_auth_enabled(
     client = _client(app)
 
     with (
-        pytest.raises(WebSocketDisconnect),
-        client.websocket_connect("/api/v1/talk/cameras/front/sessions/session-1/stream"),
+        client.websocket_connect(
+            "/api/v1/talk/cameras/front/sessions/session-1/stream"
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
     ):
-        pass
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1008
     assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_rejects_expired_token_when_auth_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expired talk tokens should be rejected before runtime stream attachment."""
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret")
+    token, _ = issue_camera_talk_token(
+        api_key="secret",
+        camera_name="front",
+        session_id="session-1",
+        ttl_s=1,
+        now=datetime(2020, 1, 1, tzinfo=UTC),
+    )
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    client = _client(app)
+
+    with (
+        client.websocket_connect(
+            f"/api/v1/talk/cameras/front/sessions/session-1/stream?token={token}"
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
+    ):
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1008
+    assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_rejects_wrong_purpose_token_when_auth_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wrong-purpose signed tokens should not authorize talk WebSocket streams."""
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret")
+    expires_at = int(datetime(2099, 1, 1, tzinfo=UTC).timestamp())
+    payload_json = json.dumps(
+        {
+            "camera_name": "front",
+            "exp": expires_at,
+            "scope": "preview_stream",
+            "session_id": "session-1",
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    payload_segment = talk_tokens._base64url_encode(payload_json)
+    signature = talk_tokens._base64url_encode(
+        talk_tokens._sign("secret", talk_tokens._signing_input(payload_segment))
+    )
+    token = f"{talk_tokens.TOKEN_VERSION}.{payload_segment}.{signature}"
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    client = _client(app)
+
+    with (
+        client.websocket_connect(
+            f"/api/v1/talk/cameras/front/sessions/session-1/stream?token={token}"
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
+    ):
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1008
+    assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -10,10 +10,13 @@ from typing import cast
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from fastapi import status
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+import homesec.api.routes.talk as talk_route_module
 import homesec.api.talk_tokens as talk_tokens
+from homesec.api.errors import APIErrorCode
 from homesec.api.server import create_app
 from homesec.api.talk_tokens import issue_camera_talk_token, validate_camera_talk_token
 from homesec.models.config import FastAPIServerConfig, TalkConfig
@@ -33,22 +36,33 @@ from tests.homesec.ui_dist_stub import ensure_stub_ui_dist
 
 
 class _MemoryTalkWriter:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        drain_error: Exception | None = None,
+        wait_closed_error: Exception | None = None,
+    ) -> None:
         self.data = bytearray()
         self.closed = False
         self.drain_count = 0
+        self.drain_error = drain_error
+        self.wait_closed_error = wait_closed_error
 
     def write(self, data: bytes) -> None:
         self.data.extend(data)
 
     async def drain(self) -> None:
         self.drain_count += 1
+        if self.drain_error is not None:
+            raise self.drain_error
 
     def close(self) -> None:
         self.closed = True
 
     async def wait_closed(self) -> None:
         self.closed = True
+        if self.wait_closed_error is not None:
+            raise self.wait_closed_error
 
 
 class _StubTalkApp:
@@ -288,6 +302,21 @@ def test_prepare_talk_session_returns_websocket_url_and_runtime_contract() -> No
     assert app.prepare_calls == [("front", "custom-session", input_format)]
 
 
+def test_prepare_talk_session_generates_session_id_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session creation should mint an opaque id when the client does not provide one."""
+    monkeypatch.setattr(talk_route_module.secrets, "token_urlsafe", lambda size: f"fixed-{size}")
+    app = _StubTalkApp()
+    client = _client(app)
+
+    response = client.post("/api/v1/talk/cameras/front/sessions", json={})
+
+    assert response.status_code == 201
+    generated_session_id = app.prepare_calls[0][1]
+    assert generated_session_id == "tk_fixed-16"
+
+
 def test_prepare_talk_session_mints_short_lived_stream_token_when_auth_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -327,6 +356,26 @@ def test_prepare_talk_session_mints_short_lived_stream_token_when_auth_enabled(
     assert decoded.session_id == "session-1"
 
 
+def test_prepare_talk_session_reports_missing_api_key_when_auth_enabled() -> None:
+    """Auth-enabled session creation should fail closed if no API key is configured."""
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(
+            auth_enabled=True,
+            api_key_env="HOMESEC_MISSING_TEST_API_KEY",
+        )
+    )
+    client = _client(app)
+
+    response = client.post(
+        "/api/v1/talk/cameras/front/sessions",
+        headers={"Authorization": "Bearer anything"},
+        json={"session_id": "session-1"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["error_code"] == APIErrorCode.API_KEY_NOT_CONFIGURED
+
+
 def test_talk_control_routes_require_api_key_when_auth_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -360,24 +409,84 @@ def test_prepare_talk_session_requires_api_key_when_auth_enabled(
     assert app.prepare_calls == []
 
 
-def test_prepare_talk_session_maps_runtime_refusal_to_api_error() -> None:
+@pytest.mark.parametrize(
+    ("reason", "expected_status", "expected_error_code"),
+    [
+        (
+            TalkRefusalReason.CAMERA_NOT_FOUND,
+            status.HTTP_404_NOT_FOUND,
+            APIErrorCode.TALK_CAMERA_NOT_FOUND,
+        ),
+        (TalkRefusalReason.TALK_DISABLED, status.HTTP_409_CONFLICT, APIErrorCode.TALK_DISABLED),
+        (
+            TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
+            status.HTTP_409_CONFLICT,
+            APIErrorCode.TALK_SOURCE_NOT_TALK_CAPABLE,
+        ),
+        (
+            TalkRefusalReason.SESSION_ALREADY_ACTIVE,
+            status.HTTP_409_CONFLICT,
+            APIErrorCode.TALK_SESSION_ALREADY_ACTIVE,
+        ),
+        (
+            TalkRefusalReason.SESSION_BUDGET_EXHAUSTED,
+            status.HTTP_409_CONFLICT,
+            APIErrorCode.TALK_SESSION_BUDGET_EXHAUSTED,
+        ),
+        (
+            TalkRefusalReason.UNSUPPORTED_CAMERA,
+            status.HTTP_409_CONFLICT,
+            APIErrorCode.TALK_UNSUPPORTED_CAMERA,
+        ),
+        (
+            TalkRefusalReason.UNSUPPORTED_CODEC,
+            status.HTTP_400_BAD_REQUEST,
+            APIErrorCode.TALK_UNSUPPORTED_CODEC,
+        ),
+        (
+            TalkRefusalReason.CAMERA_BACKCHANNEL_FAILED,
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            APIErrorCode.TALK_CAMERA_BACKCHANNEL_FAILED,
+        ),
+        (
+            TalkRefusalReason.RUNTIME_UNAVAILABLE,
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            APIErrorCode.TALK_RUNTIME_UNAVAILABLE,
+        ),
+        (
+            TalkRefusalReason.INVALID_AUDIO_FRAME,
+            status.HTTP_400_BAD_REQUEST,
+            APIErrorCode.TALK_INVALID_AUDIO_FRAME,
+        ),
+        (
+            TalkRefusalReason.BACKPRESSURE,
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            APIErrorCode.TALK_BACKPRESSURE,
+        ),
+    ],
+)
+def test_prepare_talk_session_maps_runtime_refusal_to_api_error(
+    reason: TalkRefusalReason,
+    expected_status: int,
+    expected_error_code: APIErrorCode,
+) -> None:
     """Machine-readable talk refusal reasons should survive the HTTP boundary."""
     app = _StubTalkApp(
         prepare_result=CameraTalkStartRefusal(
             camera_name="front",
-            reason=TalkRefusalReason.SESSION_ALREADY_ACTIVE,
-            message="A talk session is already active for this camera",
+            reason=reason,
+            message="Talk session refused",
         )
     )
     client = _client(app)
 
     response = client.post("/api/v1/talk/cameras/front/sessions", json={"session_id": "session-1"})
 
-    assert response.status_code == 409
+    assert response.status_code == expected_status
     assert response.json() == {
-        "detail": "A talk session is already active for this camera",
-        "error_code": "TALK_SESSION_ALREADY_ACTIVE",
-        "reason": "session_already_active",
+        "detail": "Talk session refused",
+        "error_code": expected_error_code,
+        "reason": reason.value,
     }
 
 
@@ -390,6 +499,47 @@ def test_talk_routes_map_camera_not_found() -> None:
 
     assert response.status_code == 404
     assert response.json()["error_code"] == "TALK_CAMERA_NOT_FOUND"
+
+
+@pytest.mark.parametrize("method", ["get", "post", "delete"])
+def test_talk_control_routes_map_runtime_unavailable(method: str) -> None:
+    """Control routes should expose runtime availability failures consistently."""
+    error = TalkRuntimeUnavailableError("worker unavailable")
+    app = _StubTalkApp(
+        status_error=error if method == "get" else None,
+        prepare_error=error if method == "post" else None,
+        stop_error=error if method == "delete" else None,
+    )
+    client = _client(app)
+
+    if method == "get":
+        response = client.get("/api/v1/talk/cameras/front")
+    elif method == "post":
+        response = client.post("/api/v1/talk/cameras/front/sessions", json={"session_id": "s1"})
+    else:
+        response = client.delete("/api/v1/talk/cameras/front/sessions/s1")
+
+    assert response.status_code == 503
+    assert response.json()["error_code"] == APIErrorCode.TALK_RUNTIME_UNAVAILABLE
+
+
+@pytest.mark.parametrize("method", ["post", "delete"])
+def test_talk_mutation_routes_map_camera_not_found(method: str) -> None:
+    """Session mutation routes should keep camera-not-found errors talk-specific."""
+    error = TalkCameraNotFoundError("missing")
+    app = _StubTalkApp(
+        prepare_error=error if method == "post" else None,
+        stop_error=error if method == "delete" else None,
+    )
+    client = _client(app)
+
+    if method == "post":
+        response = client.post("/api/v1/talk/cameras/missing/sessions", json={"session_id": "s1"})
+    else:
+        response = client.delete("/api/v1/talk/cameras/missing/sessions/s1")
+
+    assert response.status_code == 404
+    assert response.json()["error_code"] == APIErrorCode.TALK_CAMERA_NOT_FOUND
 
 
 def test_delete_talk_session_returns_stop_result() -> None:
@@ -517,6 +667,38 @@ def test_talk_websocket_cleans_up_reserved_session_on_invalid_start_message() ->
     assert app.stop_calls == [("front", "session-1")]
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_code"),
+    [
+        (b"not json", 1003),
+        ("not json", 1008),
+        (json.dumps(["not", "an", "object"]), 1008),
+        (json.dumps({"type": "start", "unexpected": True}), 1008),
+    ],
+)
+def test_talk_websocket_rejects_invalid_start_payload_shapes(
+    payload: str | bytes,
+    expected_code: int,
+) -> None:
+    """The first WebSocket message must be a strict JSON start control object."""
+    app = _StubTalkApp()
+    client = _client(app)
+
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream"
+    ) as websocket:
+        if isinstance(payload, bytes):
+            websocket.send_bytes(payload)
+        else:
+            websocket.send_text(payload)
+        with pytest.raises(WebSocketDisconnect) as disconnect:
+            websocket.receive_text()
+
+    assert disconnect.value.code == expected_code
+    assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]
+
+
 def test_talk_websocket_rejects_start_message_without_type() -> None:
     """Start control messages must be explicit, not inferred from defaults."""
     app = _StubTalkApp()
@@ -552,6 +734,26 @@ def test_talk_websocket_cleans_up_when_runtime_stream_open_fails() -> None:
     assert app.stop_calls == [("front", "session-1")]
 
 
+def test_talk_websocket_does_not_stop_when_camera_disappears_during_open() -> None:
+    """A camera-not-found attach failure means the runtime did not reserve this session."""
+    app = _StubTalkApp(open_error=TalkCameraNotFoundError("missing"))
+    client = _client(app)
+
+    with (
+        client.websocket_connect(
+            "/api/v1/talk/cameras/front/sessions/session-1/stream"
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
+    ):
+        websocket.send_text(_start_message(TalkInputFormat()))
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1008
+    assert disconnect.value.reason == "Camera not found"
+    assert app.open_calls == []
+    assert app.stop_calls == []
+
+
 def test_talk_websocket_maps_typed_stream_open_refusal_to_policy_close() -> None:
     """Attach-time typed refusals should survive to WebSocket close semantics."""
     app = _StubTalkApp(
@@ -574,6 +776,97 @@ def test_talk_websocket_maps_typed_stream_open_refusal_to_policy_close() -> None
     assert disconnect.value.code == 1008
     assert disconnect.value.reason == "Talk stream refused"
     assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_maps_backpressure_refusal_to_internal_error_close() -> None:
+    """Infrastructure/open failures should use retryable internal-error close semantics."""
+    app = _StubTalkApp(
+        open_error=TalkStreamOpenRefused(
+            "Backpressure while opening stream",
+            reason=TalkRefusalReason.BACKPRESSURE,
+        )
+    )
+    client = _client(app)
+
+    with (
+        client.websocket_connect(
+            "/api/v1/talk/cameras/front/sessions/session-1/stream"
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
+    ):
+        websocket.send_text(_start_message(TalkInputFormat()))
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1011
+    assert disconnect.value.reason == "Talk stream unavailable"
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_rejects_non_binary_frame_after_ready() -> None:
+    """Once active, only binary PCM frames or an exact stop control message are valid."""
+    app = _StubTalkApp()
+    client = _client(app)
+
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream"
+    ) as websocket:
+        websocket.send_text(_start_message(TalkInputFormat()))
+        websocket.receive_json()
+        websocket.send_text(json.dumps({"type": "stop", "extra": "not allowed"}))
+        with pytest.raises(WebSocketDisconnect) as disconnect:
+            websocket.receive_text()
+
+    assert disconnect.value.code == 1003
+    assert disconnect.value.reason == "Binary audio frames required"
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_closes_when_runtime_ipc_write_fails() -> None:
+    """Runtime IPC write failures should close the browser stream without buffering audio."""
+    input_format = TalkInputFormat(sample_rate=8000, frame_ms=10)
+    writer = _MemoryTalkWriter(drain_error=BrokenPipeError("runtime gone"))
+    app = _StubTalkApp(
+        talk_config=TalkConfig(enabled=True, input=input_format),
+        stream_writer=writer,
+    )
+    client = _client(app)
+
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream"
+    ) as websocket:
+        websocket.send_text(_start_message(input_format))
+        websocket.receive_json()
+        websocket.send_bytes(b"\x44" * input_format.expected_bytes_per_frame)
+        with pytest.raises(WebSocketDisconnect) as disconnect:
+            websocket.receive_text()
+
+    assert disconnect.value.code == 1011
+    assert disconnect.value.reason == "Talk stream unavailable"
+    assert writer.closed is True
+    assert app.stop_calls == [("front", "session-1")]
+
+
+def test_talk_websocket_ignores_disconnect_error_while_closing_runtime_stream() -> None:
+    """Cleanup should tolerate a runtime writer that is already closed/reset."""
+    input_format = TalkInputFormat(sample_rate=8000, frame_ms=10)
+    writer = _MemoryTalkWriter(wait_closed_error=BrokenPipeError("already closed"))
+    app = _StubTalkApp(
+        talk_config=TalkConfig(enabled=True, input=input_format),
+        stream_writer=writer,
+    )
+    client = _client(app)
+
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream"
+    ) as websocket:
+        websocket.send_text(_start_message(input_format))
+        websocket.receive_json()
+        websocket.send_text(_stop_message())
+        with pytest.raises(WebSocketDisconnect):
+            websocket.receive_text()
+
+    assert writer.closed is True
     assert app.stop_calls == [("front", "session-1")]
 
 
@@ -615,6 +908,52 @@ def test_talk_websocket_accepts_short_lived_token_when_auth_enabled(
     assert app.open_calls == [("front", "session-1", input_format)]
     assert bytes(writer.data[:4]) == len(frame).to_bytes(4, "big")
     assert bytes(writer.data[4:]) == frame
+
+
+def test_talk_websocket_accepts_bearer_api_key_when_auth_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-browser clients may authorize the stream directly with the normal bearer key."""
+    monkeypatch.setenv("HOMESEC_API_KEY", "secret")
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(auth_enabled=True, api_key_env="HOMESEC_API_KEY")
+    )
+    client = _client(app)
+
+    with client.websocket_connect(
+        "/api/v1/talk/cameras/front/sessions/session-1/stream",
+        headers={"Authorization": "Bearer secret"},
+    ) as websocket:
+        websocket.send_text(_start_message(TalkInputFormat()))
+        assert websocket.receive_json()["type"] == "ready"
+        websocket.send_text(_stop_message())
+        with pytest.raises(WebSocketDisconnect):
+            websocket.receive_text()
+
+    assert app.open_calls == [("front", "session-1", TalkInputFormat())]
+
+
+def test_talk_websocket_rejects_auth_when_api_key_missing() -> None:
+    """Auth-enabled WebSockets should not fall back open if the API key is absent."""
+    app = _StubTalkApp(
+        server_config=FastAPIServerConfig(
+            auth_enabled=True,
+            api_key_env="HOMESEC_MISSING_TEST_API_KEY",
+        )
+    )
+    client = _client(app)
+
+    with (
+        client.websocket_connect(
+            "/api/v1/talk/cameras/front/sessions/session-1/stream?token=anything"
+        ) as websocket,
+        pytest.raises(WebSocketDisconnect) as disconnect,
+    ):
+        websocket.receive_text()
+
+    assert disconnect.value.code == 1011
+    assert app.open_calls == []
+    assert app.stop_calls == [("front", "session-1")]
 
 
 def test_talk_websocket_rejects_missing_token_when_auth_enabled(

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -30,6 +30,7 @@ from homesec.models.filter import FilterConfig
 from homesec.models.talk import (
     CameraTalkStatus,
     TalkInputFormat,
+    TalkRefusalReason,
     TalkSessionOpenRequest,
     TalkSessionPrepareRequest,
     TalkSessionPrepareResult,
@@ -41,6 +42,7 @@ from homesec.runtime.ipc_stream import write_length_prefixed_frame
 from homesec.runtime.models import PreviewRefusalReason, PreviewState
 from homesec.runtime.subprocess_protocol import (
     WorkerCommand,
+    WorkerCommandErrorCode,
     WorkerCommandResult,
     WorkerCommandType,
 )
@@ -270,6 +272,177 @@ async def test_runtime_worker_talk_stream_command_forwards_frames_and_stops(
     assert source.prepared == [TalkSessionPrepareRequest(session_id="tk_1", input=input_format)]
     assert source.opened == [TalkSessionOpenRequest(session_id="tk_1", input=input_format)]
     assert source.frames == [("tk_1", first_frame), ("tk_1", second_frame)]
+    assert source.stopped == ["tk_1"]
+
+
+def test_runtime_worker_talk_status_reports_unsupported_for_non_talk_capable_source() -> None:
+    """TALK_STATUS should use structural capability checks instead of source imports."""
+    config = _make_config(notifiers=[], talk_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": object()}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.TALK_STATUS,
+        command_id="cmd-talk-status",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+    )
+
+    result = service._handle_command(command)
+
+    assert result.talk_status is not None
+    assert result.talk_status.enabled is True
+    assert result.talk_status.state == TalkState.UNSUPPORTED
+    assert result.talk_status.last_error == "Source is not talk-capable"
+
+
+@pytest.mark.asyncio
+async def test_runtime_worker_talk_prepare_refuses_non_talk_capable_source() -> None:
+    """Talk preparation should return a typed refusal for unsupported camera sources."""
+    config = _make_config(notifiers=[], talk_enabled=True)
+    service = _make_service(config)
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": object()}),
+    )
+    command = WorkerCommand(
+        command=WorkerCommandType.TALK_PREPARE_SESSION,
+        command_id="cmd-prepare-unsupported",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="front",
+        session_id="tk_unsupported",
+    )
+
+    result = await service._handle_async_command(command)
+
+    assert result.talk_refusal is not None
+    assert result.talk_refusal.reason == TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE
+    assert result.talk_refusal.message == "Camera source is not talk-capable"
+
+
+@pytest.mark.asyncio
+async def test_runtime_worker_talk_stream_open_returns_camera_not_found_error() -> None:
+    """TALK_STREAM_OPEN should fail before streaming when the camera is unknown."""
+    config = _make_config(notifiers=[], talk_enabled=True)
+    service = _make_service(config)
+    command = WorkerCommand(
+        command=WorkerCommandType.TALK_STREAM_OPEN,
+        command_id="cmd-open-missing",
+        generation=1,
+        correlation_id="test-correlation-id",
+        camera_name="missing",
+        session_id="tk_missing",
+    )
+
+    result = await service._open_talk_stream(command)
+
+    assert result.error_code == WorkerCommandErrorCode.CAMERA_NOT_FOUND
+    assert result.error_message == "Camera 'missing' not found"
+    assert result.talk_refusal is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_worker_talk_stream_invalid_frame_stops_source_session(
+    tmp_path: Path,
+) -> None:
+    """Oversized IPC frames should close the source session instead of buffering audio."""
+
+    class _TalkSource:
+        def __init__(self) -> None:
+            self.frames: list[tuple[str, bytes]] = []
+            self.stopped: list[str] = []
+            self.stop_event = asyncio.Event()
+
+        def talk_status(self) -> CameraTalkStatus:
+            return CameraTalkStatus(
+                camera_name="front",
+                enabled=True,
+                state=TalkState.ACTIVE,
+                active_session_id="tk_1",
+                supported_codecs=["PCMU/8000"],
+                selected_codec="PCMU/8000",
+            )
+
+        async def prepare_talk_session(
+            self,
+            request: TalkSessionPrepareRequest,
+        ) -> TalkSessionPrepareResult:
+            return TalkSessionPrepareResult(
+                accepted=True,
+                session_id=request.session_id,
+                input=request.input,
+            )
+
+        async def open_talk_session(self, request: TalkSessionOpenRequest) -> object:
+            return SimpleNamespace(
+                session_id=request.session_id,
+                camera_name="front",
+                selected_codec="PCMU/8000",
+            )
+
+        async def write_talk_frame(self, session_id: str, frame: bytes) -> None:
+            self.frames.append((session_id, frame))
+
+        async def stop_talk_session(self, session_id: str) -> bool:
+            self.stopped.append(session_id)
+            self.stop_event.set()
+            return True
+
+    input_format = TalkInputFormat(sample_rate=8000, frame_ms=10)
+    config = _make_config(notifiers=[], talk_enabled=True, talk_input=input_format)
+    service = _make_service(config)
+    source = _TalkSource()
+    service._runtime_bundle = cast(
+        Any,
+        SimpleNamespace(sources_by_camera={"front": source}),
+    )
+    socket_path = tmp_path / "worker-talk-invalid-frame.sock"
+    server = await asyncio.start_unix_server(
+        service._handle_command_connection,
+        path=str(socket_path),
+    )
+
+    try:
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        try:
+            writer.write(
+                WorkerCommand(
+                    command=WorkerCommandType.TALK_STREAM_OPEN,
+                    command_id="cmd-open-talk-invalid-frame",
+                    generation=1,
+                    correlation_id="test-correlation-id",
+                    camera_name="front",
+                    session_id="tk_1",
+                    talk_input=input_format,
+                )
+                .model_dump_json()
+                .encode("utf-8")
+                + b"\n"
+            )
+            await writer.drain()
+            opened = WorkerCommandResult.model_validate_json(
+                (await reader.readline()).decode("utf-8")
+            )
+            assert opened.talk_refusal is None
+
+            await write_length_prefixed_frame(
+                writer,
+                b"x" * (input_format.expected_bytes_per_frame + 1),
+            )
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        await asyncio.wait_for(source.stop_event.wait(), timeout=1.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert source.frames == []
     assert source.stopped == ["tk_1"]
 
 

--- a/ui/src/api/generated/openapi.json
+++ b/ui/src/api/generated/openapi.json
@@ -1813,6 +1813,10 @@
               }
             ],
             "title": "Token Expires At"
+          },
+          "websocket_url": {
+            "title": "Websocket Url",
+            "type": "string"
           }
         },
         "required": [
@@ -1820,6 +1824,7 @@
           "session_id",
           "state",
           "input",
+          "websocket_url",
           "stream_url",
           "max_session_s",
           "idle_timeout_s"

--- a/ui/src/api/generated/schema.ts
+++ b/ui/src/api/generated/schema.ts
@@ -1255,6 +1255,8 @@ export interface components {
             token?: string | null;
             /** Token Expires At */
             token_expires_at?: string | null;
+            /** Websocket Url */
+            websocket_url: string;
         };
         /**
          * TalkState


### PR DESCRIPTION
## Summary
- Align push-to-talk session creation with the Phase 3 API contract by returning `websocket_url` while keeping `stream_url` as a compatibility alias.
- Move browser audio format negotiation from WebSocket query params into a required first JSON `{ "type": "start", ... }` control message; accept strict JSON `{ "type": "stop" }` for shutdown.
- Harden WebSocket attach auth/token rejection coverage and include `camera_codec` in the ready message.
- Regenerate UI OpenAPI/type artifacts for the response-model change.

Design doc: https://gist.github.com/lan17/7c84e16f2819f2d3efc20941a4d0309f

## Validation
- `uv run pytest tests/homesec/test_api_talk_routes.py tests/homesec/test_api_talk_tokens.py -q`
- `make lint`
- `make typecheck`
- `make ui-api-check`
- `make test` → 1068 passed, 2 warnings
- `make ui-check` → 50 UI test files / 231 tests passed; build succeeded
