### PR TITLE
feat: add talk backend diagnostics

### DIFF
--- a/docs/push-to-talk.md
+++ b/docs/push-to-talk.md
@@ -143,6 +143,8 @@ or WebSocket diagnostics. Do not put URLs, credentials, tokens, or raw protocol
 payloads in `cameras[].talk.backend` or `cameras[].talk.backends` keys.
 `backend_reason` must not include RTSP URLs, camera credentials, password
 hashes, API keys, stream tokens, raw auth headers, or raw SDP.
+Backend config validation failures expose a stable public `last_error` rather
+than raw validator text, because validator text can include rejected input.
 
 ## Security and Privacy Notes
 

--- a/docs/push-to-talk.md
+++ b/docs/push-to-talk.md
@@ -100,8 +100,10 @@ cameras:
 
 HomeSec currently ships the ONVIF RTSP backchannel implementation. Explicit
 future backend names are accepted by config parsing so operators can stage
-configuration, but they report a talk backend selection/config error until a
-matching backend adapter is implemented and registered.
+configuration, but backend names must be safe identifiers: lowercase letters,
+numbers, and underscores, starting with a letter. Unregistered safe backend names
+report a talk backend selection/config error until a matching backend adapter is
+implemented and registered.
 
 Use environment variables for RTSP URLs and credentials. Do not commit camera
 passwords in YAML.
@@ -136,6 +138,9 @@ Backend diagnostics are intentionally minimal:
 - `backend_reason`: safe human-readable text explaining backend selection or why
   no backend was selected.
 
+Backend names are constrained to safe identifiers before they can appear in API
+or WebSocket diagnostics. Do not put URLs, credentials, tokens, or raw protocol
+payloads in `cameras[].talk.backend` or `cameras[].talk.backends` keys.
 `backend_reason` must not include RTSP URLs, camera credentials, password
 hashes, API keys, stream tokens, raw auth headers, or raw SDP.
 

