### PR TITLE
fix: quiet stale talk open races

### DIFF
--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -74,6 +74,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_STALE_TALK_OPEN_MESSAGES = {
+    "Talk session is not reserved",
+    "Talk session is no longer reserved",
+}
+
 
 @runtime_checkable
 class _PreviewStatusLike(Protocol):
@@ -753,12 +758,11 @@ class _RuntimeWorkerService:
             )
         except Exception as exc:
             reason = _talk_refusal_reason_from_exception(exc)
-            logger.warning(
-                "Talk stream open failed for camera=%s session=%s: %s",
-                command.camera_name,
-                session_id,
-                exc,
-                exc_info=True,
+            _log_talk_stream_open_failure(
+                camera_name=command.camera_name,
+                session_id=session_id,
+                reason=reason,
+                exc=exc,
             )
             return self._talk_refusal_result(
                 command,
@@ -1059,6 +1063,32 @@ def _talk_refusal_reason_from_exception(exc: Exception) -> TalkRefusalReason:
         except ValueError:
             pass
     return TalkRefusalReason.RUNTIME_UNAVAILABLE
+
+
+def _log_talk_stream_open_failure(
+    *,
+    camera_name: str,
+    session_id: str,
+    reason: TalkRefusalReason,
+    exc: Exception,
+) -> None:
+    """Log expected stale-session open races without traceback noise."""
+    if reason == TalkRefusalReason.RUNTIME_UNAVAILABLE and str(exc) in _STALE_TALK_OPEN_MESSAGES:
+        logger.info(
+            "Talk stream open skipped for stale session camera=%s session=%s: %s",
+            camera_name,
+            session_id,
+            exc,
+        )
+        return
+
+    logger.warning(
+        "Talk stream open failed for camera=%s session=%s: %s",
+        camera_name,
+        session_id,
+        exc,
+        exc_info=True,
+    )
 
 
 def _preview_state_from_source(state: object) -> PreviewState:

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -559,6 +559,55 @@ def test_worker_main_uses_shared_logging_configuration(monkeypatch) -> None:
     assert calls["ran"] is True
 
 
+def test_talk_open_stale_session_logs_without_warning_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Stop/open races for stale talk sessions should not produce warning tracebacks."""
+
+    class _TalkManagerFailure(RuntimeError):
+        reason = TalkRefusalReason.RUNTIME_UNAVAILABLE
+
+    # Given: The manager reports that a session was stopped while stream open was in flight.
+    error = _TalkManagerFailure("Talk session is no longer reserved")
+
+    # When: The worker logs the open refusal.
+    with caplog.at_level(logging.INFO, logger=worker_module.logger.name):
+        worker_module._log_talk_stream_open_failure(
+            camera_name="front",
+            session_id="tk_1",
+            reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
+            exc=error,
+        )
+
+    # Then: The expected stale-session path is informational and has no traceback.
+    assert [record.levelno for record in caplog.records] == [logging.INFO]
+    assert "stale session" in caplog.records[0].message
+    assert caplog.records[0].exc_info is None
+
+
+def test_talk_open_unexpected_failure_logs_warning_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected talk stream open failures should keep diagnostic tracebacks."""
+
+    # Given: A runtime-unavailable failure that is not an expected stale-session race.
+    error = RuntimeError("worker command socket failed")
+
+    # When: The worker logs the open failure.
+    with caplog.at_level(logging.INFO, logger=worker_module.logger.name):
+        worker_module._log_talk_stream_open_failure(
+            camera_name="front",
+            session_id="tk_1",
+            reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
+            exc=error,
+        )
+
+    # Then: The unexpected failure remains a warning with exception context.
+    assert [record.levelno for record in caplog.records] == [logging.WARNING]
+    assert "Talk stream open failed" in caplog.records[0].message
+    assert caplog.records[0].exc_info is not None
+
+
 def test_runtime_worker_create_notifier_returns_noop_when_notifier_list_empty() -> None:
     # Given: Runtime worker config with no notifier entries
     config = _make_config(notifiers=[])


### PR DESCRIPTION
## Summary
- Treat talk stream opens that finish after the session was already stopped as an expected stale-session race.
- Log that path at info without traceback noise.
- Keep unexpected talk stream open failures at warning level with exception context.

## Why
Manual testing showed a successful stop/DELETE racing with a still-opening ONVIF talk session. The manager correctly closes the unclaimed camera session, but the worker logged the expected cancellation as a warning with a traceback.

## Validation
- `uv run pytest tests/homesec/test_runtime_worker.py tests/homesec/rtsp/talk/test_manager.py tests/homesec/test_api_talk_routes.py -q`
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:55432/homesec make check`

Stacked on https://github.com/lan17/homesec/pull/80.