### PR TITLE
test: prove proprietary talk backend readiness

### DIFF
--- a/src/homesec/sources/rtsp/core.py
+++ b/src/homesec/sources/rtsp/core.py
@@ -922,6 +922,7 @@ class RTSPSource(ThreadedClipSource):
             enabled=True,
             policy_enabled=camera_talk.policy_enabled,
             supported_codecs=selector.supported_codecs,
+            supported_codecs_factory=lambda: selector.selected_supported_codecs,
             open_session_factory=self._open_selected_talk_session,
             capability_probe_factory=selector.probe,
             max_session_s=runtime_talk.max_session_s,

--- a/src/homesec/sources/rtsp/talk/manager.py
+++ b/src/homesec/sources/rtsp/talk/manager.py
@@ -89,7 +89,7 @@ class TalkManager:
         open_session_factory: Callable[[TalkSessionOpenRequest], Awaitable[TalkSession]],
         max_session_s: float,
         idle_timeout_s: float,
-        supported_codecs_factory: Callable[[], list[str]] | None = None,
+        supported_codecs_factory: Callable[[], list[str] | None] | None = None,
         capability_probe_factory: Callable[[], Awaitable[TalkCapabilityProbeResult]] | None = None,
         capability_ttl_s: float = 30.0,
     ) -> None:
@@ -151,7 +151,7 @@ class TalkManager:
         if self._supported_codecs_factory is None:
             return list(self._supported_codecs)
         try:
-            supported_codecs = list(self._supported_codecs_factory())
+            selected_codecs = self._supported_codecs_factory()
         except Exception:
             logger.debug(
                 "Talk supported codec refresh failed",
@@ -159,7 +159,9 @@ class TalkManager:
                 exc_info=True,
             )
             return list(self._supported_codecs)
-        return supported_codecs or list(self._supported_codecs)
+        if selected_codecs is None:
+            return list(self._supported_codecs)
+        return list(selected_codecs)
 
     async def refresh_status(self, *, force: bool = False) -> CameraTalkStatus:
         """Refresh capability if needed and return current source-level status."""

--- a/src/homesec/sources/rtsp/talk/manager.py
+++ b/src/homesec/sources/rtsp/talk/manager.py
@@ -89,6 +89,7 @@ class TalkManager:
         open_session_factory: Callable[[TalkSessionOpenRequest], Awaitable[TalkSession]],
         max_session_s: float,
         idle_timeout_s: float,
+        supported_codecs_factory: Callable[[], list[str]] | None = None,
         capability_probe_factory: Callable[[], Awaitable[TalkCapabilityProbeResult]] | None = None,
         capability_ttl_s: float = 30.0,
     ) -> None:
@@ -96,6 +97,7 @@ class TalkManager:
         self._enabled = enabled
         self._policy_enabled = enabled if policy_enabled is None else policy_enabled
         self._supported_codecs = list(supported_codecs)
+        self._supported_codecs_factory = supported_codecs_factory
         self._open_session_factory = open_session_factory
         self._capability_probe_factory = capability_probe_factory
         self._capability_ttl_s = capability_ttl_s
@@ -136,13 +138,28 @@ class TalkManager:
             capability=capability.capability,
             state=state,
             active_session_id=record.session_id if record is not None else None,
-            supported_codecs=self._supported_codecs,
+            supported_codecs=self._current_supported_codecs(),
             offered_codecs=capability.offered_codecs,
             selected_codec=(
                 record.selected_codec if record is not None else capability.selected_codec
             ),
             last_error=self._last_error or capability.message,
         )
+
+    def _current_supported_codecs(self) -> list[str]:
+        """Return the latest selected backend codec hints when available."""
+        if self._supported_codecs_factory is None:
+            return list(self._supported_codecs)
+        try:
+            supported_codecs = list(self._supported_codecs_factory())
+        except Exception:
+            logger.debug(
+                "Talk supported codec refresh failed",
+                extra={"camera_name": self._camera_name},
+                exc_info=True,
+            )
+            return list(self._supported_codecs)
+        return supported_codecs or list(self._supported_codecs)
 
     async def refresh_status(self, *, force: bool = False) -> CameraTalkStatus:
         """Refresh capability if needed and return current source-level status."""

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pydantic import ValidationError
 
@@ -45,10 +45,11 @@ class _SelectionError:
     result: TalkCapabilityProbeResult
     backend: str | None
     backend_reason: str | None
+    codecs: list[str] = field(default_factory=list)
 
     @property
     def supported_codecs(self) -> list[str]:
-        return []
+        return list(self.codecs)
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,11 +104,13 @@ class TalkBackendSelector:
         return self._select().supported_codecs
 
     @property
-    def selected_supported_codecs(self) -> list[str]:
-        """Return supported codecs for the selected backend, if auto selection has landed."""
+    def selected_supported_codecs(self) -> list[str] | None:
+        """Return selected backend codec hints, or None before auto selection has landed."""
+        if self._selection is None:
+            return None
         if isinstance(self._selection, _SelectedBackend):
             return self._selection.supported_codecs
-        return []
+        return self._selection.supported_codecs
 
     @property
     def backend(self) -> str | None:
@@ -214,6 +217,7 @@ class TalkBackendSelector:
                     result,
                     backend=selection.backend,
                     backend_reason=selection.backend_reason,
+                    codecs=selection.supported_codecs,
                 ),
             )
 
@@ -242,6 +246,7 @@ class TalkBackendSelector:
                     result,
                     backend=selection.backend,
                     backend_reason=selection.backend_reason,
+                    codecs=selection.supported_codecs,
                 ),
             )
 

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -83,10 +83,12 @@ class TalkBackendSelector:
     @property
     def supported_codecs(self) -> list[str]:
         """Return supported codecs for the selected backend, if one can be built."""
