### PR TITLE
feat: add talk backend registry primitives

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -51,6 +51,16 @@ cameras:
     # Optional: opt out a camera that advertises an unwanted speaker backchannel.
     # talk:
     #   mode: disabled
+    #
+    # Optional: configure a dedicated ONVIF talk URI/profile. `talk.config`
+    # remains an ONVIF compatibility alias; new configs may use `talk.backends`.
+    # talk:
+    #   mode: auto
+    #   backend: auto
+    #   backends:
+    #     onvif_rtsp_backchannel:
+    #       rtsp_url_env: FRONT_DOOR_TALK_RTSP_URL
+    #       preferred_codecs: ["PCMU/8000", "PCMA/8000"]
 
   # FTP server (receive uploads from cameras that support FTP)
   - name: ftp_camera

--- a/docs/push-to-talk.md
+++ b/docs/push-to-talk.md
@@ -80,6 +80,29 @@ cameras:
         io_timeout_s: 5.0
 ```
 
+The top-level `cameras[].talk.config` field remains a compatibility alias for
+the ONVIF RTSP backchannel backend. New backend-specific options can also be
+placed under `cameras[].talk.backends.<backend_name>`:
+
+```yaml
+cameras:
+  - name: front_door
+    talk:
+      mode: auto
+      backend: auto
+      backends:
+        onvif_rtsp_backchannel:
+          rtsp_url_env: FRONT_DOOR_TALK_RTSP_URL
+          preferred_codecs:
+            - PCMU/8000
+            - PCMA/8000
+```
+
+HomeSec currently ships the ONVIF RTSP backchannel implementation. Explicit
+future backend names are accepted by config parsing so operators can stage
+configuration, but they report `source_not_talk_capable` until a matching backend
+adapter is implemented and registered.
+
 Use environment variables for RTSP URLs and credentials. Do not commit camera
 passwords in YAML.
 

--- a/src/homesec/models/config.py
+++ b/src/homesec/models/config.py
@@ -274,8 +274,9 @@ class CameraTalkConfig(BaseModel):
         default=True,
         description="Deprecated compatibility alias for mode != 'disabled'.",
     )
-    backend: Literal["onvif_rtsp_backchannel"] = "onvif_rtsp_backchannel"
+    backend: str = "auto"
     config: dict[str, Any] | BaseModel = Field(default_factory=dict)
+    backends: dict[str, dict[str, Any] | BaseModel] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod
@@ -284,6 +285,14 @@ class CameraTalkConfig(BaseModel):
             return value
 
         config = dict(value)
+        backend = config.get("backend")
+        if isinstance(backend, str):
+            config["backend"] = backend.lower()
+        backends = config.get("backends")
+        if isinstance(backends, dict):
+            config["backends"] = {
+                key.lower() if isinstance(key, str) else key: item for key, item in backends.items()
+            }
         if "mode" not in config and "enabled" in config:
             config["mode"] = "auto" if _bool_config_value(config["enabled"]) else "disabled"
         if "enabled" not in config and "mode" in config:
@@ -302,12 +311,33 @@ class CameraTalkConfig(BaseModel):
         """Whether policy allows runtime capability discovery for this camera."""
         return self.mode != "disabled"
 
+    def config_for_backend(self, backend_name: str) -> dict[str, Any]:
+        """Return backend-specific config while preserving legacy config aliases."""
+        normalized_backend = backend_name.lower()
+        if normalized_backend in self.backends:
+            return _model_or_dict_config(self.backends[normalized_backend])
+        if self.backend == normalized_backend and self.config:
+            return _model_or_dict_config(self.config)
+        if (
+            self.backend == "auto"
+            and normalized_backend == "onvif_rtsp_backchannel"
+            and self.config
+        ):
+            return _model_or_dict_config(self.config)
+        return {}
+
     @field_validator("backend", mode="before")
     @classmethod
     def _normalize_backend(cls, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower()
         return value
+
+
+def _model_or_dict_config(value: dict[str, Any] | BaseModel) -> dict[str, Any]:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    return dict(value)
 
 
 def _bool_config_value(value: Any) -> bool:

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -100,6 +100,11 @@ def _build_onvif_backchannel_config_data(
     return adapter_config_data
 
 
+def _camera_talk_uses_onvif_for_current_runtime(camera_talk: CameraTalkConfig) -> bool:
+    """Return whether the pre-selector runtime should use the ONVIF talk path."""
+    return camera_talk.backend in {"auto", "onvif_rtsp_backchannel"}
+
+
 def _talk_config_error_probe_factory(
     message: str,
 ) -> Callable[[], Awaitable[TalkCapabilityProbeResult]]:
@@ -324,13 +329,13 @@ class RTSPSourceConfig(BaseModel):
             or camera_talk is None
             or not runtime_talk.enabled
             or not camera_talk.policy_enabled
-            or camera_talk.backend != "onvif_rtsp_backchannel"
+            or not _camera_talk_uses_onvif_for_current_runtime(camera_talk)
         ):
             return self
 
         ONVIFBackchannelConfig.model_validate(
             _build_onvif_backchannel_config_data(
-                camera_talk.config,
+                camera_talk.config_for_backend("onvif_rtsp_backchannel"),
                 fallback_rtsp_url=self.rtsp_url,
                 fallback_rtsp_url_env=self.rtsp_url_env,
             )
@@ -941,7 +946,7 @@ class RTSPSource(ThreadedClipSource):
                 max_session_s=runtime_talk.max_session_s,
                 idle_timeout_s=runtime_talk.idle_timeout_s,
             )
-        if camera_talk.backend != "onvif_rtsp_backchannel":
+        if not _camera_talk_uses_onvif_for_current_runtime(camera_talk):
             return TalkManager(
                 camera_name=self.camera_name,
                 enabled=False,
@@ -953,7 +958,7 @@ class RTSPSource(ThreadedClipSource):
             )
 
         adapter_config_data = _build_onvif_backchannel_config_data(
-            camera_talk.config,
+            camera_talk.config_for_backend("onvif_rtsp_backchannel"),
             fallback_rtsp_url=self.rtsp_url,
         )
         adapter_config = ONVIFBackchannelConfig.model_validate(adapter_config_data)

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -118,6 +118,32 @@ def _talk_config_error_probe_factory(
     return _probe
 
 
+def _talk_unsupported_backend_probe_factory(
+    backend: str,
+) -> Callable[[], Awaitable[TalkCapabilityProbeResult]]:
+    async def _probe() -> TalkCapabilityProbeResult:
+        return TalkCapabilityProbeResult(
+            capability=TalkCapabilityState.UNSUPPORTED,
+            refusal_reason=TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
+            message=f"Talk backend '{backend}' is not available in this runtime yet",
+        )
+
+    return _probe
+
+
+def _talk_unsupported_backend_open_session_factory(
+    backend: str,
+) -> Callable[[TalkSessionOpenRequest], Awaitable[TalkSession]]:
+    async def _open(request: TalkSessionOpenRequest) -> TalkSession:
+        _ = request
+        raise TalkManagerError(
+            f"Talk backend '{backend}' is not available in this runtime yet",
+            reason=TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
+        )
+
+    return _open
+
+
 def _talk_config_error_manager(
     *,
     message: str,
@@ -135,6 +161,26 @@ def _talk_config_error_manager(
         supported_codecs=list(preferred_codecs),
         open_session_factory=open_session_factory,
         capability_probe_factory=_talk_config_error_probe_factory(message),
+        max_session_s=runtime_talk.max_session_s,
+        idle_timeout_s=runtime_talk.idle_timeout_s,
+    )
+
+
+def _talk_unsupported_backend_manager(
+    *,
+    backend: str,
+    camera_name: str,
+    camera_talk: CameraTalkConfig,
+    runtime_talk: TalkConfig,
+) -> TalkManager:
+    """Build a talk manager that reports an explicit unimplemented backend."""
+    return TalkManager(
+        camera_name=camera_name,
+        enabled=True,
+        policy_enabled=camera_talk.policy_enabled,
+        supported_codecs=[],
+        open_session_factory=_talk_unsupported_backend_open_session_factory(backend),
+        capability_probe_factory=_talk_unsupported_backend_probe_factory(backend),
         max_session_s=runtime_talk.max_session_s,
         idle_timeout_s=runtime_talk.idle_timeout_s,
     )
@@ -947,14 +993,11 @@ class RTSPSource(ThreadedClipSource):
                 idle_timeout_s=runtime_talk.idle_timeout_s,
             )
         if not _camera_talk_uses_onvif_for_current_runtime(camera_talk):
-            return TalkManager(
+            return _talk_unsupported_backend_manager(
+                backend=camera_talk.backend,
                 camera_name=self.camera_name,
-                enabled=False,
-                policy_enabled=camera_talk.policy_enabled,
-                supported_codecs=[],
-                open_session_factory=self._open_disabled_talk_session,
-                max_session_s=runtime_talk.max_session_s,
-                idle_timeout_s=runtime_talk.idle_timeout_s,
+                camera_talk=camera_talk,
+                runtime_talk=runtime_talk,
             )
 
         adapter_config_data = _build_onvif_backchannel_config_data(

--- a/src/homesec/talk/__init__.py
+++ b/src/homesec/talk/__init__.py
@@ -1,0 +1,1 @@
+"""Backend-agnostic push-to-talk primitives."""

--- a/src/homesec/talk/backends.py
+++ b/src/homesec/talk/backends.py
@@ -4,16 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel
 
 from homesec.models.config import CameraTalkConfig, TalkConfig
 from homesec.models.talk import TalkCapabilityProbeResult, TalkSessionOpenRequest
-
-if TYPE_CHECKING:
-    from homesec.sources.rtsp.talk.manager import TalkSession
-
 
 TalkBackendConfidence = Literal["explicit", "high", "medium", "low", "not_applicable"]
 
@@ -33,8 +29,26 @@ class TalkBackendAdapter(Protocol):
         """Probe whether this backend can provide talk for the camera."""
         ...
 
-    async def open_session(self, request: TalkSessionOpenRequest) -> TalkSession:
+    async def open_session(self, request: TalkSessionOpenRequest) -> TalkBackendSession:
         """Open a backend-specific talk session for a reserved HomeSec session."""
+        ...
+
+
+@runtime_checkable
+class TalkBackendSession(Protocol):
+    """Camera talk session returned by a backend adapter."""
+
+    @property
+    def selected_codec(self) -> str:
+        """Codec selected by the camera adapter for this session."""
+        ...
+
+    async def write_pcm_frame(self, frame: bytes) -> None:
+        """Send one PCM frame to the camera speaker."""
+        ...
+
+    async def close(self) -> None:
+        """Close the camera talk session."""
         ...
 
 
@@ -70,9 +84,9 @@ class TalkBackendContext:
     runtime_talk: TalkConfig
     camera_talk: CameraTalkConfig
     source_host: str | None = None
-    source_rtsp_url: str | None = None
-    source_rtsp_url_env: str | None = None
-    resolved_source_rtsp_url: str | None = None
+    source_uri: str | None = None
+    source_uri_env: str | None = None
+    resolved_source_uri: str | None = None
     source_connect_timeout_s: float = 5.0
     source_io_timeout_s: float = 5.0
     fingerprint: CameraTalkFingerprint = field(default_factory=CameraTalkFingerprint)

--- a/src/homesec/talk/backends.py
+++ b/src/homesec/talk/backends.py
@@ -1,0 +1,166 @@
+"""Talk backend adapter contracts and registry primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.models.talk import TalkCapabilityProbeResult, TalkSessionOpenRequest
+
+if TYPE_CHECKING:
+    from homesec.sources.rtsp.talk.manager import TalkSession
+
+
+TalkBackendConfidence = Literal["explicit", "high", "medium", "low", "not_applicable"]
+
+
+@runtime_checkable
+class TalkBackendAdapter(Protocol):
+    """Protocol implemented by camera speaker backend adapters."""
+
+    name: str
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        """Camera-side codecs this backend can emit."""
+        ...
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        """Probe whether this backend can provide talk for the camera."""
+        ...
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> TalkSession:
+        """Open a backend-specific talk session for a reserved HomeSec session."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class CameraTalkFingerprint:
+    """Sparse camera identity hints available to talk backend detectors."""
+
+    manufacturer: str | None = None
+    model: str | None = None
+    firmware: str | None = None
+    profile_names: tuple[str, ...] = ()
+    rtsp_hosts: tuple[str, ...] = ()
+    open_ports: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TalkBackendDetection:
+    """Detector result used by auto backend selection."""
+
+    backend: str
+    confidence: TalkBackendConfidence
+    reason: str
+    safe_to_probe: bool = False
+    requires_credentials: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TalkBackendContext:
+    """Source-local context available while building and selecting talk backends."""
+
+    camera_name: str
+    source_backend: str
+    runtime_talk: TalkConfig
+    camera_talk: CameraTalkConfig
+    source_host: str | None = None
+    source_rtsp_url: str | None = None
+    source_rtsp_url_env: str | None = None
+    resolved_source_rtsp_url: str | None = None
+    source_connect_timeout_s: float = 5.0
+    source_io_timeout_s: float = 5.0
+    fingerprint: CameraTalkFingerprint = field(default_factory=CameraTalkFingerprint)
+    resolve_env: Callable[[str], str | None] | None = None
+    redact: Callable[[str], str] | None = None
+
+    def env_value(self, name: str) -> str | None:
+        """Resolve an environment value through the injected resolver when present."""
+        if self.resolve_env is None:
+            return None
+        return self.resolve_env(name)
+
+    def redacted(self, value: str) -> str:
+        """Redact a diagnostic value through the injected redactor when present."""
+        if self.redact is None:
+            return value
+        return self.redact(value)
+
+
+@dataclass(frozen=True, slots=True)
+class TalkBackendRegistration:
+    """Factory and detector metadata for one talk backend."""
+
+    name: str
+    config_model: type[BaseModel]
+    factory: Callable[[BaseModel, TalkBackendContext], TalkBackendAdapter]
+    detector: Callable[[TalkBackendContext], TalkBackendDetection] | None = None
+    priority: int = 100
+    standards_based: bool = False
+
+    def __post_init__(self) -> None:
+        normalized = self.name.lower()
+        if normalized != self.name:
+            object.__setattr__(self, "name", normalized)
+
+
+class TalkBackendRegistry:
+    """In-memory registry for built-in talk backend registrations."""
+
+    def __init__(self) -> None:
+        self._registrations: dict[str, TalkBackendRegistration] = {}
+
+    def register(self, registration: TalkBackendRegistration) -> None:
+        """Register one backend, failing fast on duplicate names."""
+        name = registration.name.lower()
+        if name in self._registrations:
+            raise ValueError(f"Talk backend '{name}' already registered")
+        self._registrations[name] = registration
+
+    def get(self, name: str) -> TalkBackendRegistration | None:
+        """Return a registration by backend name."""
+        return self._registrations.get(name.lower())
+
+    def all(self) -> list[TalkBackendRegistration]:
+        """Return all registrations in deterministic selection order."""
+        return sorted(
+            self._registrations.values(),
+            key=lambda registration: (
+                not registration.standards_based,
+                registration.priority,
+                registration.name,
+            ),
+        )
+
+    def standards_first(self) -> list[TalkBackendRegistration]:
+        """Return standards-based backends before proprietary candidates."""
+        return self.all()
+
+    def names(self) -> tuple[str, ...]:
+        """Return registered backend names in deterministic order."""
+        return tuple(registration.name for registration in self.all())
+
+
+def backend_config_for(
+    camera_talk: CameraTalkConfig,
+    backend_name: str,
+) -> dict[str, object]:
+    """Return backend config using the Phase 9 compatibility alias rules."""
+    return dict(camera_talk.config_for_backend(backend_name))
+
+
+def model_validate_backend_config(
+    registration: TalkBackendRegistration,
+    raw_config: Mapping[str, object] | BaseModel,
+) -> BaseModel:
+    """Validate backend-specific config against the registered config model."""
+    if isinstance(raw_config, registration.config_model):
+        return raw_config
+    if isinstance(raw_config, BaseModel):
+        raw_config = raw_config.model_dump(mode="json")
+    return registration.config_model.model_validate(dict(raw_config))

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -820,6 +820,48 @@ async def test_talk_disabled_by_policy_does_not_build_camera_backchannel(
 
 
 @pytest.mark.asyncio
+async def test_explicit_future_talk_backend_reports_unsupported_without_onvif_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unimplemented explicit talk backends should not look policy-disabled."""
+
+    def _unexpected_adapter(*_: object, **__: object) -> object:
+        raise AssertionError("future backend should not construct the ONVIF backchannel adapter")
+
+    monkeypatch.setattr(
+        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        _unexpected_adapter,
+    )
+    config = _make_config(
+        tmp_path,
+        **{
+            "__runtime_talk__": TalkConfig(enabled=True),
+            "__camera_talk__": CameraTalkConfig(backend="tapo_local"),
+        },
+    )
+
+    # Given: A camera explicitly configured for a future talk backend.
+    source = RTSPSource(config, camera_name="cam")
+
+    # When: Refreshing capability and attempting to reserve a talk session.
+    status = await source.refresh_talk_status()
+    prepared = await source.prepare_talk_session(
+        TalkSessionPrepareRequest(session_id="tk_future_backend")
+    )
+
+    # Then: The source reports unsupported backend diagnostics, not disabled policy.
+    assert status.enabled is True
+    assert status.policy_enabled is True
+    assert status.capability == TalkCapabilityState.UNSUPPORTED
+    assert status.state == TalkState.UNSUPPORTED
+    assert status.last_error == "Talk backend 'tapo_local' is not available in this runtime yet"
+    assert prepared.accepted is False
+    assert prepared.refusal_reason == TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE
+    assert prepared.message == status.last_error
+
+
+@pytest.mark.asyncio
 async def test_talk_missing_explicit_credential_env_reports_config_error_without_breaking_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/homesec/talk/test_backend_registry.py
+++ b/tests/homesec/talk/test_backend_registry.py
@@ -80,7 +80,8 @@ def test_registry_rejects_duplicate_backend_names() -> None:
     registry = TalkBackendRegistry()
     registry.register(_registration("fake_backend"))
 
-    # When/Then: Registering the same backend again fails clearly
+    # When: Registering the same backend again
+    # Then: The registry fails clearly
     with pytest.raises(ValueError, match="fake_backend"):
         registry.register(_registration("FAKE_BACKEND"))
 
@@ -124,7 +125,8 @@ def test_backend_context_resolves_env_and_redaction_through_injected_helpers() -
 
 def test_detection_preserves_safe_probe_metadata() -> None:
     """Talk backend detection should carry safe auto-probe metadata."""
-    # Given/When: A detector result marks a backend as safe after a strong fingerprint
+    # Given: A strong camera fingerprint for a backend detector
+    # When: Building a detector result that marks the backend as safe to probe
     detection = TalkBackendDetection(
         backend="fake_backend",
         confidence="high",

--- a/tests/homesec/talk/test_backend_registry.py
+++ b/tests/homesec/talk/test_backend_registry.py
@@ -1,0 +1,175 @@
+"""Tests for backend-agnostic talk registry primitives."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkSessionOpenRequest,
+)
+from homesec.talk.backends import (
+    CameraTalkFingerprint,
+    TalkBackendContext,
+    TalkBackendDetection,
+    TalkBackendRegistration,
+    TalkBackendRegistry,
+    backend_config_for,
+    model_validate_backend_config,
+)
+
+
+class _BackendConfig(BaseModel):
+    """Fake backend config for registry tests."""
+
+    enabled: bool = True
+
+
+class _OtherBackendConfig(BaseModel):
+    """Second fake backend config for ordering tests."""
+
+    enabled: bool = True
+
+
+class _FakeSession:
+    selected_codec = "PCMU/8000"
+
+    async def write_pcm_frame(self, frame: bytes) -> None:
+        _ = frame
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeBackend:
+    name = "fake_backend"
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return ["PCMU/8000"]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        return TalkCapabilityProbeResult(capability=TalkCapabilityState.SUPPORTED)
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> _FakeSession:
+        _ = request
+        return _FakeSession()
+
+
+def _registration(
+    name: str,
+    *,
+    priority: int = 100,
+    standards_based: bool = False,
+) -> TalkBackendRegistration:
+    return TalkBackendRegistration(
+        name=name,
+        config_model=_BackendConfig,
+        factory=lambda config, context: _FakeBackend(),
+        priority=priority,
+        standards_based=standards_based,
+    )
+
+
+def test_registry_rejects_duplicate_backend_names() -> None:
+    """Talk backend registry should reject duplicate names."""
+    # Given: A registry with one backend registration
+    registry = TalkBackendRegistry()
+    registry.register(_registration("fake_backend"))
+
+    # When/Then: Registering the same backend again fails clearly
+    with pytest.raises(ValueError, match="fake_backend"):
+        registry.register(_registration("FAKE_BACKEND"))
+
+
+def test_registry_orders_standards_backends_first() -> None:
+    """Talk backend registry should return deterministic standards-first order."""
+    # Given: Proprietary and standards-based backend registrations
+    registry = TalkBackendRegistry()
+    registry.register(_registration("vendor_backend", priority=1, standards_based=False))
+    registry.register(_registration("onvif_rtsp_backchannel", priority=50, standards_based=True))
+    registry.register(_registration("other_standard", priority=10, standards_based=True))
+
+    # When: Reading the standards-first registry order
+    names = registry.names()
+
+    # Then: Standards-based registrations sort before proprietary candidates
+    assert names == ("other_standard", "onvif_rtsp_backchannel", "vendor_backend")
+
+
+def test_backend_context_resolves_env_and_redaction_through_injected_helpers() -> None:
+    """Talk backend context should keep env and redaction helpers explicit."""
+    # Given: Backend context with injected helpers
+    context = TalkBackendContext(
+        camera_name="front",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=CameraTalkConfig(),
+        fingerprint=CameraTalkFingerprint(manufacturer="fake-vendor"),
+        resolve_env=lambda name: "secret-value" if name == "SECRET_ENV" else None,
+        redact=lambda value: value.replace("secret-value", "***"),
+    )
+
+    # When: A backend resolves an env var and redacts a diagnostic value
+    env_value = context.env_value("SECRET_ENV")
+    diagnostic = context.redacted(f"value={env_value}")
+
+    # Then: Resolution and redaction stay under injected caller control
+    assert env_value == "secret-value"
+    assert diagnostic == "value=***"
+
+
+def test_detection_preserves_safe_probe_metadata() -> None:
+    """Talk backend detection should carry safe auto-probe metadata."""
+    # Given/When: A detector result marks a backend as safe after a strong fingerprint
+    detection = TalkBackendDetection(
+        backend="fake_backend",
+        confidence="high",
+        reason="fake vendor fingerprint",
+        safe_to_probe=True,
+        requires_credentials=True,
+    )
+
+    # Then: Selection code can decide whether probing is allowed
+    assert detection.backend == "fake_backend"
+    assert detection.confidence == "high"
+    assert detection.safe_to_probe is True
+    assert detection.requires_credentials is True
+
+
+def test_backend_config_for_preserves_compatibility_aliases() -> None:
+    """Backend config lookup should preserve legacy and new config shapes."""
+    # Given: Camera talk config with explicit and backend-map entries
+    camera_talk = CameraTalkConfig(
+        backend="auto",
+        config={"preferred_codecs": ["PCMA/8000"]},
+        backends={"fake_backend": {"enabled": False}},
+    )
+
+    # When: Reading config for ONVIF and a future backend
+    onvif_config = backend_config_for(camera_talk, "onvif_rtsp_backchannel")
+    fake_config = backend_config_for(camera_talk, "fake_backend")
+
+    # Then: ONVIF gets the legacy alias and fake backend gets its own block
+    assert onvif_config == {"preferred_codecs": ["PCMA/8000"]}
+    assert fake_config == {"enabled": False}
+
+
+def test_model_validate_backend_config_uses_registration_model() -> None:
+    """Backend config validation should use the selected registration's config model."""
+    # Given: A backend registration with a typed config model
+    registration = TalkBackendRegistration(
+        name="other_backend",
+        config_model=_OtherBackendConfig,
+        factory=lambda config, context: _FakeBackend(),
+    )
+
+    # When: Validating raw backend config through the registration
+    config = model_validate_backend_config(registration, {"enabled": False})
+
+    # Then: The selected backend's model owns validation
+    assert isinstance(config, _OtherBackendConfig)
+    assert config.enabled is False

--- a/tests/homesec/test_config.py
+++ b/tests/homesec/test_config.py
@@ -902,6 +902,18 @@ def test_camera_talk_backend_normalized() -> None:
     assert config.cameras[0].talk.backend == "onvif_rtsp_backchannel"
 
 
+def test_camera_talk_backend_defaults_to_auto() -> None:
+    """Camera talk backend should default to backend auto selection."""
+    # Given: A config without per-camera talk backend overrides
+    data = minimal_config()
+
+    # When: Parsing config
+    config = Config.model_validate(data)
+
+    # Then: The camera is ready for backend auto selection
+    assert config.cameras[0].talk.backend == "auto"
+
+
 def test_camera_talk_defaults_to_auto_policy() -> None:
     """Omitted per-camera talk config should allow capability discovery."""
     # Given: A config without per-camera talk overrides
@@ -913,6 +925,7 @@ def test_camera_talk_defaults_to_auto_policy() -> None:
     # Then: Per-camera talk policy defaults to auto discovery
     assert config.cameras[0].talk.mode == "auto"
     assert config.cameras[0].talk.enabled is True
+    assert config.cameras[0].talk.backend == "auto"
     assert config.cameras[0].talk.policy_enabled is True
 
 
@@ -1014,20 +1027,83 @@ def test_talk_input_rejects_fractional_frame_size() -> None:
     assert "integral PCM frame size" in str(exc_info.value)
 
 
-def test_camera_talk_rejects_unsupported_backend() -> None:
-    """Camera talk config should reject deferred backends in the v1 contract."""
-    # Given: A config using a backend that is intentionally out of scope for MVP
+def test_camera_talk_accepts_unknown_future_backend_name() -> None:
+    """Camera talk config should allow future backend names for runtime selection."""
+    # Given: A config using a backend that is not registered in the current runtime
     data = minimal_config()
     camera = data["cameras"][0]
     assert isinstance(camera, dict)
-    camera["talk"] = {"enabled": True, "backend": "mediamtx", "config": {}}
+    camera["talk"] = {"enabled": True, "backend": "tapo_local", "config": {}}
 
     # When: validating the config.
-    # Then: validation rejects unsupported per-camera talk backends.
-    with pytest.raises(ValidationError) as exc_info:
-        Config.model_validate(data)
+    config = Config.model_validate(data)
 
-    assert "onvif_rtsp_backchannel" in str(exc_info.value)
+    # Then: config parsing preserves the future backend for runtime diagnostics.
+    assert config.cameras[0].talk.backend == "tapo_local"
+
+
+def test_camera_talk_backends_map_preserved_and_normalized() -> None:
+    """Camera talk config should preserve backend-specific config blocks."""
+    # Given: A config with future and ONVIF backend blocks
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {
+        "mode": "auto",
+        "backend": "auto",
+        "backends": {
+            "TAPO_LOCAL": {"host": "192.168.1.33", "port": 8800},
+            "ONVIF_RTSP_BACKCHANNEL": {"preferred_codecs": ["PCMA/8000"]},
+        },
+    }
+
+    # When: validating the config.
+    config = Config.model_validate(data)
+
+    # Then: backend config blocks are available under normalized names.
+    talk = config.cameras[0].talk
+    assert talk.backends["tapo_local"] == {"host": "192.168.1.33", "port": 8800}
+    assert talk.config_for_backend("onvif_rtsp_backchannel") == {"preferred_codecs": ["PCMA/8000"]}
+
+
+def test_camera_talk_config_alias_for_explicit_onvif_backend() -> None:
+    """Legacy talk.config should remain the config for an explicit ONVIF backend."""
+    # Given: Existing ONVIF-style camera talk config using the legacy config field
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {
+        "backend": "onvif_rtsp_backchannel",
+        "config": {"preferred_codecs": ["PCMA/8000"]},
+    }
+
+    # When: validating the config.
+    config = Config.model_validate(data)
+
+    # Then: The compatibility config alias resolves for ONVIF.
+    assert config.cameras[0].talk.config_for_backend("onvif_rtsp_backchannel") == {
+        "preferred_codecs": ["PCMA/8000"]
+    }
+
+
+def test_camera_talk_config_alias_for_auto_onvif_backend() -> None:
+    """Legacy talk.config should remain the ONVIF config during backend auto mode."""
+    # Given: Auto backend config with legacy ONVIF options in talk.config
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {
+        "backend": "auto",
+        "config": {"preferred_codecs": ["PCMA/8000"]},
+    }
+
+    # When: validating the config.
+    config = Config.model_validate(data)
+
+    # Then: The compatibility config alias resolves for the ONVIF candidate.
+    assert config.cameras[0].talk.config_for_backend("onvif_rtsp_backchannel") == {
+        "preferred_codecs": ["PCMA/8000"]
+    }
 
 
 def test_rtsp_talk_backend_config_is_validated_during_config_load() -> None:

--- a/ui/src/api/generated/openapi.json
+++ b/ui/src/api/generated/openapi.json
@@ -198,10 +198,24 @@
         "description": "Per-camera talk policy and backend override configuration.",
         "properties": {
           "backend": {
-            "const": "onvif_rtsp_backchannel",
-            "default": "onvif_rtsp_backchannel",
+            "default": "auto",
             "title": "Backend",
             "type": "string"
+          },
+          "backends": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                {
+                  "$ref": "#/components/schemas/BaseModel"
+                }
+              ]
+            },
+            "title": "Backends",
+            "type": "object"
           },
           "config": {
             "anyOf": [

--- a/ui/src/api/generated/schema.ts
+++ b/ui/src/api/generated/schema.ts
@@ -653,10 +653,15 @@ export interface components {
         CameraTalkConfig: {
             /**
              * Backend
-             * @default onvif_rtsp_backchannel
-             * @constant
+             * @default auto
              */
-            backend: "onvif_rtsp_backchannel";
+            backend: string;
+            /** Backends */
+            backends?: {
+                [key: string]: {
+                    [key: string]: unknown;
+                } | components["schemas"]["BaseModel"];
+            };
             /** Config */
             config?: {
                 [key: string]: unknown;


### PR DESCRIPTION
## Summary

Implements Phase 9.1 of the push-to-talk backend abstraction work.

- Adds backend-agnostic talk adapter primitives: adapter protocol, registration, registry, detection metadata, fingerprint hints, and source-local backend context.
- Opens `CameraTalkConfig.backend` to `auto` and future backend names, and adds a `talk.backends` map for backend-specific config blocks.
- Preserves the Phase 8 ONVIF behavior by treating `backend: auto` and legacy `talk.config` as ONVIF-compatible until the selector migration lands in Phase 9.2.
- Regenerates UI API artifacts for the expanded camera talk config schema.

## Notion

- Parent epic: https://www.notion.so/levneiman/Epic-Push-to-talk-camera-speaker-audio-backchannel-357d8336c59f81aa99c3c9fa820f9835
- Phase 9 parent: https://www.notion.so/levneiman/Phase-9-talk-backend-adapter-abstraction-and-selection-358d8336c59f81ff84b0f7436fdf6370
- Ticket: https://www.notion.so/levneiman/Phase-9-1-backend-registry-and-open-config-shape-359d8336c59f81839c9fd2e1d32c7447

## Validation

- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:55432/homesec make check`
