### PR TITLE
feat: add Phase 10.1 Tapo backend skeleton

### DIFF
--- a/src/homesec/talk/backend_ids.py
+++ b/src/homesec/talk/backend_ids.py
@@ -6,6 +6,12 @@ import re
 
 TALK_BACKEND_ID_PATTERN_TEXT = r"^[a-z][a-z0-9_]{0,63}$"
 _TALK_BACKEND_ID_PATTERN = re.compile(TALK_BACKEND_ID_PATTERN_TEXT)
+_SAFE_PUBLIC_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+_SAFE_ENV_VAR_DIAGNOSTIC_PATTERN = re.compile(
+    r"^(?:Required talk backend|Required Tapo local|RTSP URL|RTSP credential) "
+    r"environment variable is not set: "
+    r"(?P<env>[A-Za-z_][A-Za-z0-9_]{0,127})$"
+)
 _UNSAFE_TALK_BACKEND_REASON_PATTERN = re.compile(
     r"://|authorization|bearer|basic|digest|password|passwd|secret|token|api[_-]?key|"
     r"\bsdp\b|(?:^|\s)(?:v=0|m=|a=)",
@@ -47,6 +53,12 @@ def sanitize_talk_backend_reason(value: object) -> str | None:
         return None
     reason = value.strip()
     if not reason or len(reason) > 256 or "\n" in reason or "\r" in reason:
+        return None
+    env_match = _SAFE_ENV_VAR_DIAGNOSTIC_PATTERN.fullmatch(reason)
+    if env_match is not None:
+        env_name = env_match["env"]
+        if "_" in env_name and _SAFE_PUBLIC_ENV_VAR_NAME_PATTERN.fullmatch(env_name):
+            return reason
         return None
     if _UNSAFE_TALK_BACKEND_REASON_PATTERN.search(reason):
         return None

--- a/src/homesec/talk/registry.py
+++ b/src/homesec/talk/registry.py
@@ -8,7 +8,9 @@ from homesec.talk.backends import TalkBackendRegistry
 def build_default_talk_backend_registry() -> TalkBackendRegistry:
     """Build the built-in talk backend registry."""
     from homesec.sources.rtsp.talk.backend import onvif_rtsp_talk_backend_registration
+    from homesec.talk.tapo.backend import tapo_local_talk_backend_registration
 
     registry = TalkBackendRegistry()
     registry.register(onvif_rtsp_talk_backend_registration())
+    registry.register(tapo_local_talk_backend_registration())
     return registry

--- a/src/homesec/talk/tapo/__init__.py
+++ b/src/homesec/talk/tapo/__init__.py
@@ -1,0 +1,1 @@
+"""TP-Link Tapo local talk backend support."""

--- a/src/homesec/talk/tapo/backend.py
+++ b/src/homesec/talk/tapo/backend.py
@@ -1,0 +1,144 @@
+"""Built-in Tapo local talk backend registration and detector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkRefusalReason,
+    TalkSessionOpenRequest,
+)
+from homesec.talk.backends import (
+    TalkBackendAdapter,
+    TalkBackendContext,
+    TalkBackendDetection,
+    TalkBackendOpenError,
+    TalkBackendRegistration,
+    TalkBackendSession,
+)
+from homesec.talk.tapo.config import (
+    TapoCredential,
+    TapoLocalTalkConfig,
+    resolve_tapo_credential,
+    resolve_tapo_host,
+)
+
+TAPO_LOCAL_BACKEND = "tapo_local"
+TAPO_LOCAL_CODEC = "PCMA/8000"
+_TAPO_PROTOCOL_NOT_IMPLEMENTED = "Tapo local protocol client is not implemented yet"
+
+
+@dataclass(slots=True)
+class TapoLocalTalkBackend:
+    """Phase 10 Tapo backend skeleton.
+
+    The network protocol client and audio session are implemented in later Phase
+    10 tickets. This skeleton lets config, registry, and selector behavior land
+    without changing API/runtime/UI contracts.
+    """
+
+    config: TapoLocalTalkConfig
+    context: TalkBackendContext
+    host: str
+    credential: TapoCredential
+    name: str = TAPO_LOCAL_BACKEND
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        """Return camera-side codecs planned for the Tapo local backend."""
+        return [TAPO_LOCAL_CODEC]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        """Report that protocol probing is not implemented until the next ticket."""
+        return _protocol_not_implemented_result()
+
+    async def open_session(self, request: TalkSessionOpenRequest) -> TalkBackendSession:
+        """Refuse session open until the Tapo protocol client exists."""
+        _ = request
+        raise TalkBackendOpenError(
+            _TAPO_PROTOCOL_NOT_IMPLEMENTED,
+            reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
+        )
+
+
+def detect_tapo_local(context: TalkBackendContext) -> TalkBackendDetection:
+    """Return safe, local-only Tapo applicability metadata for auto selection."""
+    if context.camera_talk.backend == TAPO_LOCAL_BACKEND:
+        return TalkBackendDetection(
+            backend=TAPO_LOCAL_BACKEND,
+            confidence="explicit",
+            reason="Explicit Tapo local backend configured",
+            safe_to_probe=True,
+            requires_credentials=True,
+        )
+
+    if TAPO_LOCAL_BACKEND in context.camera_talk.backends:
+        return TalkBackendDetection(
+            backend=TAPO_LOCAL_BACKEND,
+            confidence="explicit",
+            reason="Tapo local backend config present",
+            safe_to_probe=True,
+            requires_credentials=True,
+        )
+
+    manufacturer = (context.fingerprint.manufacturer or "").lower()
+    model = (context.fingerprint.model or "").lower()
+    if "tp-link" in manufacturer or "tapo" in model:
+        return TalkBackendDetection(
+            backend=TAPO_LOCAL_BACKEND,
+            confidence="high",
+            reason="TP-Link/Tapo camera fingerprint",
+            safe_to_probe=True,
+            requires_credentials=True,
+        )
+
+    return TalkBackendDetection(
+        backend=TAPO_LOCAL_BACKEND,
+        confidence="not_applicable",
+        reason="No Tapo local config or fingerprint",
+        safe_to_probe=False,
+        requires_credentials=True,
+    )
+
+
+def tapo_local_talk_backend_registration() -> TalkBackendRegistration:
+    """Return the built-in Tapo local talk backend registration."""
+    return TalkBackendRegistration(
+        name=TAPO_LOCAL_BACKEND,
+        config_model=TapoLocalTalkConfig,
+        factory=build_tapo_local_backend,
+        detector=detect_tapo_local,
+        priority=50,
+        standards_based=False,
+    )
+
+
+def build_tapo_local_backend(
+    config: BaseModel,
+    context: TalkBackendContext,
+) -> TalkBackendAdapter:
+    """Build a Tapo local backend from validated backend config."""
+    if not isinstance(config, TapoLocalTalkConfig):
+        raise TypeError(f"Expected TapoLocalTalkConfig, got {type(config).__name__}")
+    host = resolve_tapo_host(config, context)
+    credential = resolve_tapo_credential(config, context)
+    return TapoLocalTalkBackend(
+        config=config,
+        context=context,
+        host=host,
+        credential=credential,
+    )
+
+
+def _protocol_not_implemented_result() -> TalkCapabilityProbeResult:
+    return TalkCapabilityProbeResult(
+        capability=TalkCapabilityState.ERROR,
+        refusal_reason=TalkRefusalReason.RUNTIME_UNAVAILABLE,
+        message=_TAPO_PROTOCOL_NOT_IMPLEMENTED,
+        offered_codecs=[TAPO_LOCAL_CODEC],
+        selected_codec=TAPO_LOCAL_CODEC,
+    )

--- a/src/homesec/talk/tapo/backend.py
+++ b/src/homesec/talk/tapo/backend.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pydantic import BaseModel
 
@@ -42,9 +42,9 @@ class TapoLocalTalkBackend:
     """
 
     config: TapoLocalTalkConfig
-    context: TalkBackendContext
+    context: TalkBackendContext = field(repr=False)
     host: str
-    credential: TapoCredential
+    credential: TapoCredential = field(repr=False)
     name: str = TAPO_LOCAL_BACKEND
 
     @property

--- a/src/homesec/talk/tapo/config.py
+++ b/src/homesec/talk/tapo/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 from urllib.parse import urlsplit
 
@@ -70,7 +70,7 @@ class TapoCredential:
     """Resolved credential material for Tapo local Digest authentication."""
 
     username: str
-    password_hash: str
+    password_hash: str = field(repr=False)
     hash_kind: Literal["sha256", "md5"]
 
 

--- a/src/homesec/talk/tapo/config.py
+++ b/src/homesec/talk/tapo/config.py
@@ -1,0 +1,168 @@
+"""Configuration helpers for the Tapo local talk backend."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from homesec.talk.backends import TalkBackendConfigError, TalkBackendContext
+
+_SAFE_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
+_HEX_PATTERN = re.compile(r"^[A-F0-9]+$")
+
+
+class TapoLocalTalkConfig(BaseModel):
+    """Config for a local TP-Link Tapo camera talk endpoint."""
+
+    model_config = {"extra": "forbid"}
+
+    host: str | None = None
+    port: int = Field(default=8800, ge=1, le=65535)
+
+    username: str = "admin"
+    username_env: str | None = None
+
+    password_sha256_env: str | None = None
+    password_md5_env: str | None = None
+
+    connect_timeout_s: float | None = Field(default=None, ge=0.1, le=30.0)
+    io_timeout_s: float | None = Field(default=None, ge=0.1, le=30.0)
+
+    mode: Literal["aec"] = "aec"
+    audio_codec: Literal["PCMA/8000"] = "PCMA/8000"
+
+    @field_validator("host", "username", mode="before")
+    @classmethod
+    def _strip_optional_string(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator(
+        "username_env",
+        "password_sha256_env",
+        "password_md5_env",
+    )
+    @classmethod
+    def _validate_env_var_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not _SAFE_ENV_VAR_NAME_PATTERN.fullmatch(stripped):
+            raise ValueError("Tapo local env var names must be safe shell identifiers")
+        return stripped
+
+    @model_validator(mode="after")
+    def _validate_non_empty_values(self) -> TapoLocalTalkConfig:
+        if self.host == "":
+            raise ValueError("Tapo local host cannot be empty")
+        if self.username == "":
+            raise ValueError("Tapo local username cannot be empty")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class TapoCredential:
+    """Resolved credential material for Tapo local Digest authentication."""
+
+    username: str
+    password_hash: str
+    hash_kind: Literal["sha256", "md5"]
+
+
+def resolve_tapo_host(config: TapoLocalTalkConfig, context: TalkBackendContext) -> str:
+    """Resolve the Tapo LAN host from backend config or source URI context."""
+    if config.host:
+        return config.host
+
+    if context.source_host:
+        return context.source_host
+
+    for uri in (context.resolved_source_uri, context.source_uri):
+        host = _host_from_uri(uri)
+        if host:
+            return host
+
+    raise TalkBackendConfigError("Tapo local backend requires host or source URI host")
+
+
+def resolve_tapo_credential(
+    config: TapoLocalTalkConfig,
+    context: TalkBackendContext,
+    *,
+    preferred_hash_kind: Literal["sha256", "md5"] = "sha256",
+) -> TapoCredential:
+    """Resolve Tapo credential hash material from configured environment variables."""
+    username = _resolve_username(config, context)
+    env_order = _credential_env_order(config, preferred_hash_kind=preferred_hash_kind)
+    if not env_order:
+        raise TalkBackendConfigError("Tapo local backend requires SHA256 or MD5 credential env var")
+
+    for hash_kind, env_name in env_order:
+        raw_value = context.env_value(env_name)
+        if raw_value is None or raw_value.strip() == "":
+            raise TalkBackendConfigError(
+                f"Required Tapo local environment variable is not set: {env_name}"
+            )
+        normalized = raw_value.strip().upper()
+        _validate_hash_shape(normalized, env_name=env_name, hash_kind=hash_kind)
+        return TapoCredential(
+            username=username,
+            password_hash=normalized,
+            hash_kind=hash_kind,
+        )
+
+    raise TalkBackendConfigError("Tapo local backend requires SHA256 or MD5 credential env var")
+
+
+def _resolve_username(config: TapoLocalTalkConfig, context: TalkBackendContext) -> str:
+    if config.username_env is None:
+        return config.username
+    username = context.env_value(config.username_env)
+    if username is None or username.strip() == "":
+        raise TalkBackendConfigError(
+            f"Required Tapo local environment variable is not set: {config.username_env}"
+        )
+    return username.strip()
+
+
+def _credential_env_order(
+    config: TapoLocalTalkConfig,
+    *,
+    preferred_hash_kind: Literal["sha256", "md5"],
+) -> list[tuple[Literal["sha256", "md5"], str]]:
+    configured: dict[Literal["sha256", "md5"], str] = {}
+    if config.password_sha256_env is not None:
+        configured["sha256"] = config.password_sha256_env
+    if config.password_md5_env is not None:
+        configured["md5"] = config.password_md5_env
+
+    ordered: list[tuple[Literal["sha256", "md5"], str]] = []
+    if preferred_hash_kind in configured:
+        ordered.append((preferred_hash_kind, configured[preferred_hash_kind]))
+    for hash_kind in ("sha256", "md5"):
+        if hash_kind in configured and hash_kind != preferred_hash_kind:
+            ordered.append((hash_kind, configured[hash_kind]))
+    return ordered
+
+
+def _validate_hash_shape(
+    value: str,
+    *,
+    env_name: str,
+    hash_kind: Literal["sha256", "md5"],
+) -> None:
+    expected_length = 64 if hash_kind == "sha256" else 32
+    if len(value) != expected_length or _HEX_PATTERN.fullmatch(value) is None:
+        raise TalkBackendConfigError(f"Tapo local credential hash in {env_name} is invalid")
+
+
+def _host_from_uri(uri: str | None) -> str | None:
+    if not uri:
+        return None
+    parsed = urlsplit(uri)
+    return parsed.hostname

--- a/tests/homesec/rtsp/test_runtime.py
+++ b/tests/homesec/rtsp/test_runtime.py
@@ -840,7 +840,7 @@ async def test_unknown_explicit_talk_backend_reports_config_error_without_onvif_
         tmp_path,
         **{
             "__runtime_talk__": TalkConfig(enabled=True),
-            "__camera_talk__": CameraTalkConfig(backend="tapo_local"),
+            "__camera_talk__": CameraTalkConfig(backend="future_backend"),
         },
     )
 
@@ -858,9 +858,9 @@ async def test_unknown_explicit_talk_backend_reports_config_error_without_onvif_
     assert status.policy_enabled is True
     assert status.capability == TalkCapabilityState.CONFIG_ERROR
     assert status.state == TalkState.ERROR
-    assert status.last_error == "Talk backend 'tapo_local' is not registered in this runtime"
-    assert status.backend == "tapo_local"
-    assert status.backend_reason == "Talk backend 'tapo_local' is not registered"
+    assert status.last_error == "Talk backend 'future_backend' is not registered in this runtime"
+    assert status.backend == "future_backend"
+    assert status.backend_reason == "Talk backend 'future_backend' is not registered"
     assert prepared.accepted is False
     assert prepared.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
     assert prepared.message == status.last_error

--- a/tests/homesec/talk/tapo/test_config.py
+++ b/tests/homesec/talk/tapo/test_config.py
@@ -1,0 +1,205 @@
+"""Tests for Tapo local talk backend config helpers."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.talk.backends import TalkBackendConfigError, TalkBackendContext
+from homesec.talk.tapo.config import (
+    TapoLocalTalkConfig,
+    resolve_tapo_credential,
+    resolve_tapo_host,
+)
+
+
+def _context(
+    *,
+    source_uri: str | None = "rtsp://admin:secret@192.168.1.33:554/stream1",
+    source_host: str | None = None,
+    env: dict[str, str] | None = None,
+) -> TalkBackendContext:
+    values = env or {}
+    return TalkBackendContext(
+        camera_name="office",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=CameraTalkConfig(),
+        source_host=source_host,
+        source_uri=source_uri,
+        resolved_source_uri=source_uri,
+        resolve_env=lambda name: values.get(name),
+    )
+
+
+def test_camera_talk_config_accepts_tapo_backend_and_config_block() -> None:
+    """Camera talk config should preserve Tapo backend config for runtime selection."""
+    # Given: A camera configured with an explicit Tapo local backend
+    # When: Validating the generic camera talk config
+    talk = CameraTalkConfig(
+        backend="TAPO_LOCAL",
+        backends={
+            "TAPO_LOCAL": {
+                "host": "192.168.1.33",
+                "password_sha256_env": "OFFICE_TAPO_SHA256",
+            }
+        },
+    )
+
+    # Then: Backend IDs are normalized and backend-specific config is preserved
+    assert talk.backend == "tapo_local"
+    assert talk.config_for_backend("tapo_local") == {
+        "host": "192.168.1.33",
+        "password_sha256_env": "OFFICE_TAPO_SHA256",
+    }
+
+
+def test_tapo_config_uses_safe_defaults() -> None:
+    """Tapo backend config should default to the local C120 protocol shape."""
+    # Given: Minimal Tapo backend config
+    # When: Validating the config model
+    config = TapoLocalTalkConfig.model_validate({"password_sha256_env": "OFFICE_SHA"})
+
+    # Then: Defaults match the local Tapo talk endpoint assumptions
+    assert config.port == 8800
+    assert config.username == "admin"
+    assert config.mode == "aec"
+    assert config.audio_codec == "PCMA/8000"
+
+
+def test_tapo_config_rejects_unknown_fields() -> None:
+    """Tapo backend config should reject unknown fields instead of ignoring mistakes."""
+    # Given: Config containing a misspelled or unsupported field
+    # When: Validating the config model
+    # Then: Validation fails before runtime selection can use the wrong shape
+    with pytest.raises(ValidationError, match="extra"):
+        TapoLocalTalkConfig.model_validate(
+            {"password_sha256_env": "OFFICE_SHA", "cloud_password": "not-supported"}
+        )
+
+
+def test_tapo_config_rejects_unsafe_env_var_names() -> None:
+    """Tapo env-var references should be safe to mention in diagnostics."""
+    # Given: A credential env var name containing unsafe characters
+    # When: Validating the config model
+    # Then: The config is rejected before that name reaches public diagnostics
+    with pytest.raises(ValidationError, match="safe shell identifiers"):
+        TapoLocalTalkConfig.model_validate({"password_sha256_env": "bad env name"})
+
+
+def test_tapo_host_prefers_explicit_config_host() -> None:
+    """Tapo host resolution should prefer the backend-specific host."""
+    # Given: A Tapo config with an explicit host and a different RTSP source URI
+    config = TapoLocalTalkConfig(host="192.168.1.50", password_sha256_env="OFFICE_SHA")
+
+    # When: Resolving the Tapo endpoint host
+    host = resolve_tapo_host(config, _context())
+
+    # Then: The explicit backend host wins
+    assert host == "192.168.1.50"
+
+
+def test_tapo_host_can_be_derived_from_rtsp_source_uri_without_credentials() -> None:
+    """Tapo host resolution should derive only the host from the RTSP source URI."""
+    # Given: A Tapo config without host and an RTSP URL containing credentials
+    config = TapoLocalTalkConfig(password_sha256_env="OFFICE_SHA")
+
+    # When: Resolving the Tapo endpoint host
+    host = resolve_tapo_host(config, _context())
+
+    # Then: Only the credential-free host is returned
+    assert host == "192.168.1.33"
+
+
+def test_tapo_host_prefers_source_host_before_parsing_source_uri() -> None:
+    """Tapo host resolution should use the source host hint when available."""
+    # Given: A Tapo config without host and a source host hint
+    config = TapoLocalTalkConfig(password_sha256_env="OFFICE_SHA")
+
+    # When: Resolving the Tapo endpoint host
+    host = resolve_tapo_host(
+        config,
+        _context(source_host="camera.local", source_uri="rtsp://192.168.1.33/stream1"),
+    )
+
+    # Then: The explicit context host wins over parsing the URI
+    assert host == "camera.local"
+
+
+def test_tapo_host_missing_from_config_and_source_uri_reports_safe_error() -> None:
+    """Tapo host resolution should fail safely when no host is available."""
+    # Given: No explicit Tapo host and no source URI host
+    config = TapoLocalTalkConfig(password_sha256_env="OFFICE_SHA")
+
+    # When: Resolving the Tapo endpoint host
+    # Then: A structured public config error explains the missing host
+    with pytest.raises(TalkBackendConfigError) as exc_info:
+        resolve_tapo_host(config, _context(source_uri=None))
+    assert exc_info.value.public_message == "Tapo local backend requires host or source URI host"
+
+
+def test_tapo_credential_requires_hash_env_config() -> None:
+    """Tapo credentials should require explicit hash env-var configuration."""
+    # Given: Tapo config without SHA256 or MD5 hash env references
+    config = TapoLocalTalkConfig()
+
+    # When: Resolving credential material
+    # Then: A safe config error is raised without requesting a raw password
+    with pytest.raises(TalkBackendConfigError) as exc_info:
+        resolve_tapo_credential(config, _context())
+    assert (
+        exc_info.value.public_message
+        == "Tapo local backend requires SHA256 or MD5 credential env var"
+    )
+
+
+def test_tapo_credential_reports_missing_env_var_by_name() -> None:
+    """Tapo credential resolution should report missing env vars without secret values."""
+    # Given: A Tapo config that references an unset credential env var
+    config = TapoLocalTalkConfig(password_sha256_env="OFFICE_TAPO_SHA256")
+
+    # When: Resolving credential material
+    # Then: The public error names only the missing env var
+    with pytest.raises(TalkBackendConfigError) as exc_info:
+        resolve_tapo_credential(config, _context())
+    assert (
+        exc_info.value.public_message
+        == "Required Tapo local environment variable is not set: OFFICE_TAPO_SHA256"
+    )
+
+
+def test_tapo_credential_normalizes_sha256_hash_from_env() -> None:
+    """Tapo credential resolution should normalize configured SHA256 hash material."""
+    # Given: A lowercase SHA256 hash in the configured env var
+    sha256 = "a" * 64
+    config = TapoLocalTalkConfig(password_sha256_env="OFFICE_TAPO_SHA256")
+
+    # When: Resolving credential material
+    credential = resolve_tapo_credential(
+        config,
+        _context(env={"OFFICE_TAPO_SHA256": sha256}),
+    )
+
+    # Then: The hash is uppercased and tagged as SHA256
+    assert credential.username == "admin"
+    assert credential.password_hash == "A" * 64
+    assert credential.hash_kind == "sha256"
+
+
+def test_tapo_credential_rejects_invalid_hash_shape_without_exposing_value() -> None:
+    """Tapo credential resolution should reject invalid hash values safely."""
+    # Given: A configured env var containing a malformed hash
+    config = TapoLocalTalkConfig(password_sha256_env="OFFICE_TAPO_SHA256")
+
+    # When: Resolving credential material
+    # Then: The error names the env var but not the invalid value
+    with pytest.raises(TalkBackendConfigError) as exc_info:
+        resolve_tapo_credential(
+            config,
+            _context(env={"OFFICE_TAPO_SHA256": "not-a-hash"}),
+        )
+    assert exc_info.value.public_message == (
+        "Tapo local credential hash in OFFICE_TAPO_SHA256 is invalid"
+    )
+    assert "not-a-hash" not in exc_info.value.public_message

--- a/tests/homesec/talk/tapo/test_config.py
+++ b/tests/homesec/talk/tapo/test_config.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from homesec.models.config import CameraTalkConfig, TalkConfig
 from homesec.talk.backends import TalkBackendConfigError, TalkBackendContext
 from homesec.talk.tapo.config import (
+    TapoCredential,
     TapoLocalTalkConfig,
     resolve_tapo_credential,
     resolve_tapo_host,
@@ -185,6 +186,20 @@ def test_tapo_credential_normalizes_sha256_hash_from_env() -> None:
     assert credential.username == "admin"
     assert credential.password_hash == "A" * 64
     assert credential.hash_kind == "sha256"
+
+
+def test_tapo_credential_repr_does_not_expose_hash_value() -> None:
+    """Tapo credential repr should not expose hash material by accident."""
+    # Given: Resolved Tapo credential hash material
+    secret_hash = "A" * 64
+    credential = TapoCredential(username="admin", password_hash=secret_hash, hash_kind="sha256")
+
+    # When: Formatting the credential for debugging
+    text = repr(credential)
+
+    # Then: The hash value is not included in the repr
+    assert secret_hash not in text
+    assert "password_hash" not in text
 
 
 def test_tapo_credential_rejects_invalid_hash_shape_without_exposing_value() -> None:

--- a/tests/homesec/talk/tapo/test_detector.py
+++ b/tests/homesec/talk/tapo/test_detector.py
@@ -1,0 +1,152 @@
+"""Tests for Tapo local backend registration and detector behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.talk.backends import CameraTalkFingerprint, TalkBackendContext
+from homesec.talk.registry import build_default_talk_backend_registry
+from homesec.talk.tapo.backend import (
+    TAPO_LOCAL_BACKEND,
+    detect_tapo_local,
+    tapo_local_talk_backend_registration,
+)
+
+
+def _context(
+    camera_talk: CameraTalkConfig,
+    *,
+    fingerprint: CameraTalkFingerprint | None = None,
+) -> TalkBackendContext:
+    return TalkBackendContext(
+        camera_name="office",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=camera_talk,
+        fingerprint=fingerprint or CameraTalkFingerprint(),
+    )
+
+
+def test_tapo_registration_is_non_standard_backend() -> None:
+    """Tapo backend registration should be a proprietary detector-gated backend."""
+    # Given: The built-in Tapo backend registration
+    # When: Inspecting registration metadata
+    registration = tapo_local_talk_backend_registration()
+
+    # Then: It uses the public backend ID and stays outside standards-first probing
+    assert registration.name == TAPO_LOCAL_BACKEND
+    assert registration.standards_based is False
+    assert registration.priority == 50
+    assert registration.detector is detect_tapo_local
+
+
+def test_default_registry_contains_onvif_before_tapo() -> None:
+    """Default registry should keep ONVIF standards probing before Tapo fallback."""
+    # Given: The built-in HomeSec talk backend registry
+    # When: Reading registered backend names
+    registry = build_default_talk_backend_registry()
+
+    # Then: ONVIF remains first and Tapo is available as the proprietary fallback
+    assert registry.names() == ("onvif_rtsp_backchannel", "tapo_local")
+    assert registry.get("onvif_rtsp_backchannel") is not None
+    tapo = registry.get("tapo_local")
+    assert tapo is not None
+    assert tapo.standards_based is False
+
+
+def test_detector_marks_explicit_tapo_backend_safe_to_probe() -> None:
+    """Explicit tapo_local selection should be safe to probe."""
+    # Given: A camera explicitly configured for tapo_local
+    context = _context(CameraTalkConfig(backend="tapo_local"))
+
+    # When: Running the Tapo detector
+    detection = detect_tapo_local(context)
+
+    # Then: The detector returns an explicit safe candidate
+    assert detection.backend == "tapo_local"
+    assert detection.confidence == "explicit"
+    assert detection.safe_to_probe is True
+    assert detection.requires_credentials is True
+
+
+def test_detector_marks_tapo_config_block_safe_to_probe_in_auto_mode() -> None:
+    """A tapo_local config block should make auto fallback safe after standards fail."""
+    # Given: A camera in auto mode with Tapo backend-specific config
+    context = _context(
+        CameraTalkConfig(
+            backend="auto",
+            backends={"tapo_local": {"host": "192.168.1.33"}},
+        )
+    )
+
+    # When: Running the Tapo detector
+    detection = detect_tapo_local(context)
+
+    # Then: Tapo is a safe explicit candidate for selector fallback
+    assert detection.backend == "tapo_local"
+    assert detection.confidence == "explicit"
+    assert detection.safe_to_probe is True
+    assert detection.reason == "Tapo local backend config present"
+
+
+def test_detector_marks_tp_link_tapo_fingerprint_safe_to_probe() -> None:
+    """A TP-Link/Tapo fingerprint should make Tapo auto probing safe."""
+    # Given: A camera fingerprint matching a Tapo C120
+    context = _context(
+        CameraTalkConfig(backend="auto"),
+        fingerprint=CameraTalkFingerprint(manufacturer="TP-Link", model="Tapo C120"),
+    )
+
+    # When: Running the Tapo detector
+    detection = detect_tapo_local(context)
+
+    # Then: The detector returns a high-confidence safe candidate
+    assert detection.backend == "tapo_local"
+    assert detection.confidence == "high"
+    assert detection.safe_to_probe is True
+    assert detection.reason == "TP-Link/Tapo camera fingerprint"
+
+
+def test_detector_rejects_auto_without_config_or_fingerprint() -> None:
+    """Auto mode should not probe Tapo without config or a safe fingerprint."""
+    # Given: A generic camera with no Tapo config or fingerprint
+    context = _context(CameraTalkConfig(backend="auto"))
+
+    # When: Running the Tapo detector
+    detection = detect_tapo_local(context)
+
+    # Then: Tapo is not a safe candidate
+    assert detection.backend == "tapo_local"
+    assert detection.confidence == "not_applicable"
+    assert detection.safe_to_probe is False
+    assert detection.reason == "No Tapo local config or fingerprint"
+
+
+def test_detector_does_not_perform_network_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tapo detection should stay synchronous and local-metadata-only."""
+
+    async def _forbidden_async_open(*_: object, **__: object) -> object:
+        raise AssertionError("detector must not open network connections")
+
+    def _forbidden_socket_connect(*_: object, **__: object) -> object:
+        raise AssertionError("detector must not open network connections")
+
+    monkeypatch.setattr(asyncio, "open_connection", _forbidden_async_open)
+    monkeypatch.setattr(socket, "create_connection", _forbidden_socket_connect)
+    context = _context(
+        CameraTalkConfig(
+            backend="auto",
+            backends={"tapo_local": {"host": "192.168.1.33"}},
+        )
+    )
+
+    # Given: Network connection helpers patched to fail if called
+    # When: Running the detector
+    detection = detect_tapo_local(context)
+
+    # Then: Detection succeeds without touching network APIs
+    assert detection.safe_to_probe is True

--- a/tests/homesec/talk/tapo/test_tapo_selector.py
+++ b/tests/homesec/talk/tapo/test_tapo_selector.py
@@ -1,0 +1,256 @@
+"""Selector tests for the built-in Tapo local backend skeleton."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.models.talk import (
+    TalkCapabilityProbeResult,
+    TalkCapabilityState,
+    TalkRefusalReason,
+)
+from homesec.talk.backends import TalkBackendContext, TalkBackendRegistration, TalkBackendRegistry
+from homesec.talk.selector import TalkBackendSelector
+from homesec.talk.tapo.backend import TAPO_LOCAL_CODEC, tapo_local_talk_backend_registration
+
+_VALID_SHA256 = "A" * 64
+
+
+class _StandardConfig(BaseModel):
+    """Fake standards backend config for Tapo selector tests."""
+
+
+class _StandardSession:
+    session_id = "tk_onvif"
+    camera_name = "office"
+    selected_codec = "PCMU/8000"
+
+    async def write_pcm_frame(self, frame: bytes) -> None:
+        _ = frame
+
+    async def close(self) -> None:
+        return None
+
+
+class _StandardBackend:
+    name = "onvif_rtsp_backchannel"
+
+    def __init__(
+        self,
+        *,
+        calls: list[str],
+        capability: TalkCapabilityState,
+    ) -> None:
+        self._calls = calls
+        self._capability = capability
+
+    @property
+    def supported_codecs(self) -> list[str]:
+        return ["PCMU/8000"]
+
+    async def probe(self) -> TalkCapabilityProbeResult:
+        self._calls.append("onvif:probe")
+        if self._capability == TalkCapabilityState.SUPPORTED:
+            return TalkCapabilityProbeResult(
+                capability=TalkCapabilityState.SUPPORTED,
+                offered_codecs=["PCMU/8000"],
+                selected_codec="PCMU/8000",
+            )
+        return TalkCapabilityProbeResult(
+            capability=TalkCapabilityState.UNSUPPORTED,
+            refusal_reason=TalkRefusalReason.UNSUPPORTED_CAMERA,
+            message="ONVIF backchannel unsupported",
+        )
+
+    async def open_session(self, request: object) -> _StandardSession:
+        self._calls.append("onvif:open")
+        _ = request
+        return _StandardSession()
+
+
+def _registry(
+    *,
+    calls: list[str],
+    standard_capability: TalkCapabilityState = TalkCapabilityState.UNSUPPORTED,
+) -> TalkBackendRegistry:
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="onvif_rtsp_backchannel",
+            config_model=_StandardConfig,
+            factory=lambda config, context: _StandardBackend(
+                calls=calls,
+                capability=standard_capability,
+            ),
+            priority=10,
+            standards_based=True,
+        )
+    )
+    registry.register(tapo_local_talk_backend_registration())
+    return registry
+
+
+def _context(camera_talk: CameraTalkConfig) -> TalkBackendContext:
+    return TalkBackendContext(
+        camera_name="office",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=camera_talk,
+        source_uri="rtsp://admin:secret@192.168.1.33:554/stream1",
+        resolved_source_uri="rtsp://admin:secret@192.168.1.33:554/stream1",
+        resolve_env=lambda name: _VALID_SHA256 if name == "OFFICE_TAPO_SHA256" else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_tapo_backend_does_not_fallback_to_onvif() -> None:
+    """Explicit tapo_local selection should not probe standards backends."""
+    # Given: A camera explicitly configured for the built-in Tapo local backend
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(
+            CameraTalkConfig(
+                backend="tapo_local",
+                backends={
+                    "tapo_local": {
+                        "host": "192.168.1.33",
+                        "password_sha256_env": "OFFICE_TAPO_SHA256",
+                    }
+                },
+            )
+        ),
+    )
+
+    # When: Probing through explicit backend selection
+    probe = await selector.probe()
+
+    # Then: Tapo is selected, ONVIF is not probed, and protocol work is deferred
+    assert selector.backend == "tapo_local"
+    assert selector.supported_codecs == [TAPO_LOCAL_CODEC]
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+    assert probe.message == "Tapo local protocol client is not implemented yet"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_tapo_missing_env_reports_config_error_without_onvif_probe() -> None:
+    """Explicit Tapo config errors should not fallback to ONVIF probing."""
+    # Given: A camera explicitly configured for Tapo with an unset credential env var
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=TalkBackendContext(
+            camera_name="office",
+            source_backend="rtsp",
+            runtime_talk=TalkConfig(),
+            camera_talk=CameraTalkConfig(
+                backend="tapo_local",
+                backends={
+                    "tapo_local": {
+                        "host": "192.168.1.33",
+                        "password_sha256_env": "MISSING_TAPO_SHA256",
+                    }
+                },
+            ),
+            resolve_env=lambda name: None,
+        ),
+    )
+
+    # When: Probing through explicit backend selection
+    probe = await selector.probe()
+
+    # Then: A stable config error is returned and standards backends remain untouched
+    assert probe.capability == TalkCapabilityState.CONFIG_ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert (
+        probe.message == "Required Tapo local environment variable is not set: MISSING_TAPO_SHA256"
+    )
+    assert selector.backend == "tapo_local"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_auto_tapo_config_is_considered_after_onvif_unsupported() -> None:
+    """Auto mode should consider Tapo only after standards probing fails."""
+    # Given: ONVIF is unsupported and Tapo config makes proprietary probing safe
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(
+            CameraTalkConfig(
+                backend="auto",
+                backends={
+                    "tapo_local": {
+                        "host": "192.168.1.33",
+                        "password_sha256_env": "OFFICE_TAPO_SHA256",
+                    }
+                },
+            )
+        ),
+    )
+
+    # When: Probing auto selection
+    probe = await selector.probe()
+
+    # Then: ONVIF is tried first and Tapo becomes the selected safe fallback
+    assert probe.capability == TalkCapabilityState.ERROR
+    assert probe.refusal_reason == TalkRefusalReason.RUNTIME_UNAVAILABLE
+    assert selector.backend == "tapo_local"
+    assert selector.backend_reason == "Selected talk backend 'tapo_local' by safe camera detector"
+    assert calls == ["onvif:probe"]
+
+
+@pytest.mark.asyncio
+async def test_auto_ignores_tapo_without_config_or_fingerprint() -> None:
+    """Auto mode should not probe Tapo without config or fingerprint evidence."""
+    # Given: ONVIF is unsupported and no Tapo config/fingerprint is present
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=_context(CameraTalkConfig(backend="auto")),
+    )
+
+    # When: Probing auto selection
+    probe = await selector.probe()
+
+    # Then: The ONVIF unsupported result remains visible and Tapo is ignored
+    assert probe.capability == TalkCapabilityState.UNSUPPORTED
+    assert probe.refusal_reason == TalkRefusalReason.UNSUPPORTED_CAMERA
+    assert selector.backend == "onvif_rtsp_backchannel"
+    assert calls == ["onvif:probe"]
+
+
+@pytest.mark.asyncio
+async def test_auto_keeps_supported_onvif_ahead_of_tapo_config() -> None:
+    """Auto mode should keep standards-first behavior even when Tapo config exists."""
+    # Given: ONVIF is supported and Tapo config is also present
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(
+            calls=calls,
+            standard_capability=TalkCapabilityState.SUPPORTED,
+        ),
+        context=_context(
+            CameraTalkConfig(
+                backend="auto",
+                backends={
+                    "tapo_local": {
+                        "host": "192.168.1.33",
+                        "password_sha256_env": "OFFICE_TAPO_SHA256",
+                    }
+                },
+            )
+        ),
+    )
+
+    # When: Probing auto selection
+    probe = await selector.probe()
+
+    # Then: ONVIF wins before the Tapo detector path is reached
+    assert probe.capability == TalkCapabilityState.SUPPORTED
+    assert selector.backend == "onvif_rtsp_backchannel"
+    assert calls == ["onvif:probe"]

--- a/tests/homesec/talk/tapo/test_tapo_selector.py
+++ b/tests/homesec/talk/tapo/test_tapo_selector.py
@@ -13,7 +13,12 @@ from homesec.models.talk import (
 )
 from homesec.talk.backends import TalkBackendContext, TalkBackendRegistration, TalkBackendRegistry
 from homesec.talk.selector import TalkBackendSelector
-from homesec.talk.tapo.backend import TAPO_LOCAL_CODEC, tapo_local_talk_backend_registration
+from homesec.talk.tapo.backend import (
+    TAPO_LOCAL_CODEC,
+    build_tapo_local_backend,
+    tapo_local_talk_backend_registration,
+)
+from homesec.talk.tapo.config import TapoLocalTalkConfig
 
 _VALID_SHA256 = "A" * 64
 
@@ -171,6 +176,68 @@ async def test_explicit_tapo_missing_env_reports_config_error_without_onvif_prob
     )
     assert selector.backend == "tapo_local"
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_tapo_missing_password_named_env_preserves_env_name() -> None:
+    """Tapo config errors should preserve safe env names that include PASSWORD."""
+    # Given: A camera explicitly configured with a common password-named env var
+    calls: list[str] = []
+    selector = TalkBackendSelector(
+        registry=_registry(calls=calls),
+        context=TalkBackendContext(
+            camera_name="office",
+            source_backend="rtsp",
+            runtime_talk=TalkConfig(),
+            camera_talk=CameraTalkConfig(
+                backend="tapo_local",
+                backends={
+                    "tapo_local": {
+                        "host": "192.168.1.33",
+                        "password_sha256_env": "TAPO_PASSWORD_SHA256",
+                    }
+                },
+            ),
+            resolve_env=lambda name: None,
+        ),
+    )
+
+    # When: Probing through explicit backend selection
+    probe = await selector.probe()
+
+    # Then: The missing env var name remains visible and ONVIF remains untouched
+    assert probe.capability == TalkCapabilityState.CONFIG_ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert probe.message == (
+        "Required Tapo local environment variable is not set: TAPO_PASSWORD_SHA256"
+    )
+    assert selector.backend_reason == probe.message
+    assert calls == []
+
+
+def test_tapo_backend_repr_does_not_expose_hash_or_rtsp_credentials() -> None:
+    """Tapo backend repr should not expose credential hashes or source URIs."""
+    # Given: A Tapo backend built with a source URI containing RTSP credentials
+    backend = build_tapo_local_backend(
+        TapoLocalTalkConfig(
+            host="192.168.1.33",
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        ),
+        _context(
+            CameraTalkConfig(
+                backend="tapo_local",
+                backends={"tapo_local": {"password_sha256_env": "OFFICE_TAPO_SHA256"}},
+            )
+        ),
+    )
+
+    # When: Formatting the backend for debugging
+    text = repr(backend)
+
+    # Then: The repr keeps secret-bearing fields out of accidental logs
+    assert _VALID_SHA256 not in text
+    assert "admin:secret" not in text
+    assert "rtsp://admin:secret@192.168.1.33" not in text
 
 
 @pytest.mark.asyncio

--- a/tests/homesec/talk/test_backend_registry.py
+++ b/tests/homesec/talk/test_backend_registry.py
@@ -125,8 +125,8 @@ def test_default_talk_backend_registry_contains_onvif_backend() -> None:
     # When: Reading registered backend names
     registry = build_default_talk_backend_registry()
 
-    # Then: ONVIF remains the standards-based default backend
-    assert registry.names() == ("onvif_rtsp_backchannel",)
+    # Then: ONVIF remains first and Tapo is available after standards probing
+    assert registry.names() == ("onvif_rtsp_backchannel", "tapo_local")
     registration = registry.get("onvif_rtsp_backchannel")
     assert registration is not None
     assert registration.standards_based is True
@@ -150,7 +150,7 @@ def test_default_talk_backend_registry_imports_without_source_cycle() -> None:
 
     # Then: The lazy ONVIF registration import avoids the RTSP source import cycle
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "('onvif_rtsp_backchannel',)"
+    assert result.stdout.strip() == "('onvif_rtsp_backchannel', 'tapo_local')"
 
 
 def test_rtsp_talk_backend_registry_alias_returns_default_registry() -> None:

--- a/tests/homesec/talk/test_selector.py
+++ b/tests/homesec/talk/test_selector.py
@@ -705,6 +705,47 @@ async def test_selector_preserves_safe_structured_config_error_message() -> None
 
 
 @pytest.mark.asyncio
+async def test_selector_preserves_safe_env_var_name_with_sensitive_words() -> None:
+    """Structured config errors should preserve safe env names even with secret-like words."""
+
+    # Given: A backend reports a missing env var whose safe name contains PASSWORD
+    def _raise_structured_config_error(
+        raw_config: dict[str, object] | BaseModel,
+        context: TalkBackendContext,
+    ) -> BaseModel:
+        _ = raw_config, context
+        raise TalkBackendConfigError(
+            "Required talk backend environment variable is not set: TAPO_PASSWORD_SHA256"
+        )
+
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            config_factory=_raise_structured_config_error,
+            factory=lambda config, context: _FakeBackend("vendor_backend", []),
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="vendor_backend")),
+    )
+
+    # When: Probing the selected backend
+    probe = await selector.probe()
+
+    # Then: The env var name remains visible because it is a reference, not a secret value
+    assert probe.capability == TalkCapabilityState.CONFIG_ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert (
+        probe.message
+        == "Required talk backend environment variable is not set: TAPO_PASSWORD_SHA256"
+    )
+    assert selector.backend_reason == probe.message
+
+
+@pytest.mark.asyncio
 async def test_selector_drops_unsafe_structured_config_error_message() -> None:
     """Structured config errors should still pass through public sanitization."""
 
@@ -741,6 +782,84 @@ async def test_selector_drops_unsafe_structured_config_error_message() -> None:
     assert probe.message == "Talk backend 'vendor_backend' config is invalid"
     assert selector.backend_reason == "Talk backend 'vendor_backend' config is invalid"
     assert "rtsp://alice:secret@camera.local/talk" not in (probe.message or "")
+
+
+@pytest.mark.asyncio
+async def test_selector_drops_auth_text_disguised_as_missing_env_message() -> None:
+    """Structured config errors should not let auth text bypass missing-env sanitization."""
+
+    # Given: A backend error embeds auth-like text before a safe env var name
+    def _raise_unsafe_structured_config_error(
+        raw_config: dict[str, object] | BaseModel,
+        context: TalkBackendContext,
+    ) -> BaseModel:
+        _ = raw_config, context
+        raise TalkBackendConfigError(
+            "Authorization Bearer hunter2 environment variable is not set: TAPO_PASSWORD_SHA256"
+        )
+
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            config_factory=_raise_unsafe_structured_config_error,
+            factory=lambda config, context: _FakeBackend("vendor_backend", []),
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="vendor_backend")),
+    )
+
+    # When: Probing the selected backend
+    probe = await selector.probe()
+
+    # Then: The unsafe prefix prevents the env-var exception from preserving the message
+    assert probe.capability == TalkCapabilityState.CONFIG_ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert probe.message == "Talk backend 'vendor_backend' config is invalid"
+    assert selector.backend_reason == "Talk backend 'vendor_backend' config is invalid"
+    assert "hunter2" not in (probe.message or "")
+
+
+@pytest.mark.asyncio
+async def test_selector_drops_lowercase_secret_disguised_as_env_name() -> None:
+    """Structured config errors should preserve only conventionally safe env var names."""
+
+    # Given: A backend error places raw secret-looking text in the env-var slot
+    def _raise_unsafe_structured_config_error(
+        raw_config: dict[str, object] | BaseModel,
+        context: TalkBackendContext,
+    ) -> BaseModel:
+        _ = raw_config, context
+        raise TalkBackendConfigError(
+            "Required talk backend environment variable is not set: hunter2"
+        )
+
+    registry = TalkBackendRegistry()
+    registry.register(
+        TalkBackendRegistration(
+            name="vendor_backend",
+            config_model=_BackendConfig,
+            config_factory=_raise_unsafe_structured_config_error,
+            factory=lambda config, context: _FakeBackend("vendor_backend", []),
+        )
+    )
+    selector = TalkBackendSelector(
+        registry=registry,
+        context=_context(CameraTalkConfig(backend="vendor_backend")),
+    )
+
+    # When: Probing the selected backend
+    probe = await selector.probe()
+
+    # Then: The lower-case token is not treated as a safe public env var reference
+    assert probe.capability == TalkCapabilityState.CONFIG_ERROR
+    assert probe.refusal_reason == TalkRefusalReason.TALK_CONFIG_ERROR
+    assert probe.message == "Talk backend 'vendor_backend' config is invalid"
+    assert selector.backend_reason == "Talk backend 'vendor_backend' config is invalid"
+    assert "hunter2" not in (probe.message or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements Phase 10.1 of the HomeSec push-to-talk work: the Tapo C120 local talkback backend skeleton, config model, backend registration, and safe detector hooks.

Links:
- Phase 10 ticket: https://www.notion.so/levneiman/Phase-10-implement-Tapo-C120-local-talkback-backend-358d8336c59f81c0b03afeb3c4708b5e
- Phase 10.1 subtask: https://www.notion.so/levneiman/35ad8336c59f81209a9ce190905315ad

## Design

- Adds built-in `tapo_local` as a proprietary talk backend registered after the standards-based ONVIF RTSP backend.
- Keeps API, UI, runtime IPC, and `TalkManager` protocol-agnostic; this only extends the Phase 9 backend registry/selector layer.
- Adds `TapoLocalTalkConfig` with local endpoint defaults for port `8800`, mode `aec`, and camera codec `PCMA/8000`.
- Resolves the Tapo host from explicit backend config, `TalkBackendContext.source_host`, or the credential-free host parsed from the source URI.
- Requires credential hash material through env var references and reports only safe env var names in public config diagnostics.
- Adds a metadata-only detector that marks Tapo safe to probe only for explicit backend/config selection or TP-Link/Tapo fingerprint evidence.

## Current Scope / Non-goals

This PR intentionally does not implement the Tapo HTTP/Digest client, multipart stream handling, MPEG-TS muxer, or audio session. The skeleton reports `RUNTIME_UNAVAILABLE` until Phase 10.2 adds the protocol client/muxer and Phase 10.3 wires the backend session/E2E path.

## Validation

- `uv run pytest tests/homesec/talk/tapo tests/homesec/talk/test_backend_registry.py tests/homesec/talk/test_selector.py tests/homesec/talk/test_proprietary_backend_readiness.py tests/homesec/rtsp/test_talk_backend.py tests/homesec/rtsp/test_runtime.py::test_unknown_explicit_talk_backend_reports_config_error_without_onvif_probe -q` -> 62 passed
- `uv run --locked ruff check src/homesec/talk/tapo src/homesec/talk/registry.py tests/homesec/talk/tapo tests/homesec/talk/test_backend_registry.py tests/homesec/rtsp/test_runtime.py` -> passed
- `uv run mypy src/homesec/talk/tapo src/homesec/talk/registry.py tests/homesec/talk/tapo tests/homesec/talk/test_backend_registry.py` -> passed
- `make check` -> ruff, format, and mypy passed; pytest reached 1256 passed, then failed on 38 local Postgres-backed fixture errors in the existing DB test suite
