### PR TITLE
refactor: route ONVIF talk through backend selector

### DIFF
--- a/docs/push-to-talk.md
+++ b/docs/push-to-talk.md
@@ -156,8 +156,8 @@ Before relying on talk for a camera:
 6. Test while recording and preview are active; some cameras have limited RTSP
    session budgets.
 7. Watch HomeSec logs for `unsupported_codec`, `unsupported_camera`,
-   `session_budget_exhausted`, `camera_backchannel_failed`, or repeated idle
-   timeouts.
+   `runtime_unavailable`, `session_budget_exhausted`,
+   `camera_backchannel_failed`, or repeated idle timeouts.
 8. Record the result in the compatibility matrix below.
 
 During operation:
@@ -215,6 +215,14 @@ Suggested result values:
 
 - The camera source backend does not expose the talk capability. The MVP supports
   RTSP sources with `onvif_rtsp_backchannel` talk config.
+
+### Session is refused with `runtime_unavailable`
+
+- Check `last_error` for a talk backend selection or config error.
+- If `cameras[].talk.backend` names a future or custom backend, confirm that
+  backend is installed and registered in this HomeSec runtime.
+- If `cameras[].talk.config.rtsp_url_env` or credential env vars are configured,
+  confirm those environment variables are set for the HomeSec process.
 
 ### Session is refused with `unsupported_camera` or `camera_backchannel_failed`
 

--- a/docs/push-to-talk.md
+++ b/docs/push-to-talk.md
@@ -100,8 +100,8 @@ cameras:
 
 HomeSec currently ships the ONVIF RTSP backchannel implementation. Explicit
 future backend names are accepted by config parsing so operators can stage
-configuration, but they report `source_not_talk_capable` until a matching backend
-adapter is implemented and registered.
+configuration, but they report a talk backend selection/config error until a
+matching backend adapter is implemented and registered.
 
 Use environment variables for RTSP URLs and credentials. Do not commit camera
 passwords in YAML.

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -11,8 +11,6 @@ import os
 import random
 import subprocess
 import time