--- a/docs/push-to-talk.md
+++ b/docs/push-to-talk.md
@@ -124,6 +124,21 @@ cameras:
       mode: disabled
 ```
 
+## Status Diagnostics
+
+`GET /api/v1/talk/cameras/{camera_name}` returns the current talk policy,
+capability, selected backend, codec negotiation, and session state.
+
+Backend diagnostics are intentionally minimal:
+
+- `backend`: selected talk backend name once selection has completed, or the
+  explicit backend name when a configured backend is invalid or unavailable.
+- `backend_reason`: safe human-readable text explaining backend selection or why
+  no backend was selected.
+
+`backend_reason` must not include RTSP URLs, camera credentials, password
+hashes, API keys, stream tokens, raw auth headers, or raw SDP.
+
 ## Security and Privacy Notes
 
 - Treat talk as live microphone access. Browser permission prompts are expected.
@@ -195,7 +210,8 @@ Suggested result values:
 - Confirm `cameras[].talk.mode` is not `disabled` for the selected camera.
 - Confirm the camera source is RTSP; non-RTSP sources are not talk-capable in the MVP.
 - Check `GET /api/v1/talk/cameras/{camera_name}` for `state`, `capability`,
-  `offered_codecs`, `selected_codec`, and `last_error`.
+  `backend`, `backend_reason`, `offered_codecs`, `selected_codec`, and
+  `last_error`.
 
 ### Browser microphone permission is denied
 

--- a/src/homesec/api/routes/talk.py
+++ b/src/homesec/api/routes/talk.py
@@ -359,6 +359,8 @@ class TalkWebSocketSession:
                     "session_id": self.session_id,
                     "input": input_format.model_dump(mode="json"),
                     "camera_codec": stream.selected_codec,
+                    "backend": stream.backend,
+                    "backend_reason": stream.backend_reason,
                 }
             )
             await _forward_websocket_frames(

--- a/src/homesec/api/routes/talk.py
+++ b/src/homesec/api/routes/talk.py
@@ -62,6 +62,8 @@ class TalkStatusResponse(BaseModel):
     supported_codecs: list[str] = Field(default_factory=list)
     offered_codecs: list[str] = Field(default_factory=list)
     selected_codec: str | None = None
+    backend: str | None = None
+    backend_reason: str | None = None
     last_error: str | None = None
 
 
@@ -132,6 +134,8 @@ def _status_response(talk_status: CameraTalkStatus) -> TalkStatusResponse:
         supported_codecs=list(talk_status.supported_codecs),
         offered_codecs=list(talk_status.offered_codecs),
         selected_codec=talk_status.selected_codec,
+        backend=talk_status.backend,
+        backend_reason=talk_status.backend_reason,
         last_error=talk_status.last_error,
     )
 

--- a/src/homesec/api/routes/talk.py
+++ b/src/homesec/api/routes/talk.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 from urllib.parse import quote, urlencode
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect, status
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from homesec.api.dependencies import get_homesec_app
 from homesec.api.errors import APIError, APIErrorCode
@@ -26,6 +26,7 @@ from homesec.models.talk import (
     TalkInputFormat,
     TalkRefusalReason,
     TalkState,
+    sanitize_talk_backend_diagnostic_fields,
 )
 from homesec.runtime.errors import (
     TalkCameraNotFoundError,
@@ -65,6 +66,11 @@ class TalkStatusResponse(BaseModel):
     backend: str | None = None
     backend_reason: str | None = None
     last_error: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _sanitize_backend_diagnostics(cls, value: object) -> object:
+        return sanitize_talk_backend_diagnostic_fields(value)
 
 
 class TalkSessionRequest(BaseModel):

--- a/src/homesec/models/config.py
+++ b/src/homesec/models/config.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from homesec.models.filter import FilterConfig
 from homesec.models.talk import TalkInputFormat
 from homesec.models.vlm import VLMConfig
+from homesec.talk.backend_ids import normalize_talk_backend_id, validate_talk_backend_id
 
 
 class AlertPolicyConfig(BaseModel):
@@ -287,11 +288,12 @@ class CameraTalkConfig(BaseModel):
         config = dict(value)
         backend = config.get("backend")
         if isinstance(backend, str):
-            config["backend"] = backend.lower()
+            config["backend"] = normalize_talk_backend_id(backend)
         backends = config.get("backends")
         if isinstance(backends, dict):
             config["backends"] = {
-                key.lower() if isinstance(key, str) else key: item for key, item in backends.items()
+                normalize_talk_backend_id(key) if isinstance(key, str) else key: item
+                for key, item in backends.items()
             }
         if "mode" not in config and "enabled" in config:
             config["mode"] = "auto" if _bool_config_value(config["enabled"]) else "disabled"
@@ -300,10 +302,13 @@ class CameraTalkConfig(BaseModel):
         return config
 
     @model_validator(mode="after")
-    def _validate_enabled_alias(self) -> CameraTalkConfig:
+    def _validate_enabled_alias_and_backend_ids(self) -> CameraTalkConfig:
         expected_enabled = self.mode != "disabled"
         if self.enabled != expected_enabled:
             raise ValueError("camera talk enabled must agree with mode")
+        validate_talk_backend_id(self.backend)
+        for backend_name in self.backends:
+            validate_talk_backend_id(backend_name)
         return self
 
     @property
@@ -313,7 +318,7 @@ class CameraTalkConfig(BaseModel):
 
     def config_for_backend(self, backend_name: str) -> dict[str, Any]:
         """Return backend-specific config while preserving legacy config aliases."""
-        normalized_backend = backend_name.lower()
+        normalized_backend = normalize_talk_backend_id(backend_name)
         if normalized_backend in self.backends:
             return _model_or_dict_config(self.backends[normalized_backend])
         if self.backend == normalized_backend and self.config:
@@ -330,7 +335,7 @@ class CameraTalkConfig(BaseModel):
     @classmethod
     def _normalize_backend(cls, value: Any) -> Any:
         if isinstance(value, str):
-            return value.lower()
+            return normalize_talk_backend_id(value)
         return value
 
 

--- a/src/homesec/models/talk.py
+++ b/src/homesec/models/talk.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from homesec.talk.backend_ids import sanitize_talk_backend_id
+from homesec.talk.backend_ids import sanitize_talk_backend_id, sanitize_talk_backend_reason
 
 
 class TalkState(StrEnum):
@@ -120,11 +120,11 @@ class CameraTalkStatus(BaseModel):
 
 def sanitize_talk_backend_diagnostic_fields(value: object) -> object:
     """Normalize or drop unsafe backend IDs before public diagnostics."""
-    if not isinstance(value, dict) or "backend" not in value:
+    if not isinstance(value, dict):
         return value
 
     raw_backend = value.get("backend")
-    if raw_backend is None:
+    if raw_backend is None and "backend_reason" not in value:
         return value
 
     sanitized_backend = sanitize_talk_backend_id(raw_backend)
@@ -132,6 +132,10 @@ def sanitize_talk_backend_diagnostic_fields(value: object) -> object:
     sanitized_value["backend"] = sanitized_backend
     if sanitized_backend is None:
         sanitized_value["backend_reason"] = None
+    elif "backend_reason" in sanitized_value:
+        sanitized_value["backend_reason"] = sanitize_talk_backend_reason(
+            sanitized_value["backend_reason"]
+        )
     return sanitized_value
 
 

--- a/src/homesec/models/talk.py
+++ b/src/homesec/models/talk.py
@@ -97,6 +97,8 @@ class CameraTalkStatus(BaseModel):
     supported_codecs: list[str] = Field(default_factory=list)
     offered_codecs: list[str] = Field(default_factory=list)
     selected_codec: str | None = None
+    backend: str | None = None
+    backend_reason: str | None = None
     last_error: str | None = None
 
     @model_validator(mode="after")

--- a/src/homesec/models/talk.py
+++ b/src/homesec/models/talk.py
@@ -7,6 +7,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from homesec.talk.backend_ids import sanitize_talk_backend_id
+
 
 class TalkState(StrEnum):
     """Current talk capability/session state for a camera."""
@@ -101,6 +103,11 @@ class CameraTalkStatus(BaseModel):
     backend_reason: str | None = None
     last_error: str | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _sanitize_backend_diagnostics(cls, value: object) -> object:
+        return sanitize_talk_backend_diagnostic_fields(value)
+
     @model_validator(mode="after")
     def _derive_compatibility_defaults(self) -> CameraTalkStatus:
         """Default new capability fields from the legacy status contract."""
@@ -109,6 +116,23 @@ class CameraTalkStatus(BaseModel):
         if "capability" not in self.model_fields_set:
             self.capability = _capability_from_state(self.state)
         return self
+
+
+def sanitize_talk_backend_diagnostic_fields(value: object) -> object:
+    """Normalize or drop unsafe backend IDs before public diagnostics."""
+    if not isinstance(value, dict) or "backend" not in value:
+        return value
+
+    raw_backend = value.get("backend")
+    if raw_backend is None:
+        return value
+
+    sanitized_backend = sanitize_talk_backend_id(raw_backend)
+    sanitized_value = dict(value)
+    sanitized_value["backend"] = sanitized_backend
+    if sanitized_backend is None:
+        sanitized_value["backend_reason"] = None
+    return sanitized_value
 
 
 def _capability_from_state(state: TalkState) -> TalkCapabilityState:

--- a/src/homesec/runtime/models.py
+++ b/src/homesec/runtime/models.py
@@ -147,6 +147,8 @@ class RuntimeTalkStream:
     reader: asyncio.StreamReader
     writer: asyncio.StreamWriter
     selected_codec: str | None = None
+    backend: str | None = None
+    backend_reason: str | None = None
 
 
 @dataclass(slots=True)

--- a/src/homesec/runtime/models.py
+++ b/src/homesec/runtime/models.py
@@ -10,7 +10,12 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
-from homesec.models.talk import TalkInputFormat, TalkRefusalReason, TalkState
+from homesec.models.talk import (
+    TalkInputFormat,
+    TalkRefusalReason,
+    TalkState,
+    sanitize_talk_backend_diagnostic_fields,
+)
 from homesec.notifiers.multiplex import NotifierEntry
 from homesec.pipeline import ClipPipeline
 
@@ -149,6 +154,17 @@ class RuntimeTalkStream:
     selected_codec: str | None = None
     backend: str | None = None
     backend_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Drop unsafe backend diagnostics before WebSocket publication."""
+        sanitized = sanitize_talk_backend_diagnostic_fields(
+            {"backend": self.backend, "backend_reason": self.backend_reason}
+        )
+        if isinstance(sanitized, dict):
+            backend = sanitized.get("backend")
+            backend_reason = sanitized.get("backend_reason")
+            self.backend = backend if isinstance(backend, str) else None
+            self.backend_reason = backend_reason if isinstance(backend_reason, str) else None
 
 
 @dataclass(slots=True)

--- a/src/homesec/runtime/subprocess_controller.py
+++ b/src/homesec/runtime/subprocess_controller.py
@@ -921,6 +921,8 @@ class SubprocessRuntimeController(RuntimeController):
             supported_codecs=list(payload.supported_codecs),
             offered_codecs=list(payload.offered_codecs),
             selected_codec=payload.selected_codec,
+            backend=payload.backend,
+            backend_reason=payload.backend_reason,
             last_error=payload.last_error,
         )
 

--- a/src/homesec/runtime/subprocess_controller.py
+++ b/src/homesec/runtime/subprocess_controller.py
@@ -792,6 +792,10 @@ class SubprocessRuntimeController(RuntimeController):
             selected_codec = (
                 result.talk_status.selected_codec if result.talk_status is not None else None
             )
+            backend = result.talk_status.backend if result.talk_status is not None else None
+            backend_reason = (
+                result.talk_status.backend_reason if result.talk_status is not None else None
+            )
             close_writer = False
             return RuntimeTalkStream(
                 camera_name=camera_name,
@@ -800,6 +804,8 @@ class SubprocessRuntimeController(RuntimeController):
                 reader=reader,
                 writer=writer,
                 selected_codec=selected_codec,
+                backend=backend,
+                backend_reason=backend_reason,
             )
         except TalkCameraNotFoundError:
             raise

--- a/src/homesec/runtime/subprocess_protocol.py
+++ b/src/homesec/runtime/subprocess_protocol.py
@@ -14,6 +14,7 @@ from homesec.models.talk import (
     TalkRefusalReason,
     TalkSessionPrepareResult,
     TalkState,
+    sanitize_talk_backend_diagnostic_fields,
 )
 from homesec.runtime.models import PreviewRefusalReason, PreviewState
 
@@ -72,6 +73,11 @@ class WorkerTalkStatusPayload(BaseModel):
     backend: str | None = None
     backend_reason: str | None = None
     last_error: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _sanitize_backend_diagnostics(cls, value: object) -> object:
+        return sanitize_talk_backend_diagnostic_fields(value)
 
     @model_validator(mode="after")
     def _derive_compatibility_defaults(self) -> WorkerTalkStatusPayload:

--- a/src/homesec/runtime/subprocess_protocol.py
+++ b/src/homesec/runtime/subprocess_protocol.py
@@ -69,6 +69,8 @@ class WorkerTalkStatusPayload(BaseModel):
     supported_codecs: list[str] = Field(default_factory=list)
     offered_codecs: list[str] = Field(default_factory=list)
     selected_codec: str | None = None
+    backend: str | None = None
+    backend_reason: str | None = None
     last_error: str | None = None
 
     @model_validator(mode="after")
@@ -92,6 +94,8 @@ class WorkerTalkStatusPayload(BaseModel):
             supported_codecs=list(status.supported_codecs),
             offered_codecs=list(status.offered_codecs),
             selected_codec=status.selected_codec,
+            backend=status.backend,
+            backend_reason=status.backend_reason,
             last_error=status.last_error,
         )
 

--- a/src/homesec/runtime/worker.py
+++ b/src/homesec/runtime/worker.py
@@ -812,13 +812,11 @@ class _RuntimeWorkerService:
             session = await source.open_talk_session(
                 TalkSessionOpenRequest(session_id=session_id, input=input_format)
             )
-            return WorkerCommandResult(
-                command=command.command,
-                command_id=command.command_id,
-                generation=self._generation,
-                correlation_id=self._correlation_id,
-                camera_name=command.camera_name,
-                talk_status=WorkerTalkStatusPayload(
+            try:
+                talk_status = source.talk_status()
+            except Exception:
+                talk_status = CameraTalkStatus(
+                    camera_name=command.camera_name,
                     enabled=True,
                     policy_enabled=self._talk_policy_enabled(command.camera_name),
                     capability=TalkCapabilityState.SUPPORTED,
@@ -827,7 +825,26 @@ class _RuntimeWorkerService:
                     supported_codecs=[session.selected_codec],
                     offered_codecs=[session.selected_codec],
                     selected_codec=session.selected_codec,
-                ),
+                )
+            else:
+                talk_status = talk_status.model_copy(
+                    update={
+                        "capability": TalkCapabilityState.SUPPORTED,
+                        "state": TalkState.ACTIVE,
+                        "active_session_id": session.session_id,
+                        "selected_codec": session.selected_codec,
+                        "supported_codecs": talk_status.supported_codecs
+                        or [session.selected_codec],
+                        "offered_codecs": talk_status.offered_codecs or [session.selected_codec],
+                    }
+                )
+            return WorkerCommandResult(
+                command=command.command,
+                command_id=command.command_id,
+                generation=self._generation,
+                correlation_id=self._correlation_id,
+                camera_name=command.camera_name,
+                talk_status=WorkerTalkStatusPayload.from_status(talk_status),
             )
         except Exception as exc:
             reason = _talk_refusal_reason_from_exception(exc)

--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -23,6 +23,7 @@ from homesec.models.clip import Clip
 from homesec.models.config import CameraTalkConfig, PreviewConfig, TalkConfig
 from homesec.models.talk import (
     CameraTalkStatus,
+    TalkCapabilityState,
     TalkRefusalReason,
     TalkSessionOpenRequest,
     TalkSessionPrepareRequest,
@@ -512,7 +513,7 @@ class RTSPSource(ThreadedClipSource):
                 enabled=False,
                 state=TalkState.DISABLED,
             )
-        return manager.status()
+        return self._with_talk_backend_diagnostics(manager.status())
 
     async def refresh_talk_status(self) -> CameraTalkStatus:
         """Refresh discovered push-to-talk capability and return current status."""
@@ -523,7 +524,23 @@ class RTSPSource(ThreadedClipSource):
                 enabled=False,
                 state=TalkState.DISABLED,
             )
-        return await manager.refresh_status()
+        return self._with_talk_backend_diagnostics(await manager.refresh_status())
+
+    def _with_talk_backend_diagnostics(self, status: CameraTalkStatus) -> CameraTalkStatus:
+        selector = self._talk_backend_selector
+        if (
+            selector is None
+            or not status.enabled
+            or not status.policy_enabled
+            or status.capability in {TalkCapabilityState.UNKNOWN, TalkCapabilityState.PROBING}
+        ):
+            return status.model_copy(update={"backend": None, "backend_reason": None})
+        return status.model_copy(
+            update={
+                "backend": selector.backend,
+                "backend_reason": selector.backend_reason,
+            }
+        )
 
     async def prepare_talk_session(
         self,

--- a/src/homesec/talk/backend_ids.py
+++ b/src/homesec/talk/backend_ids.py
@@ -21,3 +21,14 @@ def validate_talk_backend_id(value: str) -> str:
             "start with a letter, and be at most 64 characters"
         )
     return value
+
+
+def sanitize_talk_backend_id(value: object) -> str | None:
+    """Return a safe backend identifier for public diagnostics, or None."""
+    if not isinstance(value, str):
+        return None
+    normalized = normalize_talk_backend_id(value)
+    try:
+        return validate_talk_backend_id(normalized)
+    except ValueError:
+        return None

--- a/src/homesec/talk/backend_ids.py
+++ b/src/homesec/talk/backend_ids.py
@@ -1,0 +1,23 @@
+"""Safe identifiers for talk backend registration and diagnostics."""
+
+from __future__ import annotations
+
+import re
+
+TALK_BACKEND_ID_PATTERN_TEXT = r"^[a-z][a-z0-9_]{0,63}$"
+_TALK_BACKEND_ID_PATTERN = re.compile(TALK_BACKEND_ID_PATTERN_TEXT)
+
+
+def normalize_talk_backend_id(value: str) -> str:
+    """Normalize an operator/plugin provided talk backend identifier."""
+    return value.strip().lower()
+
+
+def validate_talk_backend_id(value: str) -> str:
+    """Validate that a talk backend name is safe to expose in diagnostics."""
+    if not _TALK_BACKEND_ID_PATTERN.fullmatch(value):
+        raise ValueError(
+            "talk backend names must use lowercase letters, numbers, and underscores, "
+            "start with a letter, and be at most 64 characters"
+        )
+    return value

--- a/src/homesec/talk/backend_ids.py
+++ b/src/homesec/talk/backend_ids.py
@@ -8,7 +8,7 @@ TALK_BACKEND_ID_PATTERN_TEXT = r"^[a-z][a-z0-9_]{0,63}$"
 _TALK_BACKEND_ID_PATTERN = re.compile(TALK_BACKEND_ID_PATTERN_TEXT)
 _UNSAFE_TALK_BACKEND_REASON_PATTERN = re.compile(
     r"://|authorization|bearer|basic|digest|password|passwd|secret|token|api[_-]?key|"
-    r"^v=0$|^m=|^a=|^sdp$",
+    r"\bsdp\b|(?:^|\s)(?:v=0|m=|a=)",
     re.IGNORECASE,
 )
 

--- a/src/homesec/talk/backend_ids.py
+++ b/src/homesec/talk/backend_ids.py
@@ -6,6 +6,11 @@ import re
 
 TALK_BACKEND_ID_PATTERN_TEXT = r"^[a-z][a-z0-9_]{0,63}$"
 _TALK_BACKEND_ID_PATTERN = re.compile(TALK_BACKEND_ID_PATTERN_TEXT)
+_UNSAFE_TALK_BACKEND_REASON_PATTERN = re.compile(
+    r"://|authorization|bearer|basic|digest|password|passwd|secret|token|api[_-]?key|"
+    r"^v=0$|^m=|^a=|^sdp$",
+    re.IGNORECASE,
+)
 
 
 def normalize_talk_backend_id(value: str) -> str:
@@ -32,3 +37,17 @@ def sanitize_talk_backend_id(value: object) -> str | None:
         return validate_talk_backend_id(normalized)
     except ValueError:
         return None
+
+
+def sanitize_talk_backend_reason(value: object) -> str | None:
+    """Return a safe short backend diagnostic reason, or None."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    reason = value.strip()
+    if not reason or len(reason) > 256 or "\n" in reason or "\r" in reason:
+        return None
+    if _UNSAFE_TALK_BACKEND_REASON_PATTERN.search(reason):
+        return None
+    return reason

--- a/src/homesec/talk/backends.py
+++ b/src/homesec/talk/backends.py
@@ -14,6 +14,7 @@ from homesec.models.talk import (
     TalkRefusalReason,
     TalkSessionOpenRequest,
 )
+from homesec.talk.backend_ids import normalize_talk_backend_id, validate_talk_backend_id
 
 TalkBackendConfidence = Literal["explicit", "high", "medium", "low", "not_applicable"]
 
@@ -140,7 +141,7 @@ class TalkBackendRegistration:
     standards_based: bool = False
 
     def __post_init__(self) -> None:
-        normalized = self.name.lower()
+        normalized = validate_talk_backend_id(normalize_talk_backend_id(self.name))
         if normalized != self.name:
             object.__setattr__(self, "name", normalized)
 
@@ -153,14 +154,19 @@ class TalkBackendRegistry:
 
     def register(self, registration: TalkBackendRegistration) -> None:
         """Register one backend, failing fast on duplicate names."""
-        name = registration.name.lower()
+        name = validate_talk_backend_id(normalize_talk_backend_id(registration.name))
         if name in self._registrations:
             raise ValueError(f"Talk backend '{name}' already registered")
         self._registrations[name] = registration
 
     def get(self, name: str) -> TalkBackendRegistration | None:
         """Return a registration by backend name."""
-        return self._registrations.get(name.lower())
+        normalized = normalize_talk_backend_id(name)
+        try:
+            validate_talk_backend_id(normalized)
+        except ValueError:
+            return None
+        return self._registrations.get(normalized)
 
     def all(self) -> list[TalkBackendRegistration]:
         """Return all registrations in deterministic selection order."""

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -12,6 +12,7 @@ from homesec.models.talk import (
     TalkRefusalReason,
     TalkSessionOpenRequest,
 )
+from homesec.talk.backend_ids import normalize_talk_backend_id, validate_talk_backend_id
 from homesec.talk.backends import (
     TalkBackendAdapter,
     TalkBackendConfidence,
@@ -159,8 +160,13 @@ class TalkBackendSelector:
             if registration.detector is None:
                 continue
             detection = registration.detector(self._context)
+            detected_backend = normalize_talk_backend_id(detection.backend)
+            try:
+                validate_talk_backend_id(detected_backend)
+            except ValueError:
+                continue
             if (
-                detection.backend.lower() != registration.name
+                detected_backend != registration.name
                 or detection.confidence == "not_applicable"
                 or not detection.safe_to_probe
             ):

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -28,6 +28,8 @@ from homesec.talk.backends import (
 @dataclass(frozen=True, slots=True)
 class _SelectedBackend:
     adapter: TalkBackendAdapter
+    backend: str
+    backend_reason: str
 
     @property
     def supported_codecs(self) -> list[str]:
@@ -37,6 +39,8 @@ class _SelectedBackend:
 @dataclass(frozen=True, slots=True)
 class _SelectionError:
     result: TalkCapabilityProbeResult
+    backend: str | None
+    backend_reason: str | None
 
     @property
     def supported_codecs(self) -> list[str]:
@@ -70,6 +74,16 @@ class TalkBackendSelector:
         """Return supported codecs for the selected backend, if one can be built."""
         return self._select().supported_codecs
 
+    @property
+    def backend(self) -> str | None:
+        """Return the selected or explicitly requested backend name when known."""
+        return self._select().backend
+
+    @property
+    def backend_reason(self) -> str | None:
+        """Return a safe human-readable backend selection diagnostic."""
+        return self._select().backend_reason
+
     async def probe(self) -> TalkCapabilityProbeResult:
         """Probe the selected backend or return a selection/config error."""
         selection = self._select()
@@ -98,20 +112,27 @@ class TalkBackendSelector:
 
         registration = self._registry.get(camera_talk.backend)
         if registration is None:
+            message = f"Talk backend '{camera_talk.backend}' is not registered in this runtime"
             self._selection = _SelectionError(
-                _selection_error_result(
-                    f"Talk backend '{camera_talk.backend}' is not registered in this runtime"
-                )
+                _selection_error_result(message),
+                backend=camera_talk.backend,
+                backend_reason=f"Talk backend '{camera_talk.backend}' is not registered",
             )
             return self._selection
 
-        self._selection = self._build_registered_backend(registration.name)
+        self._selection = self._build_registered_backend(
+            registration.name,
+            reason=f"Explicit backend {registration.name} configured",
+        )
         return self._selection
 
     def _select_auto(self) -> _SelectedBackend | _SelectionError:
         detected_registration = self._detected_auto_registration()
         if detected_registration is not None:
-            return self._build_registered_backend(detected_registration.name)
+            return self._build_registered_backend(
+                detected_registration.name,
+                reason=f"Selected talk backend '{detected_registration.name}' by safe camera detector",
+            )
 
         registrations = [
             registration
@@ -120,9 +141,17 @@ class TalkBackendSelector:
         ]
         if not registrations:
             return _SelectionError(
-                _selection_error_result("No standards-based talk backends are registered")
+                _selection_error_result("No standards-based talk backends are registered"),
+                backend=None,
+                backend_reason="No standards-based talk backends are registered",
             )
-        return self._build_registered_backend(registrations[0].name)
+        return self._build_registered_backend(
+            registrations[0].name,
+            reason=(
+                f"Selected {_backend_display_name(registrations[0].name)} "
+                "by standards-first auto probing"
+            ),
+        )
 
     def _detected_auto_registration(self) -> TalkBackendRegistration | None:
         detected: list[tuple[int, bool, int, str, TalkBackendRegistration]] = []
@@ -150,20 +179,34 @@ class TalkBackendSelector:
         detected.sort(key=lambda item: item[:4])
         return detected[0][4]
 
-    def _build_registered_backend(self, backend_name: str) -> _SelectedBackend | _SelectionError:
+    def _build_registered_backend(
+        self,
+        backend_name: str,
+        *,
+        reason: str,
+    ) -> _SelectedBackend | _SelectionError:
         registration = self._registry.get(backend_name)
         if registration is None:
+            message = f"Talk backend '{backend_name}' is not registered in this runtime"
             return _SelectionError(
-                _selection_error_result(
-                    f"Talk backend '{backend_name}' is not registered in this runtime"
-                )
+                _selection_error_result(message),
+                backend=backend_name,
+                backend_reason=f"Talk backend '{backend_name}' is not registered",
             )
         raw_config = backend_config_for(self._context.camera_talk, registration.name)
         try:
             config = model_validate_backend_config(registration, raw_config, context=self._context)
-            return _SelectedBackend(registration.factory(config, self._context))
+            return _SelectedBackend(
+                registration.factory(config, self._context),
+                backend=registration.name,
+                backend_reason=reason,
+            )
         except (ValueError, ValidationError) as exc:
-            return _SelectionError(_selection_error_result(str(exc)))
+            return _SelectionError(
+                _selection_error_result(str(exc)),
+                backend=registration.name,
+                backend_reason=f"Talk backend '{registration.name}' config is invalid",
+            )
 
 
 def _selection_error_result(message: str) -> TalkCapabilityProbeResult:
@@ -172,3 +215,9 @@ def _selection_error_result(message: str) -> TalkCapabilityProbeResult:
         refusal_reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
         message=message,
     )
+
+
+def _backend_display_name(backend_name: str) -> str:
+    if backend_name == "onvif_rtsp_backchannel":
+        return "ONVIF RTSP backchannel"
+    return f"talk backend '{backend_name}'"

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from pydantic import ValidationError
@@ -55,6 +56,8 @@ _AUTO_DETECTION_CONFIDENCE_RANK: dict[TalkBackendConfidence, int] = {
     "low": 3,
     "not_applicable": 4,
 }
+
+logger = logging.getLogger(__name__)
 
 
 class TalkBackendSelector:
@@ -208,10 +211,19 @@ class TalkBackendSelector:
                 backend_reason=reason,
             )
         except (ValueError, ValidationError) as exc:
+            public_message = f"Talk backend '{registration.name}' config is invalid"
+            logger.debug(
+                "Talk backend config validation failed",
+                extra={
+                    "camera_name": self._context.camera_name,
+                    "talk_backend": registration.name,
+                    "error_type": type(exc).__name__,
+                },
+            )
             return _SelectionError(
-                _selection_error_result(str(exc)),
+                _selection_error_result(public_message),
                 backend=registration.name,
-                backend_reason=f"Talk backend '{registration.name}' config is invalid",
+                backend_reason=public_message,
             )
 
 

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -899,9 +899,7 @@ async def test_talk_missing_explicit_credential_env_reports_config_error_without
     assert status.policy_enabled is True
     assert status.capability == TalkCapabilityState.ERROR
     assert status.state == TalkState.ERROR
-    assert status.last_error is not None
-    assert "RTSP credential environment variable is not set" in status.last_error
-    assert "MISSING_TALK_USER" in status.last_error
+    assert status.last_error == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
     assert status.backend == "onvif_rtsp_backchannel"
     assert status.backend_reason == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
     assert "rtsp://host/talk" not in status.backend_reason
@@ -1046,15 +1044,13 @@ async def test_talk_backchannel_missing_explicit_rtsp_url_env_reports_config_err
     assert status.enabled is True
     assert status.state == TalkState.ERROR
     assert status.capability == TalkCapabilityState.ERROR
-    assert status.last_error is not None
-    assert "MISSING_TALK_RTSP_URL" in status.last_error
+    assert status.last_error == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
     assert status.backend == "onvif_rtsp_backchannel"
     assert status.backend_reason == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
     assert "rtsp://camera.local/live" not in status.backend_reason
     assert prepared.accepted is False
     assert prepared.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
-    assert prepared.message is not None
-    assert "MISSING_TALK_RTSP_URL" in prepared.message
+    assert prepared.message == status.last_error
 
 
 @pytest.mark.parametrize("talk_config", [{"rtsp_url": ""}, {"rtsp_url_env": ""}])
@@ -1113,12 +1109,10 @@ async def test_talk_backchannel_missing_explicit_credential_env_reports_config_e
     assert status.enabled is True
     assert status.state == TalkState.ERROR
     assert status.capability == TalkCapabilityState.ERROR
-    assert status.last_error is not None
-    assert "MISSING_TALK_RTSP_USER" in status.last_error
+    assert status.last_error == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
     assert prepared.accepted is False
     assert prepared.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
-    assert prepared.message is not None
-    assert "MISSING_TALK_RTSP_USER" in prepared.message
+    assert prepared.message == status.last_error
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -815,6 +815,8 @@ async def test_talk_disabled_by_policy_does_not_build_camera_backchannel(
     assert status.enabled is False
     assert status.policy_enabled is expected_policy_enabled
     assert status.state == TalkState.DISABLED
+    assert status.backend is None
+    assert status.backend_reason is None
     assert prepared.accepted is False
     assert prepared.refusal_reason == TalkRefusalReason.TALK_DISABLED
 
@@ -856,6 +858,8 @@ async def test_unknown_explicit_talk_backend_reports_config_error_without_onvif_
     assert status.capability == TalkCapabilityState.ERROR
     assert status.state == TalkState.ERROR
     assert status.last_error == "Talk backend 'tapo_local' is not registered in this runtime"
+    assert status.backend == "tapo_local"
+    assert status.backend_reason == "Talk backend 'tapo_local' is not registered"
     assert prepared.accepted is False
     assert prepared.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
     assert prepared.message == status.last_error
@@ -898,6 +902,9 @@ async def test_talk_missing_explicit_credential_env_reports_config_error_without
     assert status.last_error is not None
     assert "RTSP credential environment variable is not set" in status.last_error
     assert "MISSING_TALK_USER" in status.last_error
+    assert status.backend == "onvif_rtsp_backchannel"
+    assert status.backend_reason == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
+    assert "rtsp://host/talk" not in status.backend_reason
 
     prepared = await source.prepare_talk_session(
         TalkSessionPrepareRequest(session_id="tk_missing_credentials")
@@ -955,6 +962,10 @@ async def test_talk_backchannel_uses_dedicated_rtsp_url_env_for_capability_probe
     assert status.capability == TalkCapabilityState.SUPPORTED
     assert status.state == TalkState.IDLE
     assert status.selected_codec == "PCMA/8000"
+    assert status.backend == "onvif_rtsp_backchannel"
+    assert (
+        status.backend_reason == "Selected ONVIF RTSP backchannel by standards-first auto probing"
+    )
 
 
 @pytest.mark.asyncio
@@ -1037,6 +1048,9 @@ async def test_talk_backchannel_missing_explicit_rtsp_url_env_reports_config_err
     assert status.capability == TalkCapabilityState.ERROR
     assert status.last_error is not None
     assert "MISSING_TALK_RTSP_URL" in status.last_error
+    assert status.backend == "onvif_rtsp_backchannel"
+    assert status.backend_reason == "Talk backend 'onvif_rtsp_backchannel' config is invalid"
+    assert "rtsp://camera.local/live" not in status.backend_reason
     assert prepared.accepted is False
     assert prepared.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
     assert prepared.message is not None

--- a/tests/homesec/talk/test_backend_registry.py
+++ b/tests/homesec/talk/test_backend_registry.py
@@ -88,6 +88,17 @@ def test_registry_rejects_duplicate_backend_names() -> None:
         registry.register(_registration("FAKE_BACKEND"))
 
 
+def test_registry_rejects_unsafe_backend_names() -> None:
+    """Talk backend registration names should be safe public identifiers."""
+    # Given: A backend registration whose name is not a safe identifier
+    registry = TalkBackendRegistry()
+
+    # When: Registering the unsafe backend
+    # Then: The registry rejects it before diagnostics can expose the name
+    with pytest.raises(ValueError, match="talk backend names"):
+        registry.register(_registration("rtsp://admin:secret@example.local/stream1"))
+
+
 def test_registry_orders_standards_backends_first() -> None:
     """Talk backend registry should return deterministic standards-first order."""
     # Given: Proprietary and standards-based backend registrations

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -27,6 +27,10 @@ class _BackendConfig(BaseModel):
     marker: str = "default"
 
 
+class _IntBackendConfig(BaseModel):
+    marker: int
+
+
 class _FakeSession:
     session_id = "tk_fake"
     camera_name = "cam"
@@ -276,3 +280,35 @@ async def test_selector_uses_explicit_registered_backend_config() -> None:
     # Then: Backend-specific config wins over the legacy config alias
     assert probe.capability == TalkCapabilityState.SUPPORTED
     assert seen_config == [_BackendConfig(marker="backend-map")]
+
+
+@pytest.mark.asyncio
+async def test_selector_reports_stable_public_message_for_invalid_backend_config() -> None:
+    """Invalid backend config should not expose raw validation text in status errors."""
+    # Given: A registered backend whose config validation would include rejected input
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_IntBackendConfig,
+            factory=lambda config, context: _FakeBackend("vendor_backend", []),
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(
+            CameraTalkConfig(
+                backend="vendor_backend",
+                config={"marker": "secret-config-value"},
+            )
+        ),
+    )
+
+    # When: Probing the selected backend
+    probe = await selector.probe()
+
+    # Then: The public error is stable and does not include raw Pydantic input text
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.message == "Talk backend 'vendor_backend' config is invalid"
+    assert selector.backend_reason == "Talk backend 'vendor_backend' config is invalid"
+    assert "secret-config-value" not in (probe.message or "")

--- a/tests/homesec/test_api_talk_e2e.py
+++ b/tests/homesec/test_api_talk_e2e.py
@@ -568,6 +568,10 @@ class _WorkerHarnessController(RuntimeController):
             selected_codec = (
                 result.talk_status.selected_codec if result.talk_status is not None else None
             )
+            backend = result.talk_status.backend if result.talk_status is not None else None
+            backend_reason = (
+                result.talk_status.backend_reason if result.talk_status is not None else None
+            )
             close_writer = False
             return RuntimeTalkStream(
                 camera_name=camera_name,
@@ -576,6 +580,8 @@ class _WorkerHarnessController(RuntimeController):
                 reader=reader,
                 writer=writer,
                 selected_codec=selected_codec,
+                backend=backend,
+                backend_reason=backend_reason,
             )
         finally:
             if close_writer:
@@ -976,6 +982,8 @@ def test_talk_websocket_streams_pcm_to_fake_onvif_backchannel(
                     "session_id": "tk_e2e",
                     "input": input_format.model_dump(mode="json"),
                     "camera_codec": "PCMU/8000",
+                    "backend": "onvif_rtsp_backchannel",
+                    "backend_reason": "Selected ONVIF RTSP backchannel by standards-first auto probing",
                 }
                 websocket.send_bytes(first_frame)
                 websocket.send_bytes(second_frame)

--- a/tests/homesec/test_api_talk_e2e.py
+++ b/tests/homesec/test_api_talk_e2e.py
@@ -485,6 +485,8 @@ class _WorkerHarnessController(RuntimeController):
             supported_codecs=result.talk_status.supported_codecs,
             offered_codecs=result.talk_status.offered_codecs,
             selected_codec=result.talk_status.selected_codec,
+            backend=result.talk_status.backend,
+            backend_reason=result.talk_status.backend_reason,
             last_error=result.talk_status.last_error,
         )
 
@@ -916,6 +918,11 @@ def test_talk_status_discovers_fake_onvif_backchannel(tmp_path: Path) -> None:
             assert payload["state"] == "idle"
             assert payload["offered_codecs"] == ["PCMU/8000"]
             assert payload["selected_codec"] == "PCMU/8000"
+            assert payload["backend"] == "onvif_rtsp_backchannel"
+            assert (
+                payload["backend_reason"]
+                == "Selected ONVIF RTSP backchannel by standards-first auto probing"
+            )
         server.wait_for_methods(["DESCRIBE"])
     finally:
         if app is not None:

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -167,6 +167,8 @@ class _StubTalkApp:
             reader=cast(asyncio.StreamReader, object()),
             writer=cast(asyncio.StreamWriter, self.stream_writer),
             selected_codec=self._status.selected_codec or "PCMU/8000",
+            backend=self._status.backend,
+            backend_reason=self._status.backend_reason,
         )
 
     async def stop_camera_talk_session(
@@ -661,6 +663,8 @@ def test_talk_websocket_forwards_binary_frames_to_runtime_stream() -> None:
             "session_id": "session-1",
             "input": input_format.model_dump(mode="json"),
             "camera_codec": "PCMU/8000",
+            "backend": None,
+            "backend_reason": None,
         }
         websocket.send_bytes(frame)
         websocket.send_text(_stop_message())

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -262,6 +262,25 @@ def test_get_talk_status_returns_disabled_camera_status() -> None:
     assert app.open_calls == []
 
 
+def test_talk_status_response_sanitizes_unsafe_backend_diagnostics() -> None:
+    """API talk status responses should not expose unsafe backend identifiers."""
+    # Given: A status response is built with unsafe backend diagnostics
+    # When: Validating the API response model
+    response = talk_route_module.TalkStatusResponse(
+        camera_name="front",
+        enabled=True,
+        policy_enabled=True,
+        capability="error",
+        state="error",
+        backend="rtsp://admin:secret@example.local/stream1",
+        backend_reason="selected rtsp://admin:secret@example.local/stream1",
+    )
+
+    # Then: The public diagnostic fields are dropped
+    assert response.backend is None
+    assert response.backend_reason is None
+
+
 def test_get_talk_status_returns_unsupported_source_status() -> None:
     """Unsupported sources should surface as talk status rather than session opens."""
     # Given: The runtime reports that the camera source has no talk support.

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -281,6 +281,44 @@ def test_talk_status_response_sanitizes_unsafe_backend_diagnostics() -> None:
     assert response.backend_reason is None
 
 
+def test_talk_status_response_drops_backend_reason_without_backend() -> None:
+    """API talk status responses should not expose backend reasons without backend IDs."""
+    # Given: A status response is built with a backend reason but no backend
+    # When: Validating the API response model
+    response = talk_route_module.TalkStatusResponse(
+        camera_name="front",
+        enabled=True,
+        policy_enabled=True,
+        capability="error",
+        state="error",
+        backend=None,
+        backend_reason="selected rtsp://admin:secret@example.local/stream1",
+    )
+
+    # Then: The standalone public diagnostic reason is dropped
+    assert response.backend is None
+    assert response.backend_reason is None
+
+
+def test_talk_status_response_drops_secret_bearing_backend_reason() -> None:
+    """API talk status responses should not expose secret-bearing backend reasons."""
+    # Given: A status response is built with a safe backend ID and unsafe reason
+    # When: Validating the API response model
+    response = talk_route_module.TalkStatusResponse(
+        camera_name="front",
+        enabled=True,
+        policy_enabled=True,
+        capability="error",
+        state="error",
+        backend="vendor_backend",
+        backend_reason="selected rtsp://admin:secret@example.local/stream1",
+    )
+
+    # Then: The backend ID is preserved but the unsafe reason is dropped
+    assert response.backend == "vendor_backend"
+    assert response.backend_reason is None
+
+
 def test_get_talk_status_returns_unsupported_source_status() -> None:
     """Unsupported sources should surface as talk status rather than session opens."""
     # Given: The runtime reports that the camera source has no talk support.

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -319,6 +319,25 @@ def test_talk_status_response_drops_secret_bearing_backend_reason() -> None:
     assert response.backend_reason is None
 
 
+def test_talk_status_response_drops_raw_sdp_backend_reason() -> None:
+    """API talk status responses should not expose raw SDP backend reasons."""
+    # Given: A status response is built with a safe backend ID and SDP reason
+    # When: Validating the API response model
+    response = talk_route_module.TalkStatusResponse(
+        camera_name="front",
+        enabled=True,
+        policy_enabled=True,
+        capability="error",
+        state="error",
+        backend="vendor_backend",
+        backend_reason="SDP answer v=0 m=audio 0 RTP/AVP 0",
+    )
+
+    # Then: The backend ID is preserved but the raw SDP reason is dropped
+    assert response.backend == "vendor_backend"
+    assert response.backend_reason is None
+
+
 def test_get_talk_status_returns_unsupported_source_status() -> None:
     """Unsupported sources should surface as talk status rather than session opens."""
     # Given: The runtime reports that the camera source has no talk support.

--- a/tests/homesec/test_api_talk_routes.py
+++ b/tests/homesec/test_api_talk_routes.py
@@ -204,6 +204,8 @@ def test_get_talk_status_returns_runtime_status() -> None:
             active_session_id="session-1",
             supported_codecs=["pcmu"],
             selected_codec="pcmu",
+            backend="onvif_rtsp_backchannel",
+            backend_reason="Selected ONVIF RTSP backchannel by standards-first auto probing",
             last_error=None,
         )
     )
@@ -225,6 +227,8 @@ def test_get_talk_status_returns_runtime_status() -> None:
         "supported_codecs": ["pcmu"],
         "offered_codecs": [],
         "selected_codec": "pcmu",
+        "backend": "onvif_rtsp_backchannel",
+        "backend_reason": "Selected ONVIF RTSP backchannel by standards-first auto probing",
         "last_error": None,
     }
 
@@ -251,6 +255,8 @@ def test_get_talk_status_returns_disabled_camera_status() -> None:
     assert response.status_code == 200
     assert response.json()["enabled"] is False
     assert response.json()["state"] == "disabled"
+    assert response.json()["backend"] is None
+    assert response.json()["backend_reason"] is None
     assert app.open_calls == []
 
 

--- a/tests/homesec/test_config.py
+++ b/tests/homesec/test_config.py
@@ -1042,6 +1042,27 @@ def test_camera_talk_accepts_unknown_future_backend_name() -> None:
     assert config.cameras[0].talk.backend == "tapo_local"
 
 
+def test_camera_talk_rejects_unsafe_backend_name() -> None:
+    """Camera talk backend names should be safe public diagnostics identifiers."""
+    # Given: A config that accidentally places a credential-bearing URL in backend name
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {
+        "enabled": True,
+        "backend": "rtsp://admin:secret@example.local/stream1",
+        "config": {},
+    }
+
+    # When: validating the config.
+    # Then: validation rejects the unsafe diagnostic identifier before runtime.
+    with pytest.raises(ValidationError) as exc_info:
+        Config.model_validate(data)
+
+    message = str(exc_info.value)
+    assert "talk backend names" in message
+
+
 def test_camera_talk_backends_map_preserved_and_normalized() -> None:
     """Camera talk config should preserve backend-specific config blocks."""
     # Given: A config with future and ONVIF backend blocks
@@ -1064,6 +1085,28 @@ def test_camera_talk_backends_map_preserved_and_normalized() -> None:
     talk = config.cameras[0].talk
     assert talk.backends["tapo_local"] == {"host": "192.168.1.33", "port": 8800}
     assert talk.config_for_backend("onvif_rtsp_backchannel") == {"preferred_codecs": ["PCMA/8000"]}
+
+
+def test_camera_talk_rejects_unsafe_backend_map_key() -> None:
+    """Camera talk backend map keys should use safe public identifiers."""
+    # Given: A backend-specific config block with an unsafe key
+    data = minimal_config()
+    camera = data["cameras"][0]
+    assert isinstance(camera, dict)
+    camera["talk"] = {
+        "mode": "auto",
+        "backends": {
+            "Bearer secret-token": {"host": "192.168.1.33"},
+        },
+    }
+
+    # When: validating the config.
+    # Then: validation rejects the unsafe key without preserving it for diagnostics.
+    with pytest.raises(ValidationError) as exc_info:
+        Config.model_validate(data)
+
+    message = str(exc_info.value)
+    assert "talk backend names" in message
 
 
 def test_camera_talk_config_alias_for_explicit_onvif_backend() -> None:

--- a/tests/homesec/test_runtime_subprocess_controller.py
+++ b/tests/homesec/test_runtime_subprocess_controller.py
@@ -387,6 +387,8 @@ async def test_subprocess_controller_uses_extended_timeout_for_talk_status(
                 enabled=True,
                 policy_enabled=True,
                 state=TalkState.IDLE,
+                backend="onvif_rtsp_backchannel",
+                backend_reason="Selected ONVIF RTSP backchannel by standards-first auto probing",
             ),
         )
 
@@ -399,6 +401,11 @@ async def test_subprocess_controller_uses_extended_timeout_for_talk_status(
         # Then: The command uses the extended talk timeout for camera probing
         assert observed_timeout_s == [7.5]
         assert status.state == TalkState.IDLE
+        assert status.backend == "onvif_rtsp_backchannel"
+        assert (
+            status.backend_reason
+            == "Selected ONVIF RTSP backchannel by standards-first auto probing"
+        )
     finally:
         runtime.process = None
         await controller._finalize_handle(runtime)

--- a/tests/homesec/test_runtime_subprocess_controller.py
+++ b/tests/homesec/test_runtime_subprocess_controller.py
@@ -676,6 +676,8 @@ async def test_subprocess_controller_uses_extended_timeout_for_talk_stream_open(
                 policy_enabled=True,
                 state=TalkState.ACTIVE,
                 selected_codec="PCMU/8000",
+                backend="onvif_rtsp_backchannel",
+                backend_reason="Selected ONVIF RTSP backchannel by standards-first auto probing",
             ),
         )
 
@@ -694,6 +696,11 @@ async def test_subprocess_controller_uses_extended_timeout_for_talk_stream_open(
 
         # Then: The controller waits for the extended talk timeout and keeps the stream open
         assert stream.selected_codec == "PCMU/8000"
+        assert stream.backend == "onvif_rtsp_backchannel"
+        assert (
+            stream.backend_reason
+            == "Selected ONVIF RTSP backchannel by standards-first auto probing"
+        )
         assert stream.writer is writer
         assert writer.closed is False
     finally:

--- a/tests/homesec/test_runtime_subprocess_protocol.py
+++ b/tests/homesec/test_runtime_subprocess_protocol.py
@@ -86,6 +86,25 @@ def test_camera_talk_status_drops_secret_bearing_backend_reason() -> None:
     assert status.backend_reason is None
 
 
+def test_camera_talk_status_drops_raw_sdp_backend_reason() -> None:
+    """Public talk status should not expose raw SDP backend reasons."""
+    # Given: A custom source reports a safe backend ID with an embedded SDP snippet
+    payload = {
+        "camera_name": "front",
+        "enabled": True,
+        "state": "error",
+        "backend": "vendor_backend",
+        "backend_reason": "raw SDP: a=crypto:1 inline:keymaterial",
+    }
+
+    # When: Parsing the public camera talk status model
+    status = CameraTalkStatus.model_validate(payload)
+
+    # Then: The backend ID is preserved but the raw SDP reason is dropped
+    assert status.backend == "vendor_backend"
+    assert status.backend_reason is None
+
+
 def test_worker_talk_status_payload_sanitizes_unsafe_backend_diagnostics() -> None:
     """Worker talk IPC should not forward unsafe backend identifiers."""
     # Given: A worker payload includes an unsafe backend identifier
@@ -136,6 +155,24 @@ def test_worker_talk_status_payload_drops_secret_bearing_backend_reason() -> Non
     status = WorkerTalkStatusPayload.model_validate(payload)
 
     # Then: The backend ID is preserved but the unsafe reason is dropped
+    assert status.backend == "vendor_backend"
+    assert status.backend_reason is None
+
+
+def test_worker_talk_status_payload_drops_raw_sdp_backend_reason() -> None:
+    """Worker talk IPC should not forward raw SDP backend reasons."""
+    # Given: A worker payload includes a safe backend ID with an embedded SDP snippet
+    payload = {
+        "enabled": True,
+        "state": "error",
+        "backend": "vendor_backend",
+        "backend_reason": "SDP answer v=0 m=audio 0 RTP/AVP 0",
+    }
+
+    # When: Parsing the worker IPC payload
+    status = WorkerTalkStatusPayload.model_validate(payload)
+
+    # Then: The backend ID is preserved but the raw SDP reason is dropped
     assert status.backend == "vendor_backend"
     assert status.backend_reason is None
 
@@ -193,5 +230,24 @@ def test_runtime_talk_stream_drops_secret_bearing_backend_reason() -> None:
     )
 
     # Then: The backend ID remains but the unsafe reason is dropped
+    assert stream.backend == "vendor_backend"
+    assert stream.backend_reason is None
+
+
+def test_runtime_talk_stream_drops_raw_sdp_backend_reason() -> None:
+    """Runtime talk stream ready metadata should not expose raw SDP reasons."""
+    # Given: A runtime stream is created with a safe backend ID and SDP reason
+    # When: The stream model is initialized
+    stream = RuntimeTalkStream(
+        camera_name="front",
+        session_id="tk_sdp_reason",
+        input=TalkInputFormat(),
+        reader=cast(asyncio.StreamReader, object()),
+        writer=cast(asyncio.StreamWriter, object()),
+        backend="vendor_backend",
+        backend_reason="raw SDP: a=crypto:1 inline:keymaterial",
+    )
+
+    # Then: The backend ID remains but the raw SDP reason is dropped
     assert stream.backend == "vendor_backend"
     assert stream.backend_reason is None

--- a/tests/homesec/test_runtime_subprocess_protocol.py
+++ b/tests/homesec/test_runtime_subprocess_protocol.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from homesec.models.talk import TalkCapabilityState, TalkState
+import asyncio
+from typing import cast
+
+from homesec.models.talk import CameraTalkStatus, TalkCapabilityState, TalkInputFormat, TalkState
+from homesec.runtime.models import RuntimeTalkStream
 from homesec.runtime.subprocess_protocol import WorkerTalkStatusPayload
 
 
@@ -23,3 +27,59 @@ def test_worker_talk_status_payload_derives_capability_defaults() -> None:
     assert status.state == TalkState.IDLE
     assert status.backend is None
     assert status.backend_reason is None
+
+
+def test_camera_talk_status_sanitizes_unsafe_backend_diagnostics() -> None:
+    """Public talk status should not expose unsafe backend identifiers."""
+    # Given: A custom source reports a credential-bearing backend identifier
+    payload = {
+        "camera_name": "front",
+        "enabled": True,
+        "state": "error",
+        "backend": "rtsp://admin:secret@example.local/stream1",
+        "backend_reason": "selected rtsp://admin:secret@example.local/stream1",
+    }
+
+    # When: Parsing the public camera talk status model
+    status = CameraTalkStatus.model_validate(payload)
+
+    # Then: The unsafe backend diagnostic fields are dropped
+    assert status.backend is None
+    assert status.backend_reason is None
+
+
+def test_worker_talk_status_payload_sanitizes_unsafe_backend_diagnostics() -> None:
+    """Worker talk IPC should not forward unsafe backend identifiers."""
+    # Given: A worker payload includes an unsafe backend identifier
+    payload = {
+        "enabled": True,
+        "state": "error",
+        "backend": "Bearer secret-token",
+        "backend_reason": "selected Bearer secret-token",
+    }
+
+    # When: Parsing the worker IPC payload
+    status = WorkerTalkStatusPayload.model_validate(payload)
+
+    # Then: The unsafe backend diagnostic fields are dropped before API mapping
+    assert status.backend is None
+    assert status.backend_reason is None
+
+
+def test_runtime_talk_stream_sanitizes_unsafe_backend_diagnostics() -> None:
+    """Runtime talk stream ready metadata should not expose unsafe backend identifiers."""
+    # Given: A runtime stream is created with unsafe backend diagnostics
+    # When: The stream model is initialized
+    stream = RuntimeTalkStream(
+        camera_name="front",
+        session_id="tk_unsafe",
+        input=TalkInputFormat(),
+        reader=cast(asyncio.StreamReader, object()),
+        writer=cast(asyncio.StreamWriter, object()),
+        backend="rtsp://admin:secret@example.local/stream1",
+        backend_reason="selected rtsp://admin:secret@example.local/stream1",
+    )
+
+    # Then: The metadata that will be sent in WebSocket ready is dropped
+    assert stream.backend is None
+    assert stream.backend_reason is None

--- a/tests/homesec/test_runtime_subprocess_protocol.py
+++ b/tests/homesec/test_runtime_subprocess_protocol.py
@@ -21,3 +21,5 @@ def test_worker_talk_status_payload_derives_capability_defaults() -> None:
     assert status.policy_enabled is True
     assert status.capability == TalkCapabilityState.SUPPORTED
     assert status.state == TalkState.IDLE
+    assert status.backend is None
+    assert status.backend_reason is None

--- a/tests/homesec/test_runtime_subprocess_protocol.py
+++ b/tests/homesec/test_runtime_subprocess_protocol.py
@@ -48,6 +48,44 @@ def test_camera_talk_status_sanitizes_unsafe_backend_diagnostics() -> None:
     assert status.backend_reason is None
 
 
+def test_camera_talk_status_drops_backend_reason_without_backend() -> None:
+    """Public talk status should not expose backend reasons without a backend ID."""
+    # Given: A custom source reports a backend reason without a selected backend
+    payload = {
+        "camera_name": "front",
+        "enabled": True,
+        "state": "error",
+        "backend": None,
+        "backend_reason": "selected rtsp://admin:secret@example.local/stream1",
+    }
+
+    # When: Parsing the public camera talk status model
+    status = CameraTalkStatus.model_validate(payload)
+
+    # Then: The standalone backend reason is dropped
+    assert status.backend is None
+    assert status.backend_reason is None
+
+
+def test_camera_talk_status_drops_secret_bearing_backend_reason() -> None:
+    """Public talk status should not expose secret-bearing backend reasons."""
+    # Given: A custom source reports a safe backend ID with an unsafe reason
+    payload = {
+        "camera_name": "front",
+        "enabled": True,
+        "state": "error",
+        "backend": "vendor_backend",
+        "backend_reason": "selected rtsp://admin:secret@example.local/stream1",
+    }
+
+    # When: Parsing the public camera talk status model
+    status = CameraTalkStatus.model_validate(payload)
+
+    # Then: The backend ID is preserved but the unsafe reason is dropped
+    assert status.backend == "vendor_backend"
+    assert status.backend_reason is None
+
+
 def test_worker_talk_status_payload_sanitizes_unsafe_backend_diagnostics() -> None:
     """Worker talk IPC should not forward unsafe backend identifiers."""
     # Given: A worker payload includes an unsafe backend identifier
@@ -63,6 +101,42 @@ def test_worker_talk_status_payload_sanitizes_unsafe_backend_diagnostics() -> No
 
     # Then: The unsafe backend diagnostic fields are dropped before API mapping
     assert status.backend is None
+    assert status.backend_reason is None
+
+
+def test_worker_talk_status_payload_drops_backend_reason_without_backend() -> None:
+    """Worker talk IPC should not forward backend reasons without backend IDs."""
+    # Given: A worker payload includes a backend reason without a backend identifier
+    payload = {
+        "enabled": True,
+        "state": "error",
+        "backend": None,
+        "backend_reason": "selected rtsp://admin:secret@example.local/stream1",
+    }
+
+    # When: Parsing the worker IPC payload
+    status = WorkerTalkStatusPayload.model_validate(payload)
+
+    # Then: The standalone backend reason is dropped before API mapping
+    assert status.backend is None
+    assert status.backend_reason is None
+
+
+def test_worker_talk_status_payload_drops_secret_bearing_backend_reason() -> None:
+    """Worker talk IPC should not forward secret-bearing backend reasons."""
+    # Given: A worker payload includes a safe backend ID with an unsafe reason
+    payload = {
+        "enabled": True,
+        "state": "error",
+        "backend": "vendor_backend",
+        "backend_reason": "selected Bearer secret-token",
+    }
+
+    # When: Parsing the worker IPC payload
+    status = WorkerTalkStatusPayload.model_validate(payload)
+
+    # Then: The backend ID is preserved but the unsafe reason is dropped
+    assert status.backend == "vendor_backend"
     assert status.backend_reason is None
 
 
@@ -82,4 +156,42 @@ def test_runtime_talk_stream_sanitizes_unsafe_backend_diagnostics() -> None:
 
     # Then: The metadata that will be sent in WebSocket ready is dropped
     assert stream.backend is None
+    assert stream.backend_reason is None
+
+
+def test_runtime_talk_stream_drops_backend_reason_without_backend() -> None:
+    """Runtime talk stream ready metadata should require a safe backend ID."""
+    # Given: A runtime stream is created with a backend reason but no backend ID
+    # When: The stream model is initialized
+    stream = RuntimeTalkStream(
+        camera_name="front",
+        session_id="tk_reason_only",
+        input=TalkInputFormat(),
+        reader=cast(asyncio.StreamReader, object()),
+        writer=cast(asyncio.StreamWriter, object()),
+        backend=None,
+        backend_reason="selected rtsp://admin:secret@example.local/stream1",
+    )
+
+    # Then: The reason that would be sent in WebSocket ready is dropped
+    assert stream.backend is None
+    assert stream.backend_reason is None
+
+
+def test_runtime_talk_stream_drops_secret_bearing_backend_reason() -> None:
+    """Runtime talk stream ready metadata should not expose unsafe reasons."""
+    # Given: A runtime stream is created with a safe backend ID and unsafe reason
+    # When: The stream model is initialized
+    stream = RuntimeTalkStream(
+        camera_name="front",
+        session_id="tk_secret_reason",
+        input=TalkInputFormat(),
+        reader=cast(asyncio.StreamReader, object()),
+        writer=cast(asyncio.StreamWriter, object()),
+        backend="vendor_backend",
+        backend_reason="selected rtsp://admin:secret@example.local/stream1",
+    )
+
+    # Then: The backend ID remains but the unsafe reason is dropped
+    assert stream.backend == "vendor_backend"
     assert stream.backend_reason is None

--- a/tests/homesec/test_runtime_worker.py
+++ b/tests/homesec/test_runtime_worker.py
@@ -542,6 +542,8 @@ async def test_runtime_worker_talk_status_uses_refreshable_source_status() -> No
                 state=TalkState.IDLE,
                 offered_codecs=["PCMA/8000"],
                 selected_codec="PCMA/8000",
+                backend="onvif_rtsp_backchannel",
+                backend_reason="Selected ONVIF RTSP backchannel by standards-first auto probing",
             )
 
         async def prepare_talk_session(
@@ -588,6 +590,11 @@ async def test_runtime_worker_talk_status_uses_refreshable_source_status() -> No
     assert result.talk_status.capability == TalkCapabilityState.SUPPORTED
     assert result.talk_status.state == TalkState.IDLE
     assert result.talk_status.offered_codecs == ["PCMA/8000"]
+    assert result.talk_status.backend == "onvif_rtsp_backchannel"
+    assert (
+        result.talk_status.backend_reason
+        == "Selected ONVIF RTSP backchannel by standards-first auto probing"
+    )
 
 
 @pytest.mark.asyncio

--- a/ui/src/api/client.test.ts
+++ b/ui/src/api/client.test.ts
@@ -1372,6 +1372,8 @@ describe('HomeSecApiClient push-to-talk', () => {
           supported_codecs: ['pcm_s16le'],
           offered_codecs: ['PCMU/8000'],
           selected_codec: 'pcm_s16le',
+          backend: 'onvif_rtsp_backchannel',
+          backend_reason: 'Selected ONVIF RTSP backchannel by standards-first auto probing',
           last_error: null,
         }),
         {
@@ -1396,6 +1398,8 @@ describe('HomeSecApiClient push-to-talk', () => {
       supported_codecs: ['pcm_s16le'],
       offered_codecs: ['PCMU/8000'],
       selected_codec: 'pcm_s16le',
+      backend: 'onvif_rtsp_backchannel',
+      backend_reason: 'Selected ONVIF RTSP backchannel by standards-first auto probing',
       last_error: null,
       httpStatus: 200,
     })

--- a/ui/src/api/generated/openapi.json
+++ b/ui/src/api/generated/openapi.json
@@ -1905,6 +1905,28 @@
             ],
             "title": "Active Session Id"
           },
+          "backend": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Backend"
+          },
+          "backend_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Backend Reason"
+          },
           "camera_name": {
             "title": "Camera Name",
             "type": "string"

--- a/ui/src/api/generated/schema.ts
+++ b/ui/src/api/generated/schema.ts
@@ -1286,6 +1286,10 @@ export interface components {
         TalkStatusResponse: {
             /** Active Session Id */
             active_session_id?: string | null;
+            /** Backend */
+            backend?: string | null;
+            /** Backend Reason */
+            backend_reason?: string | null;
             /** Camera Name */
             camera_name: string;
             capability: components["schemas"]["TalkCapabilityState"];

--- a/ui/src/api/parsing.ts
+++ b/ui/src/api/parsing.ts
@@ -604,6 +604,8 @@ export function parseTalkStatusResponse(payload: unknown): TalkStatusResponse {
         ? []
         : expectStringArray(rawOfferedCodecs, 'offered_codecs'),
     selected_codec: expectNullableString(payload.selected_codec, 'selected_codec'),
+    backend: expectNullableString(payload.backend, 'backend'),
+    backend_reason: expectNullableString(payload.backend_reason, 'backend_reason'),
     last_error: expectNullableString(payload.last_error, 'last_error'),
   }
 }

--- a/ui/src/features/cameras/hooks/usePushToTalk.test.tsx
+++ b/ui/src/features/cameras/hooks/usePushToTalk.test.tsx
@@ -459,12 +459,18 @@ describe('usePushToTalk', () => {
     sockets[0].message(JSON.stringify({
       type: 'ready',
       camera_codec: 'PCMA/8000',
+      backend: 'onvif_rtsp_backchannel',
+      backend_reason: 'Selected ONVIF RTSP backchannel by standards-first auto probing',
     }))
     await waitFor(() => expect(result.current.isStreaming).toBe(true))
 
     // Then: Optimistic UI state uses the camera-side codec, not the browser PCM codec.
     expect(result.current.status?.state).toBe('active')
     expect(result.current.status?.selected_codec).toBe('PCMA/8000')
+    expect(result.current.status?.backend).toBe('onvif_rtsp_backchannel')
+    expect(result.current.status?.backend_reason).toBe(
+      'Selected ONVIF RTSP backchannel by standards-first auto probing',
+    )
     expect(result.current.status?.supported_codecs).toEqual(['PCMU/8000'])
     expect(result.current.status?.offered_codecs).toEqual(['PCMU/8000'])
     expect(result.current.status?.last_error).toBeNull()

--- a/ui/src/features/cameras/hooks/usePushToTalk.ts
+++ b/ui/src/features/cameras/hooks/usePushToTalk.ts
@@ -29,6 +29,8 @@ const TALK_MAX_BUFFERED_AUDIO_MS = 500
 type TalkReadyMessage = {
   type: typeof TALK_WS_READY_TYPE
   camera_codec?: unknown
+  backend?: unknown
+  backend_reason?: unknown
 }
 
 type AudioPipeline = {
@@ -192,6 +194,8 @@ function nextStatusFromState(
   sessionId: string | null,
   previous: TalkStatusResponse | null,
   selectedCameraCodec?: string | null,
+  selectedBackend?: string | null,
+  selectedBackendReason?: string | null,
 ): TalkStatusResponse {
   const optimisticCapability: TalkCapabilityState = (
     state === 'idle'
@@ -212,8 +216,8 @@ function nextStatusFromState(
     supported_codecs: previous?.supported_codecs ?? [],
     offered_codecs: previous?.offered_codecs ?? [],
     selected_codec: selectedCameraCodec ?? previous?.selected_codec ?? null,
-    backend: previous?.backend ?? null,
-    backend_reason: previous?.backend_reason ?? null,
+    backend: selectedBackend ?? previous?.backend ?? null,
+    backend_reason: selectedBackendReason ?? previous?.backend_reason ?? null,
     last_error: null,
   }
 }
@@ -329,6 +333,8 @@ export function usePushToTalk(cameraName: string): PushToTalkState {
             return
           }
           const selectedCameraCodec = typeof parsed.camera_codec === 'string' ? parsed.camera_codec : null
+          const selectedBackend = typeof parsed.backend === 'string' ? parsed.backend : null
+          const selectedBackendReason = typeof parsed.backend_reason === 'string' ? parsed.backend_reason : null
           if (isStartCancelled()) {
             socket.close(1000, 'Talk start cancelled')
             settleReject(new Error('Talk start cancelled'))
@@ -358,6 +364,8 @@ export function usePushToTalk(cameraName: string): PushToTalkState {
                     nextSession.session_id,
                     previous,
                     selectedCameraCodec,
+                    selectedBackend,
+                    selectedBackendReason,
                   ),
                 )
               }

--- a/ui/src/features/cameras/hooks/usePushToTalk.ts
+++ b/ui/src/features/cameras/hooks/usePushToTalk.ts
@@ -212,6 +212,8 @@ function nextStatusFromState(
     supported_codecs: previous?.supported_codecs ?? [],
     offered_codecs: previous?.offered_codecs ?? [],
     selected_codec: selectedCameraCodec ?? previous?.selected_codec ?? null,
+    backend: previous?.backend ?? null,
+    backend_reason: previous?.backend_reason ?? null,
     last_error: null,
   }
 }


### PR DESCRIPTION
## Summary
Implements Phase 9.3 of the push-to-talk backend abstraction work.

- Adds additive `backend` and `backend_reason` fields to talk status models and API responses.
- Propagates backend diagnostics through source status, worker IPC, subprocess controller mapping, API responses, generated UI API types, and client parsing.
- Reports ONVIF auto selection, explicit unknown backend selection failures, disabled policy, and config-error cases with safe diagnostics.
- Keeps WebSocket/session protocol unchanged and avoids candidate-backend matrix complexity.
- Documents the minimal backend diagnostics contract and secret-safety constraints.

## Notion
- Parent epic: https://www.notion.so/levneiman/Epic-Push-to-talk-camera-speaker-audio-backchannel-357d8336c59f81aa99c3c9fa820f9835
- Phase 9 parent: https://www.notion.so/levneiman/Phase-9-talk-backend-adapter-abstraction-and-selection-358d8336c59f81ff84b0f7436fdf6370
- Ticket: https://www.notion.so/levneiman/Phase-9-3-minimal-backend-diagnostics-359d8336c59f8146989bc0871ff7b585

## Validation
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:55432/homesec make check`