-        if self._context.camera_talk.backend == "auto" and self._selection is None:
+        if self._context.camera_talk.backend == "auto" and not isinstance(
+            self._selection, _SelectedBackend
+        ):
             return _unique_codecs(
                 codec
-                for registration in self._auto_candidate_registrations()
+                for registration in self._standards_registrations()
                 for codec in self._build_registered_backend(
                     registration.name,
                     reason=self._auto_candidate_reason(registration),
@@ -168,18 +170,21 @@ class TalkBackendSelector:
     async def _probe_auto(self) -> TalkCapabilityProbeResult:
         if isinstance(self._selection, _SelectedBackend):
             return await self._selection.adapter.probe()
-        candidates = self._auto_candidate_registrations()
-        if not candidates:
+        standards = self._standards_registrations()
+        if not standards:
             self._selection = _SelectionError(
                 _runtime_selection_error_result("No standards-based talk backends are registered"),
                 backend=None,
                 backend_reason="No standards-based talk backends are registered",
             )
             return self._selection.result
+        candidates = standards + [
+            registration
+            for registration in self._detected_auto_registrations()
+            if registration.name not in {standard.name for standard in standards}
+        ]
 
-        first_result: TalkCapabilityProbeResult | None = None
-        first_backend: str | None = None
-        first_reason: str | None = None
+        best_failure: _SelectionError | None = None
         for registration in candidates:
             selection = self._build_registered_backend(
                 registration.name,
@@ -193,30 +198,29 @@ class TalkBackendSelector:
             if result.capability == TalkCapabilityState.SUPPORTED:
                 self._selection = selection
                 return result
-            if first_result is None:
-                first_result = result
-                first_backend = selection.backend
-                first_reason = selection.backend_reason
+            candidate_failure = _SelectionError(
+                result,
+                backend=selection.backend,
+                backend_reason=selection.backend_reason,
+            )
+            if best_failure is None or _auto_failure_rank(
+                candidate_failure.result
+            ) < _auto_failure_rank(best_failure.result):
+                best_failure = candidate_failure
 
-        if first_result is None:
+        if best_failure is None:
             return _SelectionError(
                 _runtime_selection_error_result("No standards-based talk backends are registered"),
                 backend=None,
                 backend_reason="No standards-based talk backends are registered",
             ).result
-        self._selection = _SelectionError(
-            first_result,
-            backend=first_backend,
-            backend_reason=first_reason,
-        )
-        return first_result
+        self._selection = best_failure
+        return best_failure.result
 
     def _auto_candidate_registrations(self) -> list[TalkBackendRegistration]:
-        standards = [
-            registration
-            for registration in self._registry.standards_first()
-            if registration.standards_based
-        ]
+        standards = self._standards_registrations()
+        if not standards:
+            return []
         seen = {registration.name for registration in standards}
         detected = [
             registration
@@ -224,6 +228,13 @@ class TalkBackendSelector:
             if registration.name not in seen
         ]
         return standards + detected
+
+    def _standards_registrations(self) -> list[TalkBackendRegistration]:
+        return [
+            registration
+            for registration in self._registry.standards_first()
+            if registration.standards_based
+        ]
 
     def _detected_auto_registrations(self) -> list[TalkBackendRegistration]:
         detected: list[tuple[int, bool, int, str, TalkBackendRegistration]] = []
@@ -339,6 +350,20 @@ def _backend_display_name(backend_name: str) -> str:
     if backend_name == "onvif_rtsp_backchannel":
         return "ONVIF RTSP backchannel"
     return f"talk backend '{backend_name}'"
+
+
+def _auto_failure_rank(result: TalkCapabilityProbeResult) -> int:
+    match result.capability:
+        case TalkCapabilityState.CONFIG_ERROR:
+            return 0
+        case TalkCapabilityState.ERROR:
+            return 1 if result.refusal_reason == TalkRefusalReason.TALK_AUTH_FAILED else 2
+        case TalkCapabilityState.UNSUPPORTED_CODEC:
+            return 3
+        case TalkCapabilityState.UNSUPPORTED:
+            return 4
+        case _:
+            return 5
 
 
 def _unique_codecs(values: Iterable[str]) -> list[str]:

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from pydantic import ValidationError
@@ -82,20 +83,35 @@ class TalkBackendSelector:
     @property
     def supported_codecs(self) -> list[str]:
         """Return supported codecs for the selected backend, if one can be built."""
+        if self._context.camera_talk.backend == "auto" and self._selection is None:
+            return _unique_codecs(
+                codec
+                for registration in self._auto_candidate_registrations()
+                for codec in self._build_registered_backend(
+                    registration.name,
+                    reason=self._auto_candidate_reason(registration),
+                ).supported_codecs
+            )
         return self._select().supported_codecs
 
     @property
     def backend(self) -> str | None:
         """Return the selected or explicitly requested backend name when known."""
+        if self._context.camera_talk.backend == "auto" and self._selection is None:
+            return None
         return self._select().backend
 
     @property
     def backend_reason(self) -> str | None:
         """Return a safe human-readable backend selection diagnostic."""
+        if self._context.camera_talk.backend == "auto" and self._selection is None:
+            return None
         return self._select().backend_reason
 
     async def probe(self) -> TalkCapabilityProbeResult:
         """Probe the selected backend or return a selection/config error."""
+        if self._context.camera_talk.backend == "auto":
+            return await self._probe_auto()
         selection = self._select()
         if isinstance(selection, _SelectionError):
             return selection.result
@@ -103,6 +119,16 @@ class TalkBackendSelector:
 
     async def open_session(self, request: TalkSessionOpenRequest) -> TalkBackendSession:
         """Open a talk session through the selected backend."""
+        if self._context.camera_talk.backend == "auto" and not isinstance(
+            self._selection,
+            _SelectedBackend,
+        ):
+            probe = await self._probe_auto()
+            if probe.capability != TalkCapabilityState.SUPPORTED:
+                raise TalkBackendOpenError(
+                    probe.message or "Talk backend is not available",
+                    reason=probe.refusal_reason or TalkRefusalReason.RUNTIME_UNAVAILABLE,
+                )
         selection = self._select()
         if isinstance(selection, _SelectionError):
             raise TalkBackendOpenError(
@@ -117,8 +143,11 @@ class TalkBackendSelector:
 
         camera_talk = self._context.camera_talk
         if camera_talk.backend == "auto":
-            self._selection = self._select_auto()
-            return self._selection
+            return _SelectionError(
+                _runtime_selection_error_result("Talk backend auto selection has not been probed"),
+                backend=None,
+                backend_reason=None,
+            )
 
         registration = self._registry.get(camera_talk.backend)
         if registration is None:
@@ -136,34 +165,67 @@ class TalkBackendSelector:
         )
         return self._selection
 
-    def _select_auto(self) -> _SelectedBackend | _SelectionError:
-        detected_registration = self._detected_auto_registration()
-        if detected_registration is not None:
-            return self._build_registered_backend(
-                detected_registration.name,
-                reason=f"Selected talk backend '{detected_registration.name}' by safe camera detector",
-            )
-
-        registrations = [
-            registration
-            for registration in self._registry.standards_first()
-            if registration.standards_based
-        ]
-        if not registrations:
-            return _SelectionError(
+    async def _probe_auto(self) -> TalkCapabilityProbeResult:
+        if isinstance(self._selection, _SelectedBackend):
+            return await self._selection.adapter.probe()
+        candidates = self._auto_candidate_registrations()
+        if not candidates:
+            self._selection = _SelectionError(
                 _runtime_selection_error_result("No standards-based talk backends are registered"),
                 backend=None,
                 backend_reason="No standards-based talk backends are registered",
             )
-        return self._build_registered_backend(
-            registrations[0].name,
-            reason=(
-                f"Selected {_backend_display_name(registrations[0].name)} "
-                "by standards-first auto probing"
-            ),
-        )
+            return self._selection.result
 
-    def _detected_auto_registration(self) -> TalkBackendRegistration | None:
+        first_result: TalkCapabilityProbeResult | None = None
+        first_backend: str | None = None
+        first_reason: str | None = None
+        for registration in candidates:
+            selection = self._build_registered_backend(
+                registration.name,
+                reason=self._auto_candidate_reason(registration),
+            )
+            if isinstance(selection, _SelectionError):
+                self._selection = selection
+                return selection.result
+
+            result = await selection.adapter.probe()
+            if result.capability == TalkCapabilityState.SUPPORTED:
+                self._selection = selection
+                return result
+            if first_result is None:
+                first_result = result
+                first_backend = selection.backend
+                first_reason = selection.backend_reason
+
+        if first_result is None:
+            return _SelectionError(
+                _runtime_selection_error_result("No standards-based talk backends are registered"),
+                backend=None,
+                backend_reason="No standards-based talk backends are registered",
+            ).result
+        self._selection = _SelectionError(
+            first_result,
+            backend=first_backend,
+            backend_reason=first_reason,
+        )
+        return first_result
+
+    def _auto_candidate_registrations(self) -> list[TalkBackendRegistration]:
+        standards = [
+            registration
+            for registration in self._registry.standards_first()
+            if registration.standards_based
+        ]
+        seen = {registration.name for registration in standards}
+        detected = [
+            registration
+            for registration in self._detected_auto_registrations()
+            if registration.name not in seen
+        ]
+        return standards + detected
+
+    def _detected_auto_registrations(self) -> list[TalkBackendRegistration]:
         detected: list[tuple[int, bool, int, str, TalkBackendRegistration]] = []
         for registration in self._registry.all():
             if registration.detector is None:
@@ -190,9 +252,17 @@ class TalkBackendSelector:
                 )
             )
         if not detected:
-            return None
+            return []
         detected.sort(key=lambda item: item[:4])
-        return detected[0][4]
+        return [item[4] for item in detected]
+
+    def _auto_candidate_reason(self, registration: TalkBackendRegistration) -> str:
+        if registration.standards_based:
+            return (
+                f"Selected {_backend_display_name(registration.name)} "
+                "by standards-first auto probing"
+            )
+        return f"Selected talk backend '{registration.name}' by safe camera detector"
 
     def _build_registered_backend(
         self,
@@ -269,3 +339,14 @@ def _backend_display_name(backend_name: str) -> str:
     if backend_name == "onvif_rtsp_backchannel":
         return "ONVIF RTSP backchannel"
     return f"talk backend '{backend_name}'"
+
+
+def _unique_codecs(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/src/homesec/talk/selector.py
+++ b/src/homesec/talk/selector.py
@@ -51,6 +51,12 @@ class _SelectionError:
         return []
 
 
+@dataclass(frozen=True, slots=True)
+class _AutoDetectionResult:
+    registrations: list[TalkBackendRegistration]
+    failures: list[_SelectionError]
+
+
 _AUTO_DETECTION_CONFIDENCE_RANK: dict[TalkBackendConfidence, int] = {
     "explicit": 0,
     "high": 1,
@@ -95,6 +101,13 @@ class TalkBackendSelector:
                 ).supported_codecs
             )
         return self._select().supported_codecs
+
+    @property
+    def selected_supported_codecs(self) -> list[str]:
+        """Return supported codecs for the selected backend, if auto selection has landed."""
+        if isinstance(self._selection, _SelectedBackend):
+            return self._selection.supported_codecs
+        return []
 
     @property
     def backend(self) -> str | None:
@@ -178,35 +191,59 @@ class TalkBackendSelector:
                 backend_reason="No standards-based talk backends are registered",
             )
             return self._selection.result
-        candidates = standards + [
-            registration
-            for registration in self._detected_auto_registrations()
-            if registration.name not in {standard.name for standard in standards}
-        ]
 
         best_failure: _SelectionError | None = None
-        for registration in candidates:
+        seen = set[str]()
+        for registration in standards:
+            seen.add(registration.name)
             selection = self._build_registered_backend(
                 registration.name,
                 reason=self._auto_candidate_reason(registration),
             )
             if isinstance(selection, _SelectionError):
-                self._selection = selection
-                return selection.result
+                best_failure = _better_auto_failure(best_failure, selection)
+                continue
 
             result = await selection.adapter.probe()
             if result.capability == TalkCapabilityState.SUPPORTED:
                 self._selection = selection
                 return result
-            candidate_failure = _SelectionError(
-                result,
-                backend=selection.backend,
-                backend_reason=selection.backend_reason,
+            best_failure = _better_auto_failure(
+                best_failure,
+                _SelectionError(
+                    result,
+                    backend=selection.backend,
+                    backend_reason=selection.backend_reason,
+                ),
             )
-            if best_failure is None or _auto_failure_rank(
-                candidate_failure.result
-            ) < _auto_failure_rank(best_failure.result):
-                best_failure = candidate_failure
+
+        detected = self._detected_auto_registrations()
+        for failure in detected.failures:
+            best_failure = _better_auto_failure(best_failure, failure)
+
+        for registration in detected.registrations:
+            if registration.name in seen:
+                continue
+            selection = self._build_registered_backend(
+                registration.name,
+                reason=self._auto_candidate_reason(registration),
+            )
+            if isinstance(selection, _SelectionError):
+                best_failure = _better_auto_failure(best_failure, selection)
+                continue
+
+            result = await selection.adapter.probe()
+            if result.capability == TalkCapabilityState.SUPPORTED:
+                self._selection = selection
+                return result
+            best_failure = _better_auto_failure(
+                best_failure,
+                _SelectionError(
+                    result,
+                    backend=selection.backend,
+                    backend_reason=selection.backend_reason,
+                ),
+            )
 
         if best_failure is None:
             return _SelectionError(
@@ -217,18 +254,6 @@ class TalkBackendSelector:
         self._selection = best_failure
         return best_failure.result
 
-    def _auto_candidate_registrations(self) -> list[TalkBackendRegistration]:
-        standards = self._standards_registrations()
-        if not standards:
-            return []
-        seen = {registration.name for registration in standards}
-        detected = [
-            registration
-            for registration in self._detected_auto_registrations()
-            if registration.name not in seen
-        ]
-        return standards + detected
-
     def _standards_registrations(self) -> list[TalkBackendRegistration]:
         return [
             registration
@@ -236,12 +261,32 @@ class TalkBackendSelector:
             if registration.standards_based
         ]
 
-    def _detected_auto_registrations(self) -> list[TalkBackendRegistration]:
+    def _detected_auto_registrations(self) -> _AutoDetectionResult:
         detected: list[tuple[int, bool, int, str, TalkBackendRegistration]] = []
+        failures: list[_SelectionError] = []
         for registration in self._registry.all():
             if registration.detector is None:
                 continue
-            detection = registration.detector(self._context)
+            try:
+                detection = registration.detector(self._context)
+            except Exception:
+                logger.debug(
+                    "Talk backend detector failed",
+                    extra={
+                        "camera_name": self._context.camera_name,
+                        "talk_backend": registration.name,
+                    },
+                    exc_info=True,
+                )
+                message = f"Talk backend '{registration.name}' detector failed"
+                failures.append(
+                    _SelectionError(
+                        _runtime_selection_error_result(message),
+                        backend=registration.name,
+                        backend_reason=message,
+                    )
+                )
+                continue
             detected_backend = normalize_talk_backend_id(detection.backend)
             try:
                 validate_talk_backend_id(detected_backend)
@@ -263,9 +308,12 @@ class TalkBackendSelector:
                 )
             )
         if not detected:
-            return []
+            return _AutoDetectionResult(registrations=[], failures=failures)
         detected.sort(key=lambda item: item[:4])
-        return [item[4] for item in detected]
+        return _AutoDetectionResult(
+            registrations=[item[4] for item in detected],
+            failures=failures,
+        )
 
     def _auto_candidate_reason(self, registration: TalkBackendRegistration) -> str:
         if registration.standards_based:
@@ -364,6 +412,17 @@ def _auto_failure_rank(result: TalkCapabilityProbeResult) -> int:
             return 4
         case _:
             return 5
+
+
+def _better_auto_failure(
+    current: _SelectionError | None,
+    candidate: _SelectionError,
+) -> _SelectionError:
+    if current is None:
+        return candidate
+    if _auto_failure_rank(candidate.result) < _auto_failure_rank(current.result):
+        return candidate
+    return current
 
 
 def _unique_codecs(values: Iterable[str]) -> list[str]:

--- a/tests/homesec/talk/test_proprietary_backend_readiness.py
+++ b/tests/homesec/talk/test_proprietary_backend_readiness.py
@@ -28,7 +28,7 @@ from homesec.talk.selector import TalkBackendSelector
 
 
 class _FakeConfig(BaseModel):
-    supported: bool = True
+    supported: bool = False
 
 
 @dataclass(slots=True)
@@ -166,6 +166,12 @@ def _fake_detector(context: TalkBackendContext) -> TalkBackendDetection:
     )
 
 
+def _require_fake_config(config: BaseModel) -> _FakeConfig:
+    if not isinstance(config, _FakeConfig):
+        raise TypeError(f"Expected _FakeConfig, got {type(config).__name__}")
+    return config
+
+
 def _registry(
     *,
     calls: list[str],
@@ -191,7 +197,7 @@ def _registry(
             name="fake_proprietary",
             config_model=_FakeConfig,
             factory=lambda config, context: _FakeProprietaryTalkBackend(
-                config=config if isinstance(config, _FakeConfig) else _FakeConfig(),
+                config=_require_fake_config(config),
                 calls=calls,
                 sessions=session_store,
             ),
@@ -206,6 +212,7 @@ def _registry(
 @pytest.mark.asyncio
 async def test_explicit_fake_proprietary_backend_is_selected_without_onvif_probe() -> None:
     """Explicit proprietary backend selection should not fall back to ONVIF."""
+    # Given: A camera explicitly configured for a registered fake proprietary backend
     calls: list[str] = []
     sessions: list[_FakeProprietaryTalkSession] = []
     selector = TalkBackendSelector(
@@ -218,7 +225,6 @@ async def test_explicit_fake_proprietary_backend_is_selected_without_onvif_probe
         ),
     )
 
-    # Given: A camera explicitly configured for a registered fake proprietary backend
     # When: Probing and opening through the selector
     probe = await selector.probe()
     session = await selector.open_session(
@@ -235,6 +241,7 @@ async def test_explicit_fake_proprietary_backend_is_selected_without_onvif_probe
 @pytest.mark.asyncio
 async def test_auto_prefers_supported_onvif_before_fake_fingerprint() -> None:
     """Auto selection should keep ONVIF first when the standards backend works."""
+    # Given: A safe fake fingerprint and a supported standards backend
     calls: list[str] = []
     selector = TalkBackendSelector(
         registry=_registry(
@@ -247,7 +254,6 @@ async def test_auto_prefers_supported_onvif_before_fake_fingerprint() -> None:
         ),
     )
 
-    # Given: A safe fake fingerprint and a supported standards backend
     # When: Probing auto talk capability
     probe = await selector.probe()
 
@@ -260,6 +266,7 @@ async def test_auto_prefers_supported_onvif_before_fake_fingerprint() -> None:
 @pytest.mark.asyncio
 async def test_auto_selects_safe_fake_backend_after_onvif_is_unsupported() -> None:
     """Auto selection should fall through to safe proprietary candidates after ONVIF fails."""
+    # Given: ONVIF is unsupported but fake proprietary config makes that backend safe to probe
     calls: list[str] = []
     selector = TalkBackendSelector(
         registry=_registry(calls=calls),
@@ -271,7 +278,6 @@ async def test_auto_selects_safe_fake_backend_after_onvif_is_unsupported() -> No
         ),
     )
 
-    # Given: ONVIF is unsupported but fake proprietary config makes that backend safe to probe
     # When: Probing auto talk capability
     probe = await selector.probe()
 
@@ -284,13 +290,13 @@ async def test_auto_selects_safe_fake_backend_after_onvif_is_unsupported() -> No
 @pytest.mark.asyncio
 async def test_auto_ignores_fake_backend_without_safe_config_or_fingerprint() -> None:
     """Auto selection should not probe unsafe proprietary candidates."""
+    # Given: ONVIF is unsupported and the fake backend has no safe detector match
     calls: list[str] = []
     selector = TalkBackendSelector(
         registry=_registry(calls=calls),
         context=_context(CameraTalkConfig(backend="auto")),
     )
 
-    # Given: ONVIF is unsupported and the fake backend has no safe detector match
     # When: Probing auto talk capability
     probe = await selector.probe()
 
@@ -304,6 +310,7 @@ async def test_auto_ignores_fake_backend_without_safe_config_or_fingerprint() ->
 @pytest.mark.asyncio
 async def test_fake_backend_session_receives_pcm_through_talk_manager() -> None:
     """A proprietary backend should work behind the existing TalkManager interface."""
+    # Given: A TalkManager wired to selector factories for a safe fake proprietary backend
     calls: list[str] = []
     sessions: list[_FakeProprietaryTalkSession] = []
     selector = TalkBackendSelector(
@@ -319,26 +326,32 @@ async def test_fake_backend_session_receives_pcm_through_talk_manager() -> None:
         camera_name="front",
         enabled=True,
         supported_codecs=selector.supported_codecs,
+        supported_codecs_factory=lambda: selector.selected_supported_codecs,
         open_session_factory=selector.open_session,
         capability_probe_factory=selector.probe,
         max_session_s=60.0,
         idle_timeout_s=60.0,
     )
     frame = b"\x00" * TalkInputFormat().expected_bytes_per_frame
+    initial_status = manager.status()
 
-    # Given: A TalkManager wired to selector factories for a safe fake proprietary backend
     # When: Preparing, opening, writing, and stopping a talk session
     prepared = await manager.prepare_session(TalkSessionPrepareRequest(session_id="tk_fake"))
+    prepared_status = manager.status()
     session = await manager.open_session(TalkSessionOpenRequest(session_id="tk_fake"))
     await manager.write_pcm_frame("tk_fake", frame)
     stopped = await manager.stop_session("tk_fake")
+    stopped_status = manager.status()
 
     # Then: Existing manager lifecycle forwards PCM to the fake backend with no API/runtime changes
     assert prepared.accepted is True
+    assert initial_status.supported_codecs == ["PCMU/8000"]
+    assert prepared_status.supported_codecs == ["PCMA/8000"]
     assert session is sessions[0]
     assert sessions[0].selected_codec == "PCMA/8000"
     assert sessions[0].frames == [frame]
     assert manager.status().selected_codec == "PCMA/8000"
+    assert stopped_status.supported_codecs == ["PCMA/8000"]
     assert stopped is True
     assert sessions[0].closed is True
     assert calls == ["onvif:probe", "fake:probe", "fake:open:tk_fake"]

--- a/tests/homesec/talk/test_proprietary_backend_readiness.py
+++ b/tests/homesec/talk/test_proprietary_backend_readiness.py
@@ -1,0 +1,344 @@
+"""Readiness tests for non-ONVIF talk backend adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from pydantic import BaseModel
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkInputFormat,
+    TalkRefusalReason,
+    TalkSessionOpenRequest,
+    TalkSessionPrepareRequest,
+)
+from homesec.sources.rtsp.talk.manager import TalkManager
+from homesec.talk.backends import (
+    CameraTalkFingerprint,
+    TalkBackendContext,
+    TalkBackendDetection,
+    TalkBackendRegistration,
+    TalkBackendRegistry,
+)
+from homesec.talk.selector import TalkBackendSelector
+
+
+class _FakeConfig(BaseModel):
+    supported: bool = True
+
+
+@dataclass(slots=True)
+class _FakeProprietaryTalkSession:
+    session_id: str
+    camera_name: str = "front"
+    selected_codec: str = "PCMA/8000"
+    frames: list[bytes] = field(default_factory=list)
+    closed: bool = False
+
+    async def write_pcm_frame(self, frame: bytes) -> None:
+        self.frames.append(frame)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _StandardTalkBackend:
+    name = "onvif_rtsp_backchannel"
+
+    def __init__(
+        self,
+        *,
+        calls: list[str],
+        capability: TalkCapabilityState = TalkCapabilityState.UNSUPPORTED,
+    ) -> None:
+        self._calls = calls
+        self._capability = capability
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return ["PCMU/8000"]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        self._calls.append("onvif:probe")
+        if self._capability == TalkCapabilityState.SUPPORTED:
+            return TalkCapabilityProbeResult(
+                capability=TalkCapabilityState.SUPPORTED,
+                offered_codecs=["PCMU/8000"],
+                selected_codec="PCMU/8000",
+            )
+        return TalkCapabilityProbeResult(
+            capability=TalkCapabilityState.UNSUPPORTED,
+            refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+            message="ONVIF backchannel unsupported",
+        )
+
+    async def open_session(
+        self,
+        request: TalkSessionOpenRequest,
+    ) -> _FakeProprietaryTalkSession:
+        self._calls.append(f"onvif:open:{request.session_id}")
+        return _FakeProprietaryTalkSession(
+            session_id=request.session_id,
+            selected_codec="PCMU/8000",
+        )
+
+
+class _FakeProprietaryTalkBackend:
+    name = "fake_proprietary"
+
+    def __init__(
+        self,
+        *,
+        config: _FakeConfig,
+        calls: list[str],
+        sessions: list[_FakeProprietaryTalkSession],
+    ) -> None:
+        self._config = config
+        self._calls = calls
+        self._sessions = sessions
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return ["PCMA/8000"]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        self._calls.append("fake:probe")
+        if self._config.supported:
+            return TalkCapabilityProbeResult(
+                capability=TalkCapabilityState.SUPPORTED,
+                offered_codecs=["PCMA/8000"],
+                selected_codec="PCMA/8000",
+            )
+        return TalkCapabilityProbeResult(
+            capability=TalkCapabilityState.UNSUPPORTED,
+            refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+            message="fake proprietary backend unsupported",
+        )
+
+    async def open_session(
+        self,
+        request: TalkSessionOpenRequest,
+    ) -> _FakeProprietaryTalkSession:
+        self._calls.append(f"fake:open:{request.session_id}")
+        session = _FakeProprietaryTalkSession(session_id=request.session_id)
+        self._sessions.append(session)
+        return session
+
+
+def _context(
+    camera_talk: CameraTalkConfig,
+    *,
+    fingerprint: CameraTalkFingerprint | None = None,
+) -> TalkBackendContext:
+    return TalkBackendContext(
+        camera_name="front",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=camera_talk,
+        fingerprint=fingerprint or CameraTalkFingerprint(),
+    )
+
+
+def _fake_detector(context: TalkBackendContext) -> TalkBackendDetection:
+    if "fake_proprietary" in context.camera_talk.backends:
+        return TalkBackendDetection(
+            backend="fake_proprietary",
+            confidence="explicit",
+            reason="fake backend config present",
+            safe_to_probe=True,
+        )
+    if context.fingerprint.manufacturer == "fake-vendor":
+        return TalkBackendDetection(
+            backend="fake_proprietary",
+            confidence="high",
+            reason="fake vendor fingerprint",
+            safe_to_probe=True,
+        )
+    return TalkBackendDetection(
+        backend="fake_proprietary",
+        confidence="not_applicable",
+        reason="no fake backend config or fingerprint",
+        safe_to_probe=False,
+    )
+
+
+def _registry(
+    *,
+    calls: list[str],
+    sessions: list[_FakeProprietaryTalkSession] | None = None,
+    standard_capability: TalkCapabilityState = TalkCapabilityState.UNSUPPORTED,
+) -> TalkBackendRegistry:
+    session_store = sessions if sessions is not None else []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="onvif_rtsp_backchannel",
+            config_model=_FakeConfig,
+            factory=lambda config, context: _StandardTalkBackend(
+                calls=calls,
+                capability=standard_capability,
+            ),
+            priority=10,
+            standards_based=True,
+        )
+    )
+    registry.register(
+        TalkBackendRegistration(
+            name="fake_proprietary",
+            config_model=_FakeConfig,
+            factory=lambda config, context: _FakeProprietaryTalkBackend(
+                config=config if isinstance(config, _FakeConfig) else _FakeConfig(),
+                calls=calls,
+                sessions=session_store,
+            ),
+            detector=_fake_detector,
+            priority=20,
+            standards_based=False,
+        )
+    )
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_explicit_fake_proprietary_backend_is_selected_without_onvif_probe() -> None:
+    """Explicit proprietary backend selection should not fall back to ONVIF."""
+    calls: list[str] = []
+    sessions: list[_FakeProprietaryTalkSession] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls, sessions=sessions),
+        context=_context(
+            CameraTalkConfig(
+                backend="fake_proprietary",
+                backends={"fake_proprietary": {"supported": True}},
+            )
+        ),
+    )
+
+    # Given: A camera explicitly configured for a registered fake proprietary backend
+    # When: Probing and opening through the selector
+    probe = await selector.probe()
+    session = await selector.open_session(
+        TalkSessionOpenRequest(session_id="tk_explicit", input=TalkInputFormat())
+    )
+
+    # Then: Only the fake backend is used and its selected codec is exposed
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.backend == "fake_proprietary"
+    assert session.selected_codec == "PCMA/8000"
+    assert calls == ["fake:probe", "fake:open:tk_explicit"]
+
+
+@pytest.mark.asyncio
+async def test_auto_prefers_supported_onvif_before_fake_fingerprint() -> None:
+    """Auto selection should keep ONVIF first when the standards backend works."""
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(
+            calls=calls,
+            standard_capability=TalkCapabilityState.SUPPORTED,
+        ),
+        context=_context(
+            CameraTalkConfig(backend="auto"),
+            fingerprint=CameraTalkFingerprint(manufacturer="fake-vendor"),
+        ),
+    )
+
+    # Given: A safe fake fingerprint and a supported standards backend
+    # When: Probing auto talk capability
+    probe = await selector.probe()
+
+    # Then: ONVIF wins and the proprietary backend is not probed
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.backend == "onvif_rtsp_backchannel"
+    assert calls == ["onvif:probe"]
+
+
+@pytest.mark.asyncio
+async def test_auto_selects_safe_fake_backend_after_onvif_is_unsupported() -> None:
+    """Auto selection should fall through to safe proprietary candidates after ONVIF fails."""
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(
+            CameraTalkConfig(
+                backend="auto",
+                backends={"fake_proprietary": {"supported": True}},
+            )
+        ),
+    )
+
+    # Given: ONVIF is unsupported but fake proprietary config makes that backend safe to probe
+    # When: Probing auto talk capability
+    probe = await selector.probe()
+
+    # Then: The fake backend is selected after the ONVIF probe fails
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.backend == "fake_proprietary"
+    assert calls == ["onvif:probe", "fake:probe"]
+
+
+@pytest.mark.asyncio
+async def test_auto_ignores_fake_backend_without_safe_config_or_fingerprint() -> None:
+    """Auto selection should not probe unsafe proprietary candidates."""
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # Given: ONVIF is unsupported and the fake backend has no safe detector match
+    # When: Probing auto talk capability
+    probe = await selector.probe()
+
+    # Then: The ONVIF unsupported result remains visible and fake is ignored
+    assert probe.capability == TalkCapabilityState.UNSUPPORTED
+    assert probe.refusal_reason == TalkRefusalReason.UNSUPPORTED_CAMERA
+    assert selector.backend == "onvif_rtsp_backchannel"
+    assert calls == ["onvif:probe"]
+
+
+@pytest.mark.asyncio
+async def test_fake_backend_session_receives_pcm_through_talk_manager() -> None:
+    """A proprietary backend should work behind the existing TalkManager interface."""
+    calls: list[str] = []
+    sessions: list[_FakeProprietaryTalkSession] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls, sessions=sessions),
+        context=_context(
+            CameraTalkConfig(
+                backend="auto",
+                backends={"fake_proprietary": {"supported": True}},
+            )
+        ),
+    )
+    manager = TalkManager(
+        camera_name="front",
+        enabled=True,
+        supported_codecs=selector.supported_codecs,
+        open_session_factory=selector.open_session,
+        capability_probe_factory=selector.probe,
+        max_session_s=60.0,
+        idle_timeout_s=60.0,
+    )
+    frame = b"\x00" * TalkInputFormat().expected_bytes_per_frame
+
+    # Given: A TalkManager wired to selector factories for a safe fake proprietary backend
+    # When: Preparing, opening, writing, and stopping a talk session
+    prepared = await manager.prepare_session(TalkSessionPrepareRequest(session_id="tk_fake"))
+    session = await manager.open_session(TalkSessionOpenRequest(session_id="tk_fake"))
+    await manager.write_pcm_frame("tk_fake", frame)
+    stopped = await manager.stop_session("tk_fake")
+
+    # Then: Existing manager lifecycle forwards PCM to the fake backend with no API/runtime changes
+    assert prepared.accepted is True
+    assert session is sessions[0]
+    assert sessions[0].selected_codec == "PCMA/8000"
+    assert sessions[0].frames == [frame]
+    assert manager.status().selected_codec == "PCMA/8000"
+    assert stopped is True
+    assert sessions[0].closed is True
+    assert calls == ["onvif:probe", "fake:probe", "fake:open:tk_fake"]

--- a/tests/homesec/talk/test_proprietary_backend_readiness.py
+++ b/tests/homesec/talk/test_proprietary_backend_readiness.py
@@ -28,7 +28,13 @@ from homesec.talk.selector import TalkBackendSelector
 
 
 class _FakeConfig(BaseModel):
-    supported: bool = False
+    model_config = {"extra": "forbid"}
+
+    supported: bool
+
+
+class _StandardConfig(BaseModel):
+    model_config = {"extra": "forbid"}
 
 
 @dataclass(slots=True)
@@ -183,7 +189,7 @@ def _registry(
     registry.register(
         TalkBackendRegistration(
             name="onvif_rtsp_backchannel",
-            config_model=_FakeConfig,
+            config_model=_StandardConfig,
             factory=lambda config, context: _StandardTalkBackend(
                 calls=calls,
                 capability=standard_capability,
@@ -287,6 +293,39 @@ async def test_auto_selects_safe_fake_backend_after_onvif_is_unsupported() -> No
     assert calls == ["onvif:probe", "fake:probe"]
 
 
+@pytest.mark.parametrize(
+    "invalid_config",
+    [
+        pytest.param({}, id="missing-required-field"),
+        pytest.param({"supports": True}, id="unknown-field"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_auto_reports_fake_backend_config_error(invalid_config: dict[str, object]) -> None:
+    """Auto fallback should surface invalid proprietary config instead of silent defaults."""
+    # Given: ONVIF is unsupported and a safe fake proprietary backend has invalid config
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(
+            CameraTalkConfig(
+                backend="auto",
+                backends={"fake_proprietary": invalid_config},
+            )
+        ),
+    )
+
+    # When: Probing auto talk capability
+    probe = await selector.probe()
+
+    # Then: Fake backend config validation fails before probing that backend
+    assert probe.capability == TalkCapabilityState.CONFIG_ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert probe.message == "Talk backend 'fake_proprietary' config is invalid"
+    assert selector.backend == "fake_proprietary"
+    assert calls == ["onvif:probe"]
+
+
 @pytest.mark.asyncio
 async def test_auto_ignores_fake_backend_without_safe_config_or_fingerprint() -> None:
     """Auto selection should not probe unsafe proprietary candidates."""
@@ -304,6 +343,45 @@ async def test_auto_ignores_fake_backend_without_safe_config_or_fingerprint() ->
     assert probe.capability == TalkCapabilityState.UNSUPPORTED
     assert probe.refusal_reason == TalkRefusalReason.UNSUPPORTED_CAMERA
     assert selector.backend == "onvif_rtsp_backchannel"
+    assert calls == ["onvif:probe"]
+
+
+@pytest.mark.asyncio
+async def test_fake_backend_config_error_clears_startup_codec_hints() -> None:
+    """Status should not keep ONVIF codec hints after a selected proprietary config error."""
+    # Given: A TalkManager wired to a safe fake backend with invalid proprietary config
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(
+            CameraTalkConfig(
+                backend="auto",
+                backends={"fake_proprietary": {"supports": True}},
+            )
+        ),
+    )
+    manager = TalkManager(
+        camera_name="front",
+        enabled=True,
+        supported_codecs=selector.supported_codecs,
+        supported_codecs_factory=lambda: selector.selected_supported_codecs,
+        open_session_factory=selector.open_session,
+        capability_probe_factory=selector.probe,
+        max_session_s=60.0,
+        idle_timeout_s=60.0,
+    )
+    initial_status = manager.status()
+
+    # When: Preparing the session forces auto selection and config validation
+    prepared = await manager.prepare_session(TalkSessionPrepareRequest(session_id="tk_bad_config"))
+    failed_status = manager.status()
+
+    # Then: Status reports the proprietary failure without stale ONVIF codec hints
+    assert prepared.accepted is False
+    assert prepared.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert initial_status.supported_codecs == ["PCMU/8000"]
+    assert failed_status.supported_codecs == []
+    assert failed_status.last_error == "Talk backend 'fake_proprietary' config is invalid"
     assert calls == ["onvif:probe"]
 
 

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -223,6 +223,104 @@ async def test_selector_auto_falls_back_to_safe_detector_after_standard_unsuppor
 
 
 @pytest.mark.asyncio
+async def test_selector_auto_reports_safe_detector_failure_after_standard_unsupported() -> None:
+    """Backend auto mode should surface actionable fallback failures when all candidates fail."""
+    # Given: A standards backend is unsupported and a safe vendor detector hits auth failure
+    calls: list[str] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="standard_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend(
+                "standard_backend",
+                calls,
+                probe_result=TalkCapabilityProbeResult(
+                    capability=TalkCapabilityState.UNSUPPORTED,
+                    refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+                    message="standard backend unsupported",
+                ),
+            ),
+            priority=10,
+            standards_based=True,
+        )
+    )
+    registry.register(
+        TalkBackendRegistration(
+            name="detected_vendor",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend(
+                "detected_vendor",
+                calls,
+                probe_result=TalkCapabilityProbeResult(
+                    capability=TalkCapabilityState.ERROR,
+                    refusal_reason=TalkRefusalReason.TALK_AUTH_FAILED,
+                    message="fake vendor auth failed",
+                ),
+            ),
+            detector=lambda context: TalkBackendDetection(
+                backend="detected_vendor",
+                confidence="high",
+                reason="camera fingerprint matched detected vendor",
+                safe_to_probe=True,
+            ),
+            priority=200,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing all auto candidates
+    probe = await selector.probe()
+
+    # Then: The safe vendor auth failure is reported instead of hiding behind ONVIF unsupported
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_AUTH_FAILED
+    assert probe.message == "fake vendor auth failed"
+    assert selector.backend == "detected_vendor"
+    assert calls == ["standard_backend:probe", "detected_vendor:probe"]
+
+
+def test_selector_auto_supported_codecs_does_not_build_proprietary_fallback() -> None:
+    """Startup codec metadata should not instantiate proprietary fallback backends."""
+    # Given: A safe proprietary detector whose backend factory must wait for standards failure
+    calls: list[str] = []
+    registry = _registry(calls)
+    registry.register(
+        TalkBackendRegistration(
+            name="detected_vendor",
+            config_model=_BackendConfig,
+            factory=lambda config, context: pytest.fail(
+                "proprietary fallback should not build for startup codec metadata"
+            ),
+            detector=lambda context: TalkBackendDetection(
+                backend="detected_vendor",
+                confidence="high",
+                reason="camera fingerprint matched detected vendor",
+                safe_to_probe=True,
+            ),
+            priority=200,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Source startup asks for supported codecs before any capability probe
+    codecs = selector.supported_codecs
+
+    # Then: Only standards-based codec metadata is built
+    assert codecs == ["PCMU/8000"]
+    assert selector.backend is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_selector_auto_ignores_detector_that_is_not_safe_to_probe() -> None:
     """Backend auto mode should not auto-probe unsafe detector matches."""
     # Given: A selector in auto mode with a vendor detector that is not safe to probe
@@ -303,6 +401,43 @@ async def test_selector_auto_refuses_vendor_only_registry_without_safe_detector(
     assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
     assert probe.message == "No standards-based talk backends are registered"
     assert selector.supported_codecs == []
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_refuses_safe_vendor_when_no_standard_backend_is_registered() -> None:
+    """Safe proprietary detections should not replace the standards-first prerequisite."""
+    # Given: A registry with only a safe vendor detector and no standards backend
+    calls: list[str] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("vendor_backend", calls),
+            detector=lambda context: TalkBackendDetection(
+                backend="vendor_backend",
+                confidence="high",
+                reason="camera fingerprint matched vendor",
+                safe_to_probe=True,
+            ),
+            priority=1,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing through auto selection
+    probe = await selector.probe()
+
+    # Then: Auto selection refuses without probing proprietary-only candidates
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+    assert probe.message == "No standards-based talk backends are registered"
+    assert selector.backend is None
     assert calls == []
 
 

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -135,11 +135,8 @@ async def test_selector_auto_uses_standards_backend_before_safe_detector() -> No
             name="detected_vendor",
             config_model=_BackendConfig,
             factory=lambda config, context: _FakeBackend("detected_vendor", calls),
-            detector=lambda context: TalkBackendDetection(
-                backend="detected_vendor",
-                confidence="high",
-                reason="camera fingerprint matched detected vendor",
-                safe_to_probe=True,
+            detector=lambda context: pytest.fail(
+                "proprietary detector should wait until standards fail"
             ),
             priority=200,
             standards_based=False,
@@ -160,6 +157,48 @@ async def test_selector_auto_uses_standards_backend_before_safe_detector() -> No
     assert probe.capability == TalkCapabilityState.SUPPORTED
     assert session.selected_codec == "PCMU/8000"
     assert calls == ["standard_backend:probe", "standard_backend:open:tk_detected"]
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_continues_after_candidate_config_error() -> None:
+    """Backend auto mode should not let one invalid candidate block a later supported one."""
+    # Given: The first standards backend has invalid config but a later standards backend works
+    calls: list[str] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="bad_standard_backend",
+            config_model=_IntBackendConfig,
+            factory=lambda config, context: _FakeBackend("bad_standard_backend", calls),
+            priority=1,
+            standards_based=True,
+        )
+    )
+    registry.register(
+        TalkBackendRegistration(
+            name="good_standard_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("good_standard_backend", calls),
+            priority=2,
+            standards_based=True,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing and opening through auto selection
+    probe = await selector.probe()
+    session = await selector.open_session(
+        TalkSessionOpenRequest(session_id="tk_config", input=TalkInputFormat())
+    )
+
+    # Then: The valid later standards backend is selected
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.backend == "good_standard_backend"
+    assert session.selected_codec == "PCMU/8000"
+    assert calls == ["good_standard_backend:probe", "good_standard_backend:open:tk_config"]
 
 
 @pytest.mark.asyncio
@@ -282,6 +321,55 @@ async def test_selector_auto_reports_safe_detector_failure_after_standard_unsupp
     assert probe.message == "fake vendor auth failed"
     assert selector.backend == "detected_vendor"
     assert calls == ["standard_backend:probe", "detected_vendor:probe"]
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_reports_detector_failure_after_standard_unsupported() -> None:
+    """Backend auto mode should isolate proprietary detector failures to fallback probing."""
+    # Given: Standards probing fails and a proprietary detector raises before selection
+    calls: list[str] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="standard_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend(
+                "standard_backend",
+                calls,
+                probe_result=TalkCapabilityProbeResult(
+                    capability=TalkCapabilityState.UNSUPPORTED,
+                    refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+                    message="standard backend unsupported",
+                ),
+            ),
+            priority=10,
+            standards_based=True,
+        )
+    )
+    registry.register(
+        TalkBackendRegistration(
+            name="detected_vendor",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("detected_vendor", calls),
+            detector=lambda context: (_ for _ in ()).throw(RuntimeError("detector boom")),
+            priority=200,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing through auto selection
+    probe = await selector.probe()
+
+    # Then: The detector failure is reported without raising or skipping standards probing
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+    assert probe.message == "Talk backend 'detected_vendor' detector failed"
+    assert selector.backend == "detected_vendor"
+    assert calls == ["standard_backend:probe"]
 
 
 def test_selector_auto_supported_codecs_does_not_build_proprietary_fallback() -> None:

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -44,9 +44,17 @@ class _FakeSession:
 
 
 class _FakeBackend:
-    def __init__(self, name: str, calls: list[str]) -> None:
+    def __init__(
+        self,
+        name: str,
+        calls: list[str],
+        probe_result: TalkCapabilityProbeResult | None = None,
+    ) -> None:
         self.name = name
         self._calls = calls
+        self._probe_result = probe_result or TalkCapabilityProbeResult(
+            capability=TalkCapabilityState.SUPPORTED
+        )
 
     @property
     def supported_codecs(self) -> list[str]:
@@ -54,7 +62,7 @@ class _FakeBackend:
 
     async def probe(self) -> TalkCapabilityProbeResult:
         self._calls.append(f"{self.name}:probe")
-        return TalkCapabilityProbeResult(capability=TalkCapabilityState.SUPPORTED)
+        return self._probe_result
 
     async def open_session(self, request: TalkSessionOpenRequest) -> _FakeSession:
         self._calls.append(f"{self.name}:open:{request.session_id}")
@@ -117,9 +125,9 @@ async def test_selector_auto_uses_standards_backend_first() -> None:
 
 
 @pytest.mark.asyncio
-async def test_selector_auto_uses_safe_high_confidence_detector_before_default() -> None:
-    """Backend auto mode should honor safe high-confidence detector matches."""
-    # Given: A selector in auto mode with a standard default and detected vendor backend
+async def test_selector_auto_uses_standards_backend_before_safe_detector() -> None:
+    """Backend auto mode should try standards before proprietary detector matches."""
+    # Given: A selector in auto mode with a supported standard backend and safe vendor detector
     calls: list[str] = []
     registry = _registry(calls)
     registry.register(
@@ -148,10 +156,70 @@ async def test_selector_auto_uses_safe_high_confidence_detector_before_default()
         TalkSessionOpenRequest(session_id="tk_detected", input=TalkInputFormat())
     )
 
-    # Then: The detector-selected backend handles the request before the standard default
+    # Then: The standards backend wins and the detected vendor is not probed
     assert probe.capability == TalkCapabilityState.SUPPORTED
     assert session.selected_codec == "PCMU/8000"
-    assert calls == ["detected_vendor:probe", "detected_vendor:open:tk_detected"]
+    assert calls == ["standard_backend:probe", "standard_backend:open:tk_detected"]
+
+
+@pytest.mark.asyncio
+async def test_selector_auto_falls_back_to_safe_detector_after_standard_unsupported() -> None:
+    """Backend auto mode should use a safe proprietary backend after standards fail."""
+    # Given: A selector in auto mode with unsupported standard talk and a safe vendor detector
+    calls: list[str] = []
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="standard_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend(
+                "standard_backend",
+                calls,
+                probe_result=TalkCapabilityProbeResult(
+                    capability=TalkCapabilityState.UNSUPPORTED,
+                    refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+                    message="standard backend unsupported",
+                ),
+            ),
+            priority=10,
+            standards_based=True,
+        )
+    )
+    registry.register(
+        TalkBackendRegistration(
+            name="detected_vendor",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend("detected_vendor", calls),
+            detector=lambda context: TalkBackendDetection(
+                backend="detected_vendor",
+                confidence="high",
+                reason="camera fingerprint matched detected vendor",
+                safe_to_probe=True,
+            ),
+            priority=200,
+            standards_based=False,
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing and opening a talk session
+    probe = await selector.probe()
+    session = await selector.open_session(
+        TalkSessionOpenRequest(session_id="tk_detected", input=TalkInputFormat())
+    )
+
+    # Then: The selector falls through from standards to the safe vendor backend
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.backend == "detected_vendor"
+    assert session.selected_codec == "PCMU/8000"
+    assert calls == [
+        "standard_backend:probe",
+        "detected_vendor:probe",
+        "detected_vendor:open:tk_detected",
+    ]
 
 
 @pytest.mark.asyncio
@@ -159,7 +227,24 @@ async def test_selector_auto_ignores_detector_that_is_not_safe_to_probe() -> Non
     """Backend auto mode should not auto-probe unsafe detector matches."""
     # Given: A selector in auto mode with a vendor detector that is not safe to probe
     calls: list[str] = []
-    registry = _registry(calls)
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="standard_backend",
+            config_model=_BackendConfig,
+            factory=lambda config, context: _FakeBackend(
+                "standard_backend",
+                calls,
+                probe_result=TalkCapabilityProbeResult(
+                    capability=TalkCapabilityState.UNSUPPORTED,
+                    refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+                    message="standard backend unsupported",
+                ),
+            ),
+            priority=10,
+            standards_based=True,
+        )
+    )
     registry.register(
         TalkBackendRegistration(
             name="unsafe_vendor",
@@ -183,8 +268,10 @@ async def test_selector_auto_ignores_detector_that_is_not_safe_to_probe() -> Non
     # When: Probing through auto selection
     probe = await selector.probe()
 
-    # Then: Selection falls back to the standard backend instead of unsafe vendor probing
-    assert probe.capability == TalkCapabilityState.SUPPORTED
+    # Then: Selection preserves the standard result instead of probing the unsafe vendor
+    assert probe.capability == TalkCapabilityState.UNSUPPORTED
+    assert probe.refusal_reason == TalkRefusalReason.UNSUPPORTED_CAMERA
+    assert selector.backend == "standard_backend"
     assert calls == ["standard_backend:probe"]
 
 


### PR DESCRIPTION
## Summary
- Make auto talk backend selection standards-first, with safe proprietary detector fallback only after a registered standards backend has been probed and does not find support.
- Defer proprietary detector execution until standards probing fails, isolate detector failures to fallback diagnostics, and keep auto probing moving past one candidate's config/build error when a later candidate can succeed.
- Add fake proprietary backend readiness coverage for explicit selection, safe detector fallback, unsafe detector suppression, proprietary-only auto refusal, detector/fallback/config failure diagnostics, and standards-first preference.
- Prove a non-ONVIF backend can receive PCM frames through the existing `TalkManager` path without API/runtime/UI protocol changes.
- Harden auto startup metadata so proprietary fallback backends are not instantiated while source construction is only asking for supported codec hints, while status updates to the selected backend codec list after fallback selection and clears stale startup hints for selected backend config failures.

## Notion
- Epic: https://www.notion.so/levneiman/Phase-9-talk-backend-adapter-abstraction-and-selection-358d8336c59f81ff84b0f7436fdf6370
- Ticket: https://www.notion.so/levneiman/Phase-9-5-fake-proprietary-backend-readiness-tests-359d8336c59f81cf8e92db02e0f865fb

## Validation
- `uv run ruff check src tests`
- `uv run mypy --package homesec --strict`
- `uv run pytest tests/homesec/talk/test_selector.py tests/homesec/talk/test_proprietary_backend_readiness.py tests/homesec/rtsp/talk/test_manager.py tests/homesec/rtsp/test_runtime.py -q` passed: `110 passed`.
- `TEST_DB_DSN=postgresql://homesec:homesec@localhost:55432/homesec make check` passed: Python `1251 passed, 2 warnings`; UI `260 passed`; API artifacts up to date; production build succeeded with the existing local Node/Vite version warning.

Stacked on https://github.com/lan17/homesec/pull/88.