-from asyncio import TimeoutError as AsyncioTimeoutError
-from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
@@ -25,8 +23,6 @@ from homesec.models.clip import Clip
 from homesec.models.config import CameraTalkConfig, PreviewConfig, TalkConfig
 from homesec.models.talk import (
     CameraTalkStatus,
-    TalkCapabilityProbeResult,
-    TalkCapabilityState,
     TalkRefusalReason,
     TalkSessionOpenRequest,
     TalkSessionPrepareRequest,
@@ -59,10 +55,11 @@ from homesec.sources.rtsp.preflight import (
 )
 from homesec.sources.rtsp.recorder import FfmpegRecorder, Recorder
 from homesec.sources.rtsp.recording_profile import MotionProfile, build_default_recording_profile
-from homesec.sources.rtsp.talk.errors import TalkProtocolError, TalkProtocolErrorCode
+from homesec.sources.rtsp.talk.backend import (
+    build_rtsp_talk_backend_registry,
+    validate_rtsp_talk_backend_config,
+)
 from homesec.sources.rtsp.talk.manager import TalkManager, TalkManagerError, TalkSession
-from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
-from homesec.sources.rtsp.talk.onvif_backchannel import ONVIFBackchannelAdapter
 from homesec.sources.rtsp.url_derivation import derive_detect_rtsp_url
 from homesec.sources.rtsp.utils import (
     _build_timeout_attempts,
@@ -70,120 +67,10 @@ from homesec.sources.rtsp.utils import (
     _next_backoff,
     _redact_rtsp_url,
 )
+from homesec.talk.backends import TalkBackendContext, TalkBackendOpenError
+from homesec.talk.selector import TalkBackendSelector
 
 logger = logging.getLogger(__name__)
-
-
-def _talk_config_dict(value: dict[str, object] | BaseModel) -> dict[str, object]:
-    if isinstance(value, BaseModel):
-        return value.model_dump(mode="json")
-    return dict(value)
-
-
-def _build_onvif_backchannel_config_data(
-    value: dict[str, object] | BaseModel,
-    *,
-    fallback_rtsp_url: str | None,
-    fallback_rtsp_url_env: str | None = None,
-) -> dict[str, object]:
-    """Build ONVIF talk adapter config with inherited source URL fallback rules."""
-    adapter_config_data = _talk_config_dict(value)
-    if (
-        adapter_config_data.get("rtsp_url") is not None
-        or adapter_config_data.get("rtsp_url_env") is not None
-    ):
-        return adapter_config_data
-    if fallback_rtsp_url is not None:
-        adapter_config_data["rtsp_url"] = fallback_rtsp_url
-    elif fallback_rtsp_url_env is not None:
-        adapter_config_data["rtsp_url_env"] = fallback_rtsp_url_env
-    return adapter_config_data
-
-
-def _camera_talk_uses_onvif_for_current_runtime(camera_talk: CameraTalkConfig) -> bool:
-    """Return whether the pre-selector runtime should use the ONVIF talk path."""
-    return camera_talk.backend in {"auto", "onvif_rtsp_backchannel"}
-
-
-def _talk_config_error_probe_factory(
-    message: str,
-) -> Callable[[], Awaitable[TalkCapabilityProbeResult]]:
-    async def _probe() -> TalkCapabilityProbeResult:
-        return TalkCapabilityProbeResult(
-            capability=TalkCapabilityState.ERROR,
-            refusal_reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
-            message=message,
-        )
-
-    return _probe
-
-
-def _talk_unsupported_backend_probe_factory(
-    backend: str,
-) -> Callable[[], Awaitable[TalkCapabilityProbeResult]]:
-    async def _probe() -> TalkCapabilityProbeResult:
-        return TalkCapabilityProbeResult(
-            capability=TalkCapabilityState.UNSUPPORTED,
-            refusal_reason=TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
-            message=f"Talk backend '{backend}' is not available in this runtime yet",
-        )
-
-    return _probe
-
-
-def _talk_unsupported_backend_open_session_factory(
-    backend: str,
-) -> Callable[[TalkSessionOpenRequest], Awaitable[TalkSession]]:
-    async def _open(request: TalkSessionOpenRequest) -> TalkSession:
-        _ = request
-        raise TalkManagerError(
-            f"Talk backend '{backend}' is not available in this runtime yet",
-            reason=TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
-        )
-
-    return _open
-
-
-def _talk_config_error_manager(
-    *,
-    message: str,
-    camera_name: str,
-    camera_talk: CameraTalkConfig,
-    runtime_talk: TalkConfig,
-    preferred_codecs: list[str],
-    open_session_factory: Callable[[TalkSessionOpenRequest], Awaitable[TalkSession]],
-) -> TalkManager:
-    """Build a talk manager that reports talk-specific config errors safely."""
-    return TalkManager(
-        camera_name=camera_name,
-        enabled=True,
-        policy_enabled=camera_talk.policy_enabled,
-        supported_codecs=list(preferred_codecs),
-        open_session_factory=open_session_factory,
-        capability_probe_factory=_talk_config_error_probe_factory(message),
-        max_session_s=runtime_talk.max_session_s,
-        idle_timeout_s=runtime_talk.idle_timeout_s,
-    )
-
-
-def _talk_unsupported_backend_manager(
-    *,
-    backend: str,
-    camera_name: str,
-    camera_talk: CameraTalkConfig,
-    runtime_talk: TalkConfig,
-) -> TalkManager:
-    """Build a talk manager that reports an explicit unimplemented backend."""
-    return TalkManager(
-        camera_name=camera_name,
-        enabled=True,
-        policy_enabled=camera_talk.policy_enabled,
-        supported_codecs=[],
-        open_session_factory=_talk_unsupported_backend_open_session_factory(backend),
-        capability_probe_factory=_talk_unsupported_backend_probe_factory(backend),
-        max_session_s=runtime_talk.max_session_s,
-        idle_timeout_s=runtime_talk.idle_timeout_s,
-    )
 
 
 class RTSPMotionConfig(BaseModel):
@@ -375,15 +262,18 @@ class RTSPSourceConfig(BaseModel):
             or camera_talk is None
             or not runtime_talk.enabled
             or not camera_talk.policy_enabled
-            or not _camera_talk_uses_onvif_for_current_runtime(camera_talk)
         ):
             return self
 
-        ONVIFBackchannelConfig.model_validate(
-            _build_onvif_backchannel_config_data(
-                camera_talk.config_for_backend("onvif_rtsp_backchannel"),
-                fallback_rtsp_url=self.rtsp_url,
-                fallback_rtsp_url_env=self.rtsp_url_env,
+        validate_rtsp_talk_backend_config(
+            TalkBackendContext(
+                camera_name="",
+                source_backend="rtsp",
+                runtime_talk=runtime_talk,
+                camera_talk=camera_talk,
+                source_uri=self.rtsp_url,
+                source_uri_env=self.rtsp_url_env,
+                resolved_source_uri=self.rtsp_url,
             )
         )
         return self
@@ -521,7 +411,7 @@ class RTSPSource(ThreadedClipSource):
             camera_name=camera_name,
         )
         self._live_publisher_shutdown = False
-        self._talk_adapter: ONVIFBackchannelAdapter | None = None
+        self._talk_backend_selector: TalkBackendSelector | None = None
         self._talk_manager = self._build_talk_manager(config, camera_name=camera_name)
         self._talk_manager_shutdown = False
         self._owns_recorder = recorder is None
@@ -992,85 +882,46 @@ class RTSPSource(ThreadedClipSource):
                 max_session_s=runtime_talk.max_session_s,
                 idle_timeout_s=runtime_talk.idle_timeout_s,
             )
-        if not _camera_talk_uses_onvif_for_current_runtime(camera_talk):
-            return _talk_unsupported_backend_manager(
-                backend=camera_talk.backend,
-                camera_name=self.camera_name,
-                camera_talk=camera_talk,
-                runtime_talk=runtime_talk,
-            )
-
-        adapter_config_data = _build_onvif_backchannel_config_data(
-            camera_talk.config_for_backend("onvif_rtsp_backchannel"),
-            fallback_rtsp_url=self.rtsp_url,
+        context = TalkBackendContext(
+            camera_name=camera_name,
+            source_backend="rtsp",
+            runtime_talk=runtime_talk,
+            camera_talk=camera_talk,
+            source_uri=config.rtsp_url,
+            source_uri_env=config.rtsp_url_env,
+            resolved_source_uri=self.rtsp_url,
+            source_connect_timeout_s=self.rtsp_connect_timeout_s,
+            source_io_timeout_s=self.rtsp_io_timeout_s,
+            resolve_env=os.getenv,
+            redact=_redact_rtsp_url,
         )
-        adapter_config = ONVIFBackchannelConfig.model_validate(adapter_config_data)
-        try:
-            rtsp_url = adapter_config.resolve_rtsp_url()
-        except ValueError as exc:
-            return _talk_config_error_manager(
-                message=str(exc),
-                camera_name=self.camera_name,
-                camera_talk=camera_talk,
-                runtime_talk=runtime_talk,
-                preferred_codecs=adapter_config.preferred_codecs,
-                open_session_factory=self._open_disabled_talk_session,
-            )
-        try:
-            self._talk_adapter = ONVIFBackchannelAdapter(
-                adapter_config,
-                rtsp_url=rtsp_url,
-                camera_name=camera_name,
-            )
-        except ValueError as exc:
-            return _talk_config_error_manager(
-                message=str(exc),
-                camera_name=self.camera_name,
-                camera_talk=camera_talk,
-                runtime_talk=runtime_talk,
-                preferred_codecs=adapter_config.preferred_codecs,
-                open_session_factory=self._open_disabled_talk_session,
-            )
+        selector = TalkBackendSelector(
+            registry=build_rtsp_talk_backend_registry(),
+            context=context,
+        )
+        self._talk_backend_selector = selector
         return TalkManager(
             camera_name=self.camera_name,
             enabled=True,
             policy_enabled=camera_talk.policy_enabled,
-            supported_codecs=list(adapter_config.preferred_codecs),
-            open_session_factory=self._open_onvif_talk_session,
-            capability_probe_factory=self._probe_onvif_talk_capability,
+            supported_codecs=selector.supported_codecs,
+            open_session_factory=self._open_selected_talk_session,
+            capability_probe_factory=selector.probe,
             max_session_s=runtime_talk.max_session_s,
             idle_timeout_s=runtime_talk.idle_timeout_s,
         )
 
-    async def _probe_onvif_talk_capability(self) -> TalkCapabilityProbeResult:
-        adapter = self._talk_adapter
-        if adapter is None:
-            return TalkCapabilityProbeResult(
-                capability=TalkCapabilityState.UNSUPPORTED,
-                refusal_reason=TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
-                message="Talk adapter is not configured",
-            )
-        return await adapter.probe()
-
-    async def _open_onvif_talk_session(self, request: TalkSessionOpenRequest) -> TalkSession:
-        adapter = self._talk_adapter
-        if adapter is None:
+    async def _open_selected_talk_session(self, request: TalkSessionOpenRequest) -> TalkSession:
+        selector = self._talk_backend_selector
+        if selector is None:
             raise TalkManagerError(
-                "Talk adapter is not configured",
+                "Talk backend selector is not configured",
                 reason=TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE,
             )
         try:
-            return await adapter.open_session(
-                session_id=request.session_id,
-                input_sample_rate=request.input.sample_rate,
-            )
-        except TalkProtocolError as exc:
-            raise _talk_manager_error_from_protocol_error(exc) from exc
-        except (AsyncioTimeoutError, TimeoutError, EOFError, OSError) as exc:
-            raise TalkManagerError(
-                "Camera talk backchannel failed",
-                reason=TalkRefusalReason.CAMERA_BACKCHANNEL_FAILED,
-            ) from exc
+            return await selector.open_session(request)
+        except TalkBackendOpenError as exc:
+            raise TalkManagerError(str(exc), reason=exc.reason) from exc
 
     async def _open_disabled_talk_session(self, request: TalkSessionOpenRequest) -> TalkSession:
         _ = request
@@ -2172,28 +2023,3 @@ class RTSPSource(ThreadedClipSource):
             logger.exception("Unexpected error: %s", e)
         finally:
             self.cleanup()
-
-
-def _talk_manager_error_from_protocol_error(exc: TalkProtocolError) -> TalkManagerError:
-    """Translate RTSP-specific failures before they cross the source boundary."""
-    match exc.code:
-        case TalkProtocolErrorCode.CAMERA_BACKCHANNEL_UNSUPPORTED:
-            return TalkManagerError(
-                "Camera does not support ONVIF talk backchannel",
-                reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
-            )
-        case TalkProtocolErrorCode.UNSUPPORTED_CODEC:
-            return TalkManagerError(
-                "Camera talk backchannel codec is not supported",
-                reason=TalkRefusalReason.UNSUPPORTED_CODEC,
-            )
-        case (
-            TalkProtocolErrorCode.CAMERA_REJECTED_SESSION
-            | TalkProtocolErrorCode.CAMERA_STREAM_FAILED
-            | TalkProtocolErrorCode.RTSP_AUTH_FAILED
-            | TalkProtocolErrorCode.RTSP_PROTOCOL_ERROR
-        ):
-            return TalkManagerError(
-                "Camera talk backchannel failed",
-                reason=TalkRefusalReason.CAMERA_BACKCHANNEL_FAILED,
-            )

--- a/src/homesec/sources/rtsp/talk/backend.py
+++ b/src/homesec/sources/rtsp/talk/backend.py
@@ -1,0 +1,174 @@
+"""RTSP talk backend registrations."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkRefusalReason,
+    TalkSessionOpenRequest,
+)
+from homesec.sources.rtsp.talk.errors import TalkProtocolError, TalkProtocolErrorCode
+from homesec.sources.rtsp.talk.models import ONVIFBackchannelConfig
+from homesec.sources.rtsp.talk.onvif_backchannel import ONVIFBackchannelAdapter
+from homesec.talk.backends import (
+    TalkBackendAdapter,
+    TalkBackendContext,
+    TalkBackendOpenError,
+    TalkBackendRegistration,
+    TalkBackendRegistry,
+    TalkBackendSession,
+)
+
+ONVIF_RTSP_BACKCHANNEL_BACKEND = "onvif_rtsp_backchannel"
+
+
+@dataclass(slots=True)
+class ONVIFRTSPTalkBackendAdapter:
+    """Talk backend wrapper around the existing ONVIF RTSP backchannel adapter."""
+
+    config: ONVIFBackchannelConfig
+    adapter: ONVIFBackchannelAdapter
+    name: str = ONVIF_RTSP_BACKCHANNEL_BACKEND
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        """Return codecs supported by this ONVIF backend implementation."""
+        return list(self.config.preferred_codecs)
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        """Probe camera ONVIF RTSP backchannel capability."""
+        return await self.adapter.probe()
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> TalkBackendSession:
+        """Open an ONVIF RTSP backchannel session."""
+        try:
+            return await self.adapter.open_session(
+                session_id=request.session_id,
+                input_sample_rate=request.input.sample_rate,
+            )
+        except TalkProtocolError as exc:
+            raise _backend_open_error_from_protocol_error(exc) from exc
+        except (asyncio.TimeoutError, TimeoutError, EOFError, OSError) as exc:
+            raise TalkBackendOpenError(
+                "Camera talk backchannel failed",
+                reason=TalkRefusalReason.CAMERA_BACKCHANNEL_FAILED,
+            ) from exc
+
+
+def build_rtsp_talk_backend_registry() -> TalkBackendRegistry:
+    """Build the built-in RTSP talk backend registry."""
+    registry = TalkBackendRegistry()
+    registry.register(onvif_rtsp_talk_backend_registration())
+    return registry
+
+
+def onvif_rtsp_talk_backend_registration() -> TalkBackendRegistration:
+    """Return the built-in ONVIF RTSP talk backend registration."""
+    return TalkBackendRegistration(
+        name=ONVIF_RTSP_BACKCHANNEL_BACKEND,
+        config_model=ONVIFBackchannelConfig,
+        config_factory=_validate_onvif_config,
+        factory=_build_onvif_backend,
+        priority=10,
+        standards_based=True,
+    )
+
+
+def validate_rtsp_talk_backend_config(context: TalkBackendContext) -> None:
+    """Validate statically known RTSP talk backend config at source-config load time."""
+    camera_talk = context.camera_talk
+    if camera_talk.backend == "auto":
+        _validate_onvif_config(
+            camera_talk.config_for_backend(ONVIF_RTSP_BACKCHANNEL_BACKEND),
+            context,
+        )
+        return
+    if camera_talk.backend == ONVIF_RTSP_BACKCHANNEL_BACKEND:
+        _validate_onvif_config(
+            camera_talk.config_for_backend(ONVIF_RTSP_BACKCHANNEL_BACKEND),
+            context,
+        )
+
+
+def _build_onvif_backchannel_config_data(
+    value: Mapping[str, object] | BaseModel,
+    *,
+    fallback_rtsp_url: str | None,
+    fallback_rtsp_url_env: str | None = None,
+) -> dict[str, object]:
+    """Build ONVIF talk adapter config with inherited source URL fallback rules."""
+    adapter_config_data = _talk_config_dict(value)
+    if (
+        adapter_config_data.get("rtsp_url") is not None
+        or adapter_config_data.get("rtsp_url_env") is not None
+    ):
+        return adapter_config_data
+    if fallback_rtsp_url is not None:
+        adapter_config_data["rtsp_url"] = fallback_rtsp_url
+    elif fallback_rtsp_url_env is not None:
+        adapter_config_data["rtsp_url_env"] = fallback_rtsp_url_env
+    return adapter_config_data
+
+
+def _talk_config_dict(value: Mapping[str, object] | BaseModel) -> dict[str, object]:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    return dict(value)
+
+
+def _validate_onvif_config(
+    raw_config: Mapping[str, object] | BaseModel,
+    context: TalkBackendContext,
+) -> ONVIFBackchannelConfig:
+    return ONVIFBackchannelConfig.model_validate(
+        _build_onvif_backchannel_config_data(
+            raw_config,
+            fallback_rtsp_url=context.resolved_source_uri or context.source_uri,
+            fallback_rtsp_url_env=context.source_uri_env,
+        )
+    )
+
+
+def _build_onvif_backend(
+    config: BaseModel,
+    context: TalkBackendContext,
+) -> TalkBackendAdapter:
+    if not isinstance(config, ONVIFBackchannelConfig):
+        raise TypeError(f"Expected ONVIFBackchannelConfig, got {type(config).__name__}")
+    rtsp_url = config.resolve_rtsp_url()
+    adapter = ONVIFBackchannelAdapter(config, rtsp_url=rtsp_url, camera_name=context.camera_name)
+    return ONVIFRTSPTalkBackendAdapter(config=config, adapter=adapter)
+
+
+def _backend_open_error_from_protocol_error(exc: TalkProtocolError) -> TalkBackendOpenError:
+    match exc.code:
+        case TalkProtocolErrorCode.CAMERA_BACKCHANNEL_UNSUPPORTED:
+            return TalkBackendOpenError(
+                "Camera does not advertise an ONVIF talk backchannel",
+                reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+            )
+        case TalkProtocolErrorCode.UNSUPPORTED_CODEC:
+            return TalkBackendOpenError(
+                "Camera talk backchannel codec is not supported",
+                reason=TalkRefusalReason.UNSUPPORTED_CODEC,
+            )
+        case TalkProtocolErrorCode.RTSP_AUTH_FAILED:
+            return TalkBackendOpenError(
+                "Camera talk backchannel authentication failed",
+                reason=TalkRefusalReason.CAMERA_BACKCHANNEL_FAILED,
+            )
+        case (
+            TalkProtocolErrorCode.CAMERA_REJECTED_SESSION
+            | TalkProtocolErrorCode.CAMERA_STREAM_FAILED
+            | TalkProtocolErrorCode.RTSP_PROTOCOL_ERROR
+        ):
+            return TalkBackendOpenError(
+                "Camera talk backchannel failed",
+                reason=TalkRefusalReason.CAMERA_BACKCHANNEL_FAILED,
+            )

--- a/src/homesec/sources/rtsp/talk/backend.py
+++ b/src/homesec/sources/rtsp/talk/backend.py
@@ -23,6 +23,8 @@ from homesec.talk.backends import (
     TalkBackendRegistration,
     TalkBackendRegistry,
     TalkBackendSession,
+    backend_config_for,
+    model_validate_backend_config,
 )
 
 ONVIF_RTSP_BACKCHANNEL_BACKEND = "onvif_rtsp_backchannel"
@@ -80,20 +82,35 @@ def onvif_rtsp_talk_backend_registration() -> TalkBackendRegistration:
     )
 
 
-def validate_rtsp_talk_backend_config(context: TalkBackendContext) -> None:
+def validate_rtsp_talk_backend_config(
+    context: TalkBackendContext,
+    *,
+    registry: TalkBackendRegistry | None = None,
+) -> None:
     """Validate statically known RTSP talk backend config at source-config load time."""
+    registry = registry or build_rtsp_talk_backend_registry()
     camera_talk = context.camera_talk
     if camera_talk.backend == "auto":
-        _validate_onvif_config(
-            camera_talk.config_for_backend(ONVIF_RTSP_BACKCHANNEL_BACKEND),
-            context,
-        )
+        for registration in registry.standards_first():
+            if registration.standards_based:
+                _validate_registered_backend_config(registration, context)
         return
-    if camera_talk.backend == ONVIF_RTSP_BACKCHANNEL_BACKEND:
-        _validate_onvif_config(
-            camera_talk.config_for_backend(ONVIF_RTSP_BACKCHANNEL_BACKEND),
-            context,
-        )
+
+    explicit_registration = registry.get(camera_talk.backend)
+    if explicit_registration is None:
+        return
+    _validate_registered_backend_config(explicit_registration, context)
+
+
+def _validate_registered_backend_config(
+    registration: TalkBackendRegistration,
+    context: TalkBackendContext,
+) -> None:
+    model_validate_backend_config(
+        registration,
+        backend_config_for(context.camera_talk, registration.name),
+        context=context,
+    )
 
 
 def _build_onvif_backchannel_config_data(

--- a/src/homesec/talk/backends.py
+++ b/src/homesec/talk/backends.py
@@ -9,7 +9,11 @@ from typing import Literal, Protocol, runtime_checkable
 from pydantic import BaseModel
 
 from homesec.models.config import CameraTalkConfig, TalkConfig
-from homesec.models.talk import TalkCapabilityProbeResult, TalkSessionOpenRequest
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkRefusalReason,
+    TalkSessionOpenRequest,
+)
 
 TalkBackendConfidence = Literal["explicit", "high", "medium", "low", "not_applicable"]
 
@@ -37,6 +41,9 @@ class TalkBackendAdapter(Protocol):
 @runtime_checkable
 class TalkBackendSession(Protocol):
     """Camera talk session returned by a backend adapter."""
+
+    session_id: str
+    camera_name: str
 
     @property
     def selected_codec(self) -> str:
@@ -106,6 +113,14 @@ class TalkBackendContext:
         return self.redact(value)
 
 
+class TalkBackendOpenError(RuntimeError):
+    """Raised when a selected talk backend refuses or fails session open."""
+
+    def __init__(self, message: str, *, reason: TalkRefusalReason) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
 @dataclass(frozen=True, slots=True)
 class TalkBackendRegistration:
     """Factory and detector metadata for one talk backend."""
@@ -113,6 +128,13 @@ class TalkBackendRegistration:
     name: str
     config_model: type[BaseModel]
     factory: Callable[[BaseModel, TalkBackendContext], TalkBackendAdapter]
+    config_factory: (
+        Callable[
+            [Mapping[str, object] | BaseModel, TalkBackendContext],
+            BaseModel,
+        ]
+        | None
+    ) = None
     detector: Callable[[TalkBackendContext], TalkBackendDetection] | None = None
     priority: int = 100
     standards_based: bool = False
@@ -171,8 +193,14 @@ def backend_config_for(
 def model_validate_backend_config(
     registration: TalkBackendRegistration,
     raw_config: Mapping[str, object] | BaseModel,
+    *,
+    context: TalkBackendContext | None = None,
 ) -> BaseModel:
     """Validate backend-specific config against the registered config model."""
+    if registration.config_factory is not None:
+        if context is None:
+            raise ValueError("Talk backend context is required for config validation")
+        return registration.config_factory(raw_config, context)
     if isinstance(raw_config, registration.config_model):
         return raw_config
     if isinstance(raw_config, BaseModel):

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -1,0 +1,127 @@
+"""Talk backend selection and adapter dispatch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkRefusalReason,
+    TalkSessionOpenRequest,
+)
+from homesec.talk.backends import (
+    TalkBackendAdapter,
+    TalkBackendContext,
+    TalkBackendOpenError,
+    TalkBackendRegistry,
+    TalkBackendSession,
+    backend_config_for,
+    model_validate_backend_config,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _SelectedBackend:
+    adapter: TalkBackendAdapter
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return self.adapter.supported_codecs
+
+
+@dataclass(frozen=True, slots=True)
+class _SelectionError:
+    result: TalkCapabilityProbeResult
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return []
+
+
+class TalkBackendSelector:
+    """Select and dispatch to the configured camera talk backend."""
+
+    def __init__(
+        self,
+        *,
+        registry: TalkBackendRegistry,
+        context: TalkBackendContext,
+    ) -> None:
+        self._registry = registry
+        self._context = context
+        self._selection: _SelectedBackend | _SelectionError | None = None
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        """Return supported codecs for the selected backend, if one can be built."""
+        return self._select().supported_codecs
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        """Probe the selected backend or return a selection/config error."""
+        selection = self._select()
+        if isinstance(selection, _SelectionError):
+            return selection.result
+        return await selection.adapter.probe()
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> TalkBackendSession:
+        """Open a talk session through the selected backend."""
+        selection = self._select()
+        if isinstance(selection, _SelectionError):
+            raise TalkBackendOpenError(
+                selection.result.message or "Talk backend is not available",
+                reason=selection.result.refusal_reason or TalkRefusalReason.RUNTIME_UNAVAILABLE,
+            )
+        return await selection.adapter.open_session(request)
+
+    def _select(self) -> _SelectedBackend | _SelectionError:
+        if self._selection is not None:
+            return self._selection
+
+        camera_talk = self._context.camera_talk
+        if camera_talk.backend == "auto":
+            self._selection = self._select_auto()
+            return self._selection
+
+        registration = self._registry.get(camera_talk.backend)
+        if registration is None:
+            self._selection = _SelectionError(
+                _selection_error_result(
+                    f"Talk backend '{camera_talk.backend}' is not registered in this runtime"
+                )
+            )
+            return self._selection
+
+        self._selection = self._build_registered_backend(registration.name)
+        return self._selection
+
+    def _select_auto(self) -> _SelectedBackend | _SelectionError:
+        registrations = self._registry.standards_first()
+        if not registrations:
+            return _SelectionError(_selection_error_result("No talk backends are registered"))
+        return self._build_registered_backend(registrations[0].name)
+
+    def _build_registered_backend(self, backend_name: str) -> _SelectedBackend | _SelectionError:
+        registration = self._registry.get(backend_name)
+        if registration is None:
+            return _SelectionError(
+                _selection_error_result(
+                    f"Talk backend '{backend_name}' is not registered in this runtime"
+                )
+            )
+        raw_config = backend_config_for(self._context.camera_talk, registration.name)
+        try:
+            config = model_validate_backend_config(registration, raw_config, context=self._context)
+            return _SelectedBackend(registration.factory(config, self._context))
+        except (ValueError, ValidationError) as exc:
+            return _SelectionError(_selection_error_result(str(exc)))
+
+
+def _selection_error_result(message: str) -> TalkCapabilityProbeResult:
+    return TalkCapabilityProbeResult(
+        capability=TalkCapabilityState.ERROR,
+        refusal_reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
+        message=message,
+    )

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -113,9 +113,15 @@ class TalkBackendSelector:
         if detected_registration is not None:
             return self._build_registered_backend(detected_registration.name)
 
-        registrations = self._registry.standards_first()
+        registrations = [
+            registration
+            for registration in self._registry.standards_first()
+            if registration.standards_based
+        ]
         if not registrations:
-            return _SelectionError(_selection_error_result("No talk backends are registered"))
+            return _SelectionError(
+                _selection_error_result("No standards-based talk backends are registered")
+            )
         return self._build_registered_backend(registrations[0].name)
 
     def _detected_auto_registration(self) -> TalkBackendRegistration | None:

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -14,8 +14,10 @@ from homesec.models.talk import (
 )
 from homesec.talk.backends import (
     TalkBackendAdapter,
+    TalkBackendConfidence,
     TalkBackendContext,
     TalkBackendOpenError,
+    TalkBackendRegistration,
     TalkBackendRegistry,
     TalkBackendSession,
     backend_config_for,
@@ -39,6 +41,15 @@ class _SelectionError:
     @property
     def supported_codecs(self) -> list[str]:
         return []
+
+
+_AUTO_DETECTION_CONFIDENCE_RANK: dict[TalkBackendConfidence, int] = {
+    "explicit": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+    "not_applicable": 4,
+}
 
 
 class TalkBackendSelector:
@@ -98,10 +109,40 @@ class TalkBackendSelector:
         return self._selection
 
     def _select_auto(self) -> _SelectedBackend | _SelectionError:
+        detected_registration = self._detected_auto_registration()
+        if detected_registration is not None:
+            return self._build_registered_backend(detected_registration.name)
+
         registrations = self._registry.standards_first()
         if not registrations:
             return _SelectionError(_selection_error_result("No talk backends are registered"))
         return self._build_registered_backend(registrations[0].name)
+
+    def _detected_auto_registration(self) -> TalkBackendRegistration | None:
+        detected: list[tuple[int, bool, int, str, TalkBackendRegistration]] = []
+        for registration in self._registry.all():
+            if registration.detector is None:
+                continue
+            detection = registration.detector(self._context)
+            if (
+                detection.backend.lower() != registration.name
+                or detection.confidence == "not_applicable"
+                or not detection.safe_to_probe
+            ):
+                continue
+            detected.append(
+                (
+                    _AUTO_DETECTION_CONFIDENCE_RANK[detection.confidence],
+                    not registration.standards_based,
+                    registration.priority,
+                    registration.name,
+                    registration,
+                )
+            )
+        if not detected:
+            return None
+        detected.sort(key=lambda item: item[:4])
+        return detected[0][4]
 
     def _build_registered_backend(self, backend_name: str) -> _SelectedBackend | _SelectionError:
         registration = self._registry.get(backend_name)

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -792,7 +792,7 @@ async def test_talk_disabled_by_policy_does_not_build_camera_backchannel(
         raise AssertionError("disabled talk should not construct the ONVIF backchannel adapter")
 
     monkeypatch.setattr(
-        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        "homesec.sources.rtsp.talk.backend.ONVIFBackchannelAdapter",
         _unexpected_adapter,
     )
     config = _make_config(
@@ -820,17 +820,17 @@ async def test_talk_disabled_by_policy_does_not_build_camera_backchannel(
 
 
 @pytest.mark.asyncio
-async def test_explicit_future_talk_backend_reports_unsupported_without_onvif_probe(
+async def test_unknown_explicit_talk_backend_reports_config_error_without_onvif_probe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unimplemented explicit talk backends should not look policy-disabled."""
+    """Unknown explicit talk backends should not fallback or look policy-disabled."""
 
     def _unexpected_adapter(*_: object, **__: object) -> object:
         raise AssertionError("future backend should not construct the ONVIF backchannel adapter")
 
     monkeypatch.setattr(
-        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        "homesec.sources.rtsp.talk.backend.ONVIFBackchannelAdapter",
         _unexpected_adapter,
     )
     config = _make_config(
@@ -850,14 +850,14 @@ async def test_explicit_future_talk_backend_reports_unsupported_without_onvif_pr
         TalkSessionPrepareRequest(session_id="tk_future_backend")
     )
 
-    # Then: The source reports unsupported backend diagnostics, not disabled policy.
+    # Then: The source reports selection/config diagnostics, not disabled policy.
     assert status.enabled is True
     assert status.policy_enabled is True
-    assert status.capability == TalkCapabilityState.UNSUPPORTED
-    assert status.state == TalkState.UNSUPPORTED
-    assert status.last_error == "Talk backend 'tapo_local' is not available in this runtime yet"
+    assert status.capability == TalkCapabilityState.ERROR
+    assert status.state == TalkState.ERROR
+    assert status.last_error == "Talk backend 'tapo_local' is not registered in this runtime"
     assert prepared.accepted is False
-    assert prepared.refusal_reason == TalkRefusalReason.SOURCE_NOT_TALK_CAPABLE
+    assert prepared.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
     assert prepared.message == status.last_error
 
 
@@ -930,7 +930,7 @@ async def test_talk_backchannel_uses_dedicated_rtsp_url_env_for_capability_probe
             )
 
     monkeypatch.setattr(
-        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        "homesec.sources.rtsp.talk.backend.ONVIFBackchannelAdapter",
         _FakeONVIFBackchannelAdapter,
     )
     monkeypatch.setenv("TALK_RTSP_URL", "rtsp://camera.local/talk")
@@ -975,7 +975,7 @@ async def test_talk_backchannel_inherits_source_rtsp_url_when_no_override_is_con
             return TalkCapabilityProbeResult(capability=TalkCapabilityState.SUPPORTED)
 
     monkeypatch.setattr(
-        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        "homesec.sources.rtsp.talk.backend.ONVIFBackchannelAdapter",
         _FakeONVIFBackchannelAdapter,
     )
     config = _make_config(
@@ -1009,7 +1009,7 @@ async def test_talk_backchannel_missing_explicit_rtsp_url_env_reports_config_err
         raise AssertionError("missing talk rtsp_url_env should not construct the adapter")
 
     monkeypatch.setattr(
-        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        "homesec.sources.rtsp.talk.backend.ONVIFBackchannelAdapter",
         _unexpected_adapter,
     )
     monkeypatch.delenv("MISSING_TALK_RTSP_URL", raising=False)
@@ -1135,7 +1135,7 @@ async def test_talk_backchannel_open_io_failure_reports_camera_backchannel_error
             raise asyncio.TimeoutError("RTSP DESCRIBE timed out")
 
     monkeypatch.setattr(
-        "homesec.sources.rtsp.core.ONVIFBackchannelAdapter",
+        "homesec.sources.rtsp.talk.backend.ONVIFBackchannelAdapter",
         _FakeONVIFBackchannelAdapter,
     )
     config = _make_config(

--- a/tests/homesec/rtsp/test_talk_backend.py
+++ b/tests/homesec/rtsp/test_talk_backend.py
@@ -1,0 +1,104 @@
+"""Tests for RTSP talk backend registration behavior."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkSessionOpenRequest,
+)
+from homesec.sources.rtsp.talk.backend import validate_rtsp_talk_backend_config
+from homesec.talk.backends import (
+    TalkBackendContext,
+    TalkBackendRegistration,
+    TalkBackendRegistry,
+)
+
+
+class _FutureBackendConfig(BaseModel):
+    marker: str
+
+
+class _FakeSession:
+    session_id = "tk_fake"
+    camera_name = "front"
+    selected_codec = "PCMU/8000"
+
+    async def write_pcm_frame(self, frame: bytes) -> None:
+        _ = frame
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeBackend:
+    name = "future_backend"
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return ["PCMU/8000"]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        return TalkCapabilityProbeResult(capability=TalkCapabilityState.SUPPORTED)
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> _FakeSession:
+        _ = request
+        return _FakeSession()
+
+
+def _future_registry() -> TalkBackendRegistry:
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="future_backend",
+            config_model=_FutureBackendConfig,
+            factory=lambda config, context: _FakeBackend(),
+        )
+    )
+    return registry
+
+
+def _context(camera_talk: CameraTalkConfig) -> TalkBackendContext:
+    return TalkBackendContext(
+        camera_name="front",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=camera_talk,
+        resolved_source_uri="rtsp://camera.local/stream1",
+    )
+
+
+def test_rtsp_talk_config_validation_uses_registered_explicit_backend_model() -> None:
+    """Explicit registered backends should validate through the registry contract."""
+    # Given: A registered future backend with required backend-specific config
+    context = _context(
+        CameraTalkConfig(
+            backend="future_backend",
+            backends={"future_backend": {"marker": "configured"}},
+        )
+    )
+
+    # When: Validating RTSP talk backend config at source-config load time
+    validate_rtsp_talk_backend_config(context, registry=_future_registry())
+
+    # Then: The registered backend config is accepted without ONVIF-specific branches
+
+
+def test_rtsp_talk_config_validation_rejects_registered_backend_config_errors() -> None:
+    """Explicit registered backend config errors should fail source-config validation."""
+    # Given: A registered future backend with invalid backend-specific config
+    context = _context(
+        CameraTalkConfig(
+            backend="future_backend",
+            backends={"future_backend": {}},
+        )
+    )
+
+    # When: Validating RTSP talk backend config at source-config load time
+    # Then: The selected backend's Pydantic model reports the config error
+    with pytest.raises(ValidationError, match="marker"):
+        validate_rtsp_talk_backend_config(context, registry=_future_registry())

--- a/tests/homesec/talk/test_backend_registry.py
+++ b/tests/homesec/talk/test_backend_registry.py
@@ -35,6 +35,8 @@ class _OtherBackendConfig(BaseModel):
 
 
 class _FakeSession:
+    session_id = "tk_fake"
+    camera_name = "front"
     selected_codec = "PCMU/8000"
 
     async def write_pcm_frame(self, frame: bytes) -> None:

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -185,6 +185,37 @@ async def test_selector_auto_ignores_detector_that_is_not_safe_to_probe() -> Non
 
 
 @pytest.mark.asyncio
+async def test_selector_auto_refuses_vendor_only_registry_without_safe_detector() -> None:
+    """Backend auto mode should not probe proprietary backends without safe detection."""
+    # Given: A registry with only a vendor backend and no safe detector match
+    calls: list[str] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("vendor_backend", calls),
+            priority=1,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing through auto selection
+    probe = await selector.probe()
+
+    # Then: Selection returns a config/runtime error without probing the vendor backend
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+    assert probe.message == "No standards-based talk backends are registered"
+    assert selector.supported_codecs == []
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_selector_explicit_backend_does_not_fallback_to_standards_backend() -> None:
     """Explicit backend mode should not fallback to registered standards backends."""
     # Given: A selector with an explicit backend that is not registered

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -15,6 +15,7 @@ from homesec.models.talk import (
 )
 from homesec.talk.backends import (
     TalkBackendContext,
+    TalkBackendDetection,
     TalkBackendOpenError,
     TalkBackendRegistration,
     TalkBackendRegistry,
@@ -109,6 +110,78 @@ async def test_selector_auto_uses_standards_backend_first() -> None:
     assert selector.supported_codecs == ["PCMU/8000"]
     assert session.selected_codec == "PCMU/8000"
     assert calls == ["standard_backend:probe", "standard_backend:open:tk_auto"]
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_uses_safe_high_confidence_detector_before_default() -> None:
+    """Backend auto mode should honor safe high-confidence detector matches."""
+    # Given: A selector in auto mode with a standard default and detected vendor backend
+    calls: list[str] = []
+    registry = _registry(calls)
+    registry.register(
+        TalkBackendRegistration(
+            name="detected_vendor",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("detected_vendor", calls),
+            detector=lambda context: TalkBackendDetection(
+                backend="detected_vendor",
+                confidence="high",
+                reason="camera fingerprint matched detected vendor",
+                safe_to_probe=True,
+            ),
+            priority=200,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing and opening a talk session
+    probe = await selector.probe()
+    session = await selector.open_session(
+        TalkSessionOpenRequest(session_id="tk_detected", input=TalkInputFormat())
+    )
+
+    # Then: The detector-selected backend handles the request before the standard default
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert session.selected_codec == "PCMU/8000"
+    assert calls == ["detected_vendor:probe", "detected_vendor:open:tk_detected"]
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_ignores_detector_that_is_not_safe_to_probe() -> None:
+    """Backend auto mode should not auto-probe unsafe detector matches."""
+    # Given: A selector in auto mode with a vendor detector that is not safe to probe
+    calls: list[str] = []
+    registry = _registry(calls)
+    registry.register(
+        TalkBackendRegistration(
+            name="unsafe_vendor",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("unsafe_vendor", calls),
+            detector=lambda context: TalkBackendDetection(
+                backend="unsafe_vendor",
+                confidence="high",
+                reason="camera fingerprint matched but probing is not safe",
+                safe_to_probe=False,
+            ),
+            priority=1,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing through auto selection
+    probe = await selector.probe()
+
+    # Then: Selection falls back to the standard backend instead of unsafe vendor probing
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert calls == ["standard_backend:probe"]
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -1,0 +1,174 @@
+"""Tests for talk backend selection behavior."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkInputFormat,
+    TalkRefusalReason,
+    TalkSessionOpenRequest,
+)
+from homesec.talk.backends import (
+    TalkBackendContext,
+    TalkBackendOpenError,
+    TalkBackendRegistration,
+    TalkBackendRegistry,
+)
+from homesec.talk.selector import TalkBackendSelector
+
+
+class _BackendConfig(BaseModel):
+    marker: str = "default"
+
+
+class _FakeSession:
+    session_id = "tk_fake"
+    camera_name = "cam"
+    selected_codec = "PCMU/8000"
+
+    async def write_pcm_frame(self, frame: bytes) -> None:
+        _ = frame
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeBackend:
+    def __init__(self, name: str, calls: list[str]) -> None:
+        self.name = name
+        self._calls = calls
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return ["PCMU/8000"]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        self._calls.append(f"{self.name}:probe")
+        return TalkCapabilityProbeResult(capability=TalkCapabilityState.SUPPORTED)
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> _FakeSession:
+        self._calls.append(f"{self.name}:open:{request.session_id}")
+        return _FakeSession()
+
+
+def _context(camera_talk: CameraTalkConfig) -> TalkBackendContext:
+    return TalkBackendContext(
+        camera_name="cam",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=camera_talk,
+    )
+
+
+def _registry(calls: list[str]) -> TalkBackendRegistry:
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="standard_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("standard_backend", calls),
+            priority=10,
+            standards_based=True,
+        )
+    )
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("vendor_backend", calls),
+            priority=1,
+            standards_based=False,
+        )
+    )
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_uses_standards_backend_first() -> None:
+    """Backend auto mode should prefer standards-based registrations."""
+    # Given: A selector in auto mode with standards and vendor backend registrations
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls),
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing and opening a talk session
+    probe = await selector.probe()
+    session = await selector.open_session(
+        TalkSessionOpenRequest(session_id="tk_auto", input=TalkInputFormat())
+    )
+
+    # Then: The standards backend handles the request before vendor-specific candidates
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.supported_codecs == ["PCMU/8000"]
+    assert session.selected_codec == "PCMU/8000"
+    assert calls == ["standard_backend:probe", "standard_backend:open:tk_auto"]
+
+
+@pytest.mark.asyncio
+async def test_selector_explicit_backend_does_not_fallback_to_standards_backend() -> None:
+    """Explicit backend mode should not fallback to registered standards backends."""
+    # Given: A selector with an explicit backend that is not registered
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls),
+        context=_context(CameraTalkConfig(backend="missing_vendor")),
+    )
+
+    # When: Probing and opening through the selector
+    probe = await selector.probe()
+
+    # Then: Selection reports a config/runtime error without probing fallback backends
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+    assert probe.message == "Talk backend 'missing_vendor' is not registered in this runtime"
+    assert selector.supported_codecs == []
+    assert calls == []
+
+    # When: Opening a session with the same missing explicit backend
+    # Then: The selector raises the same refusal reason for TalkManager mapping
+    with pytest.raises(TalkBackendOpenError) as exc_info:
+        await selector.open_session(
+            TalkSessionOpenRequest(session_id="tk_missing", input=TalkInputFormat())
+        )
+    assert exc_info.value.reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_selector_uses_explicit_registered_backend_config() -> None:
+    """Explicit registered backends should receive their own config block."""
+    # Given: A selector with backend-specific config for an explicit vendor backend
+    seen_config: list[_BackendConfig] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: (
+                seen_config.append(config) or _FakeBackend("vendor_backend", [])
+            ),
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(
+            CameraTalkConfig(
+                backend="vendor_backend",
+                config={"marker": "legacy"},
+                backends={"vendor_backend": {"marker": "backend-map"}},
+            )
+        ),
+    )
+
+    # When: Probing the explicitly selected backend
+    probe = await selector.probe()
+
+    # Then: Backend-specific config wins over the legacy config alias
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert seen_config == [_BackendConfig(marker="backend-map")]


### PR DESCRIPTION
## Summary
Implements Phase 9.2 of the push-to-talk backend abstraction work.

- Adds `TalkBackendSelector` for explicit and `auto` backend selection.
- Adds the built-in ONVIF RTSP talk backend registration and `ONVIFRTSPTalkBackendAdapter` wrapper.
- Migrates `RTSPSource` talk manager wiring to selector-provided probe/open functions so `RTSPSource` no longer constructs `ONVIFBackchannelAdapter` directly.
- Preserves existing ONVIF fallback rules and fake-camera E2E behavior.
- Reports unknown explicit backend names as selection/config errors without falling back to ONVIF.
- Adds selector contract tests for auto selection, explicit no-fallback behavior, and backend-specific config precedence.

## Notion
- Parent epic: https://www.notion.so/levneiman/Epic-Push-to-talk-camera-speaker-audio-backchannel-357d8336c59f81aa99c3c9fa820f9835
- Phase 9 parent: https://www.notion.so/levneiman/Phase-9-talk-backend-adapter-abstraction-and-selection-358d8336c59f81ff84b0f7436fdf6370
- Ticket: https://www.notion.so/levneiman/Phase-9-2-ONVIF-backend-wrapper-and-selector-migration-359d8336c59f81159ee8c85e15c70c8b

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:55432/homesec make check`
