### PR TITLE
feat: add Phase 10.2 Tapo protocol client

### DIFF
--- a/src/homesec/talk/tapo/client.py
+++ b/src/homesec/talk/tapo/client.py
@@ -32,6 +32,7 @@ _CRLF = "\r\n"
 _HEADER_SEPARATOR = b"\r\n\r\n"
 _STREAM_URI = "/stream"
 _MAX_SETUP_RESPONSE_BYTES = 64 * 1024
+_MAX_HTTP_RESPONSE_BODY_BYTES = 64 * 1024
 _DEFAULT_CONNECT_TIMEOUT_S = 5.0
 _DEFAULT_IO_TIMEOUT_S = 5.0
 
@@ -74,7 +75,7 @@ class TapoLocalClient:
     io_timeout_s: float
     reader: asyncio.StreamReader = field(repr=False)
     writer: asyncio.StreamWriter = field(repr=False)
-    tapo_session_id: str
+    tapo_session_id: str = field(repr=False)
     _write_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
     _closed: bool = field(default=False, init=False, repr=False)
 
@@ -94,16 +95,20 @@ class TapoLocalClient:
             payload,
         )
         async with self._write_lock:
-            self.writer.write(part)
-            await asyncio.wait_for(self.writer.drain(), timeout=self.io_timeout_s)
+            try:
+                self.writer.write(part)
+                await asyncio.wait_for(self.writer.drain(), timeout=self.io_timeout_s)
+            except BaseException:
+                self._closed = True
+                await _close_writer_best_effort(self.writer, timeout_s=self.io_timeout_s)
+                raise
 
     async def close(self) -> None:
         """Close the local stream connection."""
         if self._closed:
             return
         self._closed = True
-        self.writer.close()
-        await self.writer.wait_closed()
+        await _close_writer_best_effort(self.writer, timeout_s=self.io_timeout_s)
 
 
 async def open_tapo_local_client(
@@ -161,9 +166,8 @@ async def open_tapo_local_client(
             writer=writer,
             tapo_session_id=tapo_session_id,
         )
-    except Exception:
-        writer.close()
-        await writer.wait_closed()
+    except BaseException:
+        await _close_writer_best_effort(writer, timeout_s=io_timeout_s)
         raise
 
 
@@ -296,7 +300,10 @@ async def _read_http_response(
     io_timeout_s: float,
     read_body: bool,
 ) -> TapoHTTPResponse:
-    head = await asyncio.wait_for(reader.readuntil(_HEADER_SEPARATOR), timeout=io_timeout_s)
+    try:
+        head = await asyncio.wait_for(reader.readuntil(_HEADER_SEPARATOR), timeout=io_timeout_s)
+    except (asyncio.IncompleteReadError, asyncio.LimitOverrunError) as exc:
+        raise TapoProtocolError("Malformed Tapo local HTTP response") from exc
     text = head.decode("iso-8859-1")
     lines = text.split(_CRLF)
     if not lines or not lines[0].startswith("HTTP/"):
@@ -319,8 +326,16 @@ async def _read_http_response(
     body = b""
     if read_body:
         content_length = _parse_content_length(headers.get("content-length"))
+        if content_length > _MAX_HTTP_RESPONSE_BODY_BYTES:
+            raise TapoProtocolError("Tapo local HTTP response body exceeds configured limit")
         if content_length:
-            body = await asyncio.wait_for(reader.readexactly(content_length), timeout=io_timeout_s)
+            try:
+                body = await asyncio.wait_for(
+                    reader.readexactly(content_length),
+                    timeout=io_timeout_s,
+                )
+            except asyncio.IncompleteReadError as exc:
+                raise TapoProtocolError("Malformed Tapo local HTTP response body") from exc
     return TapoHTTPResponse(
         status_code=status_code,
         reason=parts[2].strip() if len(parts) > 2 else "",
@@ -367,3 +382,15 @@ def _parse_content_length(value: str | None) -> int:
     if content_length < 0:
         raise TapoProtocolError("Invalid Tapo local HTTP Content-Length")
     return content_length
+
+
+async def _close_writer_best_effort(
+    writer: asyncio.StreamWriter,
+    *,
+    timeout_s: float,
+) -> None:
+    writer.close()
+    try:
+        await asyncio.wait_for(writer.wait_closed(), timeout=max(timeout_s, 0.1))
+    except BaseException:
+        pass

--- a/src/homesec/talk/tapo/client.py
+++ b/src/homesec/talk/tapo/client.py
@@ -1,0 +1,369 @@
+"""Async local HTTP/multipart client for the Tapo talk endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from homesec.talk.backends import TalkBackendContext
+from homesec.talk.tapo.config import (
+    TapoCredential,
+    TapoLocalTalkConfig,
+    resolve_tapo_credential,
+    resolve_tapo_host,
+)
+from homesec.talk.tapo.digest import (
+    TapoDigestChallenge,
+    TapoDigestError,
+    build_digest_authorization_header,
+    parse_www_authenticate,
+)
+from homesec.talk.tapo.multipart import (
+    CLIENT_BOUNDARY,
+    CLIENT_PART_PREFIX,
+    multipart_part,
+    read_multipart_part,
+)
+
+_CRLF = "\r\n"
+_HEADER_SEPARATOR = b"\r\n\r\n"
+_STREAM_URI = "/stream"
+_MAX_SETUP_RESPONSE_BYTES = 64 * 1024
+_DEFAULT_CONNECT_TIMEOUT_S = 5.0
+_DEFAULT_IO_TIMEOUT_S = 5.0
+
+
+class TapoClientError(RuntimeError):
+    """Base class for safe Tapo client failures."""
+
+
+class TapoAuthError(TapoClientError):
+    """Raised when the Tapo endpoint rejects authentication."""
+
+    def __init__(self, message: str = "Tapo local authentication failed") -> None:
+        super().__init__(message)
+
+
+class TapoProtocolError(TapoClientError):
+    """Raised for malformed or rejected Tapo local protocol data."""
+
+
+@dataclass(frozen=True, slots=True)
+class TapoHTTPResponse:
+    """Parsed HTTP response headers and optional body."""
+
+    status_code: int
+    reason: str
+    headers: dict[str, str] = field(default_factory=dict)
+    body: bytes = b""
+
+    def header(self, name: str) -> str | None:
+        """Return a case-insensitive response header."""
+        return self.headers.get(name.lower())
+
+
+@dataclass(slots=True)
+class TapoLocalClient:
+    """Connected Tapo local stream client after talk setup succeeds."""
+
+    host: str
+    port: int
+    io_timeout_s: float
+    reader: asyncio.StreamReader = field(repr=False)
+    writer: asyncio.StreamWriter = field(repr=False)
+    tapo_session_id: str
+    _write_lock: asyncio.Lock = field(default_factory=asyncio.Lock, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+
+    async def write_audio_mp2t(self, payload: bytes) -> None:
+        """Write one audio/mp2t multipart chunk to the Tapo stream."""
+        if self._closed:
+            raise TapoProtocolError("Cannot write to closed Tapo local stream")
+        if not payload:
+            raise TapoProtocolError("Tapo audio payload must not be empty")
+        part = multipart_part(
+            CLIENT_PART_PREFIX,
+            {
+                "Content-Type": "audio/mp2t",
+                "X-If-Encrypt": "0",
+                "X-Session-Id": self.tapo_session_id,
+            },
+            payload,
+        )
+        async with self._write_lock:
+            self.writer.write(part)
+            await asyncio.wait_for(self.writer.drain(), timeout=self.io_timeout_s)
+
+    async def close(self) -> None:
+        """Close the local stream connection."""
+        if self._closed:
+            return
+        self._closed = True
+        self.writer.close()
+        await self.writer.wait_closed()
+
+
+async def open_tapo_local_client(
+    config: TapoLocalTalkConfig,
+    context: TalkBackendContext,
+) -> TapoLocalClient:
+    """Authenticate to the local Tapo stream endpoint and run talk setup."""
+    host = resolve_tapo_host(config, context)
+    port = config.port
+    connect_timeout_s = config.connect_timeout_s or context.source_connect_timeout_s
+    io_timeout_s = config.io_timeout_s or context.source_io_timeout_s
+    if connect_timeout_s <= 0:
+        connect_timeout_s = _DEFAULT_CONNECT_TIMEOUT_S
+    if io_timeout_s <= 0:
+        io_timeout_s = _DEFAULT_IO_TIMEOUT_S
+
+    reader, writer = await asyncio.wait_for(
+        asyncio.open_connection(host, port),
+        timeout=connect_timeout_s,
+    )
+    try:
+        challenge = await _request_digest_challenge(
+            reader,
+            writer,
+            host=host,
+            port=port,
+            io_timeout_s=io_timeout_s,
+        )
+        credential = resolve_tapo_credential(
+            config,
+            context,
+            preferred_hash_kind=challenge.preferred_hash_kind,
+        )
+        response_boundary = await _authenticate_stream(
+            reader,
+            writer,
+            host=host,
+            port=port,
+            credential=credential,
+            challenge=challenge,
+            io_timeout_s=io_timeout_s,
+        )
+        tapo_session_id = await _setup_talk(
+            reader,
+            writer,
+            response_boundary=response_boundary,
+            mode=config.mode,
+            io_timeout_s=io_timeout_s,
+        )
+        return TapoLocalClient(
+            host=host,
+            port=port,
+            io_timeout_s=io_timeout_s,
+            reader=reader,
+            writer=writer,
+            tapo_session_id=tapo_session_id,
+        )
+    except Exception:
+        writer.close()
+        await writer.wait_closed()
+        raise
+
+
+async def _request_digest_challenge(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    host: str,
+    port: int,
+    io_timeout_s: float,
+) -> TapoDigestChallenge:
+    await _write_stream_request(
+        writer,
+        host=host,
+        port=port,
+        headers={},
+        io_timeout_s=io_timeout_s,
+    )
+    response = await _read_http_response(reader, io_timeout_s=io_timeout_s, read_body=True)
+    if response.status_code != 401:
+        raise TapoProtocolError("Tapo local endpoint did not request Digest authentication")
+    authenticate = response.header("www-authenticate")
+    if authenticate is None:
+        raise TapoProtocolError("Tapo local endpoint did not provide Digest authentication")
+    challenge = parse_www_authenticate(authenticate)
+    if challenge.scheme != "digest":
+        raise TapoProtocolError("Tapo local endpoint requires unsupported authentication")
+    return challenge
+
+
+async def _authenticate_stream(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    host: str,
+    port: int,
+    credential: TapoCredential,
+    challenge: TapoDigestChallenge,
+    io_timeout_s: float,
+) -> str:
+    try:
+        authorization = build_digest_authorization_header(
+            challenge=challenge,
+            method="POST",
+            uri=_STREAM_URI,
+            username=credential.username,
+            password_material=credential.password_hash,
+            nonce_count=1,
+            cnonce=secrets.token_hex(8),
+        )
+    except TapoDigestError as exc:
+        raise TapoProtocolError("Tapo local Digest challenge is not supported") from exc
+
+    await _write_stream_request(
+        writer,
+        host=host,
+        port=port,
+        headers={"Authorization": authorization},
+        io_timeout_s=io_timeout_s,
+    )
+    response = await _read_http_response(reader, io_timeout_s=io_timeout_s, read_body=False)
+    if response.status_code == 401:
+        raise TapoAuthError()
+    if response.status_code != 200:
+        raise TapoProtocolError("Tapo local endpoint returned an unexpected HTTP status")
+    boundary = _boundary_from_content_type(response.header("content-type"))
+    if boundary is None:
+        raise TapoProtocolError("Tapo local endpoint did not provide a multipart boundary")
+    return boundary
+
+
+async def _setup_talk(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    response_boundary: str,
+    mode: str,
+    io_timeout_s: float,
+) -> str:
+    body = _talk_setup_body(mode=mode)
+    part = multipart_part(
+        CLIENT_PART_PREFIX,
+        {"Content-Type": "application/json"},
+        body,
+    )
+    writer.write(part)
+    await asyncio.wait_for(writer.drain(), timeout=io_timeout_s)
+
+    response = await read_multipart_part(
+        reader,
+        boundary=response_boundary,
+        max_payload_bytes=_MAX_SETUP_RESPONSE_BYTES,
+        timeout_s=io_timeout_s,
+    )
+    if not _is_json_content_type(response.header("content-type")):
+        raise TapoProtocolError("Tapo local talk setup returned a non-JSON response")
+    try:
+        payload = json.loads(response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise TapoProtocolError("Tapo local talk setup returned malformed JSON") from exc
+    session_id = payload.get("params", {}).get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise TapoProtocolError("Tapo local talk setup did not return a session id")
+    return session_id.strip()
+
+
+async def _write_stream_request(
+    writer: asyncio.StreamWriter,
+    *,
+    host: str,
+    port: int,
+    headers: Mapping[str, str],
+    io_timeout_s: float,
+) -> None:
+    merged: dict[str, str] = {
+        "Host": f"{host}:{port}",
+        "Content-Type": f"multipart/mixed; boundary={CLIENT_BOUNDARY}",
+        "Connection": "keep-alive",
+    }
+    merged.update(headers)
+    lines = [f"POST {_STREAM_URI} HTTP/1.1"]
+    lines.extend(f"{name}: {value}" for name, value in merged.items())
+    writer.write((_CRLF.join(lines) + _CRLF * 2).encode("iso-8859-1"))
+    await asyncio.wait_for(writer.drain(), timeout=io_timeout_s)
+
+
+async def _read_http_response(
+    reader: asyncio.StreamReader,
+    *,
+    io_timeout_s: float,
+    read_body: bool,
+) -> TapoHTTPResponse:
+    head = await asyncio.wait_for(reader.readuntil(_HEADER_SEPARATOR), timeout=io_timeout_s)
+    text = head.decode("iso-8859-1")
+    lines = text.split(_CRLF)
+    if not lines or not lines[0].startswith("HTTP/"):
+        raise TapoProtocolError("Malformed Tapo local HTTP response")
+    parts = lines[0].split(" ", maxsplit=2)
+    if len(parts) < 2:
+        raise TapoProtocolError("Malformed Tapo local HTTP status line")
+    try:
+        status_code = int(parts[1])
+    except ValueError as exc:
+        raise TapoProtocolError("Malformed Tapo local HTTP status line") from exc
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        if not line:
+            continue
+        name, separator, value = line.partition(":")
+        if not separator:
+            raise TapoProtocolError("Malformed Tapo local HTTP header")
+        headers[name.strip().lower()] = value.strip()
+    body = b""
+    if read_body:
+        content_length = _parse_content_length(headers.get("content-length"))
+        if content_length:
+            body = await asyncio.wait_for(reader.readexactly(content_length), timeout=io_timeout_s)
+    return TapoHTTPResponse(
+        status_code=status_code,
+        reason=parts[2].strip() if len(parts) > 2 else "",
+        headers=headers,
+        body=body,
+    )
+
+
+def _talk_setup_body(*, mode: str) -> bytes:
+    return json.dumps(
+        {
+            "params": {"talk": {"mode": mode}, "method": "get"},
+            "seq": 3,
+            "type": "request",
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _boundary_from_content_type(content_type: str | None) -> str | None:
+    if content_type is None:
+        return None
+    for part in content_type.split(";"):
+        name, separator, value = part.strip().partition("=")
+        if separator and name.lower() == "boundary":
+            return value.strip().strip('"')
+    return None
+
+
+def _is_json_content_type(content_type: str | None) -> bool:
+    if content_type is None:
+        return False
+    media_type = content_type.split(";", maxsplit=1)[0].strip().lower()
+    return media_type == "application/json"
+
+
+def _parse_content_length(value: str | None) -> int:
+    if value is None or value.strip() == "":
+        return 0
+    try:
+        content_length = int(value)
+    except ValueError as exc:
+        raise TapoProtocolError("Invalid Tapo local HTTP Content-Length") from exc
+    if content_length < 0:
+        raise TapoProtocolError("Invalid Tapo local HTTP Content-Length")
+    return content_length

--- a/src/homesec/talk/tapo/digest.py
+++ b/src/homesec/talk/tapo/digest.py
@@ -1,0 +1,197 @@
+"""HTTP Digest helpers for the Tapo local talk endpoint."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+
+class TapoDigestError(ValueError):
+    """Raised when a Tapo Digest challenge cannot be parsed or used."""
+
+
+@dataclass(frozen=True, slots=True)
+class TapoDigestChallenge:
+    """Parsed Digest challenge from the Tapo local stream endpoint."""
+
+    scheme: str
+    params: dict[str, str]
+
+    @property
+    def realm(self) -> str | None:
+        """Return the Digest realm."""
+        return self.params.get("realm")
+
+    @property
+    def nonce(self) -> str | None:
+        """Return the Digest nonce."""
+        return self.params.get("nonce")
+
+    @property
+    def encrypt_type(self) -> str | None:
+        """Return the Tapo encryption hint when provided."""
+        return self.params.get("encrypt_type")
+
+    @property
+    def preferred_hash_kind(self) -> Literal["sha256", "md5"]:
+        """Return the preferred credential hash kind for this challenge."""
+        return "sha256" if self.encrypt_type == "3" else "md5"
+
+
+def parse_www_authenticate(header: str) -> TapoDigestChallenge:
+    """Parse a Tapo WWW-Authenticate Digest challenge."""
+    stripped = header.strip()
+    scheme, separator, rest = stripped.partition(" ")
+    if not separator:
+        return TapoDigestChallenge(scheme=stripped.lower(), params={})
+    return TapoDigestChallenge(
+        scheme=scheme.lower(),
+        params=_parse_auth_params(rest),
+    )
+
+
+def parse_digest_authorization(header: str) -> dict[str, str]:
+    """Parse a Digest Authorization header into lower-case keys."""
+    stripped = header.strip()
+    if stripped.lower().startswith("digest "):
+        stripped = stripped.partition(" ")[2]
+    return _parse_auth_params(stripped)
+
+
+def build_digest_authorization_header(
+    *,
+    challenge: TapoDigestChallenge,
+    method: str,
+    uri: str,
+    username: str,
+    password_material: str,
+    nonce_count: int = 1,
+    cnonce: str = "homesec",
+) -> str:
+    """Build a Digest Authorization header for the Tapo local endpoint."""
+    if challenge.scheme != "digest":
+        raise TapoDigestError("Tapo local endpoint requires Digest authentication")
+
+    params = challenge.params
+    realm = params.get("realm")
+    nonce = params.get("nonce")
+    if not realm or not nonce:
+        raise TapoDigestError("Tapo Digest challenge requires realm and nonce")
+
+    algorithm = params.get("algorithm", "MD5")
+    if algorithm.upper() != "MD5":
+        raise TapoDigestError("Tapo Digest challenge uses an unsupported algorithm")
+
+    qop = _select_qop(params.get("qop"))
+    nc_value = f"{nonce_count:08x}"
+    ha1 = _md5_hex(f"{username}:{realm}:{password_material}")
+    ha2 = _md5_hex(f"{method}:{uri}")
+    if qop is None:
+        response = _md5_hex(f"{ha1}:{nonce}:{ha2}")
+    else:
+        response = _md5_hex(f"{ha1}:{nonce}:{nc_value}:{cnonce}:{qop}:{ha2}")
+
+    items: list[tuple[str, str, bool]] = [
+        ("username", username, True),
+        ("realm", realm, True),
+        ("nonce", nonce, True),
+        ("uri", uri, True),
+        ("response", response, True),
+        ("algorithm", algorithm, False),
+    ]
+    opaque = params.get("opaque")
+    if opaque is not None:
+        items.append(("opaque", opaque, True))
+    if qop is not None:
+        items.extend(
+            [
+                ("qop", qop, False),
+                ("nc", nc_value, False),
+                ("cnonce", cnonce, True),
+            ]
+        )
+
+    rendered: list[str] = []
+    for key, value, should_quote in items:
+        if should_quote:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            rendered.append(f'{key}="{escaped}"')
+        else:
+            rendered.append(f"{key}={value}")
+    return "Digest " + ", ".join(rendered)
+
+
+def digest_authorization_matches(
+    *,
+    authorization_header: str | None,
+    challenge: TapoDigestChallenge,
+    method: str,
+    uri: str,
+    username: str,
+    password_material: str,
+) -> bool:
+    """Return whether an Authorization header matches the expected Digest response."""
+    if authorization_header is None or not authorization_header.lower().startswith("digest "):
+        return False
+    actual = parse_digest_authorization(authorization_header)
+    if actual.get("username") != username:
+        return False
+    if actual.get("realm") != challenge.realm or actual.get("nonce") != challenge.nonce:
+        return False
+    if actual.get("uri") != uri:
+        return False
+
+    qop = actual.get("qop")
+    nc = actual.get("nc")
+    cnonce = actual.get("cnonce")
+    if qop:
+        if nc is None or cnonce is None:
+            return False
+        try:
+            nonce_count = int(nc, 16)
+        except ValueError:
+            return False
+        if nonce_count <= 0:
+            return False
+        expected = build_digest_authorization_header(
+            challenge=challenge,
+            method=method,
+            uri=uri,
+            username=username,
+            password_material=password_material,
+            nonce_count=nonce_count,
+            cnonce=cnonce,
+        )
+    else:
+        expected = build_digest_authorization_header(
+            challenge=challenge,
+            method=method,
+            uri=uri,
+            username=username,
+            password_material=password_material,
+        )
+    return actual.get("response") == parse_digest_authorization(expected).get("response")
+
+
+def _parse_auth_params(value: str) -> dict[str, str]:
+    params: dict[str, str] = {}
+    for match in re.finditer(r'(\w+)\s*=\s*("(?:[^"\\]|\\.)*"|[^,]+)', value):
+        key = match.group(1).lower()
+        raw = match.group(2).strip()
+        if raw.startswith('"') and raw.endswith('"'):
+            raw = raw[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+        params[key] = raw
+    return params
+
+
+def _select_qop(qop_value: str | None) -> str | None:
+    if qop_value is None:
+        return None
+    options = [item.strip().lower() for item in qop_value.split(",")]
+    return "auth" if "auth" in options else None
+
+
+def _md5_hex(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8"), usedforsecurity=False).hexdigest()

--- a/src/homesec/talk/tapo/digest.py
+++ b/src/homesec/talk/tapo/digest.py
@@ -146,32 +146,37 @@ def digest_authorization_matches(
     qop = actual.get("qop")
     nc = actual.get("nc")
     cnonce = actual.get("cnonce")
-    if qop:
-        if nc is None or cnonce is None:
-            return False
-        try:
-            nonce_count = int(nc, 16)
-        except ValueError:
-            return False
-        if nonce_count <= 0:
-            return False
-        expected = build_digest_authorization_header(
-            challenge=challenge,
-            method=method,
-            uri=uri,
-            username=username,
-            password_material=password_material,
-            nonce_count=nonce_count,
-            cnonce=cnonce,
-        )
-    else:
-        expected = build_digest_authorization_header(
-            challenge=challenge,
-            method=method,
-            uri=uri,
-            username=username,
-            password_material=password_material,
-        )
+    try:
+        if qop is not None:
+            if qop != "auth":
+                return False
+            if nc is None or cnonce is None:
+                return False
+            try:
+                nonce_count = int(nc, 16)
+            except ValueError:
+                return False
+            if nonce_count <= 0:
+                return False
+            expected = build_digest_authorization_header(
+                challenge=challenge,
+                method=method,
+                uri=uri,
+                username=username,
+                password_material=password_material,
+                nonce_count=nonce_count,
+                cnonce=cnonce,
+            )
+        else:
+            expected = build_digest_authorization_header(
+                challenge=challenge,
+                method=method,
+                uri=uri,
+                username=username,
+                password_material=password_material,
+            )
+    except TapoDigestError:
+        return False
     return actual.get("response") == parse_digest_authorization(expected).get("response")
 
 
@@ -190,7 +195,9 @@ def _select_qop(qop_value: str | None) -> str | None:
     if qop_value is None:
         return None
     options = [item.strip().lower() for item in qop_value.split(",")]
-    return "auth" if "auth" in options else None
+    if "auth" in options:
+        return "auth"
+    raise TapoDigestError("Tapo Digest challenge uses an unsupported qop")
 
 
 def _md5_hex(value: str) -> str:

--- a/src/homesec/talk/tapo/mpegts.py
+++ b/src/homesec/talk/tapo/mpegts.py
@@ -16,6 +16,10 @@ AUDIO_STREAM_ID = 0xC0
 _PROGRAM_NUMBER = 1
 _TRANSPORT_STREAM_ID = 1
 _MAX_TS_PAYLOAD_SIZE = 184
+_PCR_ADAPTATION_BYTES = 8
+_AUDIO_SAMPLE_RATE_HZ = 8_000
+_MPEGTS_CLOCK_HZ = 90_000
+_PTS_MASK = (1 << 33) - 1
 
 
 class TapoMPEGTSError(ValueError):
@@ -28,6 +32,7 @@ class TapoPCMATransportStreamMuxer:
     def __init__(self) -> None:
         self._continuity: dict[int, int] = {}
         self._pts = 0
+        self._pts_remainder = 0
 
     def header(self) -> bytes:
         """Return PAT and PMT packets for the Tapo PCMA stream."""
@@ -41,14 +46,24 @@ class TapoPCMATransportStreamMuxer:
         if not pcma:
             raise TapoMPEGTSError("PCMA payload must not be empty")
         pts = self._pts
-        self._pts = (self._pts + len(pcma)) & ((1 << 33) - 1)
-        return self._pes_packets(AUDIO_PID, _pes_packet(pcma, pts=pts))
+        self._advance_pts(len(pcma))
+        return self._pes_packets(AUDIO_PID, _pes_packet(pcma, pts=pts), pcr_base=pts)
+
+    def _advance_pts(self, sample_count: int) -> None:
+        units = (sample_count * _MPEGTS_CLOCK_HZ) + self._pts_remainder
+        increment, self._pts_remainder = divmod(units, _AUDIO_SAMPLE_RATE_HZ)
+        self._pts = (self._pts + increment) & _PTS_MASK
 
     def _section_packet(self, pid: int, section: bytes) -> bytes:
         return self._packetize_payload(pid, b"\x00" + section, payload_unit_start=True)
 
-    def _pes_packets(self, pid: int, pes: bytes) -> bytes:
-        return self._packetize_payload(pid, pes, payload_unit_start=True)
+    def _pes_packets(self, pid: int, pes: bytes, *, pcr_base: int) -> bytes:
+        return self._packetize_payload(
+            pid,
+            pes,
+            payload_unit_start=True,
+            first_packet_pcr_base=pcr_base,
+        )
 
     def _packetize_payload(
         self,
@@ -56,20 +71,24 @@ class TapoPCMATransportStreamMuxer:
         payload: bytes,
         *,
         payload_unit_start: bool,
+        first_packet_pcr_base: int | None = None,
     ) -> bytes:
         packets: list[bytes] = []
         first = True
         offset = 0
         while offset < len(payload):
+            pcr_base = first_packet_pcr_base if first else None
+            max_payload_size = _max_payload_size(pcr_base=pcr_base)
             remaining = len(payload) - offset
-            if remaining >= _MAX_TS_PAYLOAD_SIZE:
-                chunk = payload[offset : offset + _MAX_TS_PAYLOAD_SIZE]
+            if remaining >= max_payload_size:
+                chunk = payload[offset : offset + max_payload_size]
                 offset += len(chunk)
                 packets.append(
                     self._ts_packet(
                         pid=pid,
                         payload=chunk,
                         payload_unit_start=payload_unit_start and first,
+                        pcr_base=pcr_base,
                     )
                 )
             else:
@@ -80,6 +99,7 @@ class TapoPCMATransportStreamMuxer:
                         pid=pid,
                         payload=chunk,
                         payload_unit_start=payload_unit_start and first,
+                        pcr_base=pcr_base,
                         pad=True,
                     )
                 )
@@ -92,15 +112,17 @@ class TapoPCMATransportStreamMuxer:
         pid: int,
         payload: bytes,
         payload_unit_start: bool,
+        pcr_base: int | None = None,
         pad: bool = False,
     ) -> bytes:
-        if len(payload) > _MAX_TS_PAYLOAD_SIZE:
+        max_payload_size = _max_payload_size(pcr_base=pcr_base)
+        if len(payload) > max_payload_size:
             raise TapoMPEGTSError("TS payload exceeds one packet")
         continuity = self._continuity.get(pid, 0) & 0x0F
         self._continuity[pid] = (continuity + 1) & 0x0F
 
         second = ((0x40 if payload_unit_start else 0x00) | ((pid >> 8) & 0x1F)) & 0xFF
-        if not pad and len(payload) == _MAX_TS_PAYLOAD_SIZE:
+        if pcr_base is None and not pad and len(payload) == _MAX_TS_PAYLOAD_SIZE:
             header = bytes([TS_SYNC_BYTE, second, pid & 0xFF, 0x10 | continuity])
             packet = header + payload
         else:
@@ -109,9 +131,16 @@ class TapoPCMATransportStreamMuxer:
                 raise TapoMPEGTSError("TS payload cannot be padded")
             header = bytes([TS_SYNC_BYTE, second, pid & 0xFF, 0x30 | continuity])
             if adaptation_length == 0:
+                if pcr_base is not None:
+                    raise TapoMPEGTSError("TS packet cannot fit PCR adaptation data")
                 adaptation = b"\x00"
             else:
-                adaptation = bytes([adaptation_length, 0x00]) + (b"\xff" * (adaptation_length - 1))
+                flags = 0x10 if pcr_base is not None else 0x00
+                pcr = _encode_pcr(pcr_base) if pcr_base is not None else b""
+                stuffing_length = adaptation_length - 1 - len(pcr)
+                if stuffing_length < 0:
+                    raise TapoMPEGTSError("TS packet cannot fit PCR adaptation data")
+                adaptation = bytes([adaptation_length, flags]) + pcr + (b"\xff" * stuffing_length)
             packet = header + adaptation + payload
         if len(packet) != TS_PACKET_SIZE:
             raise TapoMPEGTSError("Internal TS packet sizing error")
@@ -163,7 +192,7 @@ def _pes_packet(payload: bytes, *, pts: int) -> bytes:
 
 
 def _encode_pts(pts: int) -> bytes:
-    pts &= (1 << 33) - 1
+    pts &= _PTS_MASK
     return bytes(
         [
             (0x2 << 4) | (((pts >> 30) & 0x07) << 1) | 0x01,
@@ -173,6 +202,17 @@ def _encode_pts(pts: int) -> bytes:
             ((pts & 0x7F) << 1) | 0x01,
         ]
     )
+
+
+def _encode_pcr(pcr_base: int) -> bytes:
+    pcr_base &= _PTS_MASK
+    return ((pcr_base << 15) | (0x3F << 9)).to_bytes(6, "big")
+
+
+def _max_payload_size(*, pcr_base: int | None = None) -> int:
+    if pcr_base is None:
+        return _MAX_TS_PAYLOAD_SIZE
+    return _MAX_TS_PAYLOAD_SIZE - _PCR_ADAPTATION_BYTES
 
 
 def _mpeg2_crc32(data: bytes) -> int:

--- a/src/homesec/talk/tapo/mpegts.py
+++ b/src/homesec/talk/tapo/mpegts.py
@@ -1,0 +1,187 @@
+"""Minimal MPEG-TS muxer for Tapo PCMA talk audio."""
+
+from __future__ import annotations
+
+TS_PACKET_SIZE = 188
+TS_SYNC_BYTE = 0x47
+
+PAT_PID = 0x0000
+PMT_PID = 0x1000
+AUDIO_PID = 0x0100
+
+STREAM_TYPE_PCMA_TAPO = 0x90
+STREAM_TYPE_PCMU_TAPO = 0x91
+AUDIO_STREAM_ID = 0xC0
+
+_PROGRAM_NUMBER = 1
+_TRANSPORT_STREAM_ID = 1
+_MAX_TS_PAYLOAD_SIZE = 184
+
+
+class TapoMPEGTSError(ValueError):
+    """Raised when MPEG-TS packetization input is invalid."""
+
+
+class TapoPCMATransportStreamMuxer:
+    """Build deterministic MPEG-TS packets for Tapo PCMA/8000 audio."""
+
+    def __init__(self) -> None:
+        self._continuity: dict[int, int] = {}
+        self._pts = 0
+
+    def header(self) -> bytes:
+        """Return PAT and PMT packets for the Tapo PCMA stream."""
+        return self._section_packet(PAT_PID, _pat_section()) + self._section_packet(
+            PMT_PID,
+            _pmt_section(stream_type=STREAM_TYPE_PCMA_TAPO),
+        )
+
+    def audio_payload(self, pcma: bytes) -> bytes:
+        """Return MPEG-TS packets containing one PCMA audio payload."""
+        if not pcma:
+            raise TapoMPEGTSError("PCMA payload must not be empty")
+        pts = self._pts
+        self._pts = (self._pts + len(pcma)) & ((1 << 33) - 1)
+        return self._pes_packets(AUDIO_PID, _pes_packet(pcma, pts=pts))
+
+    def _section_packet(self, pid: int, section: bytes) -> bytes:
+        return self._packetize_payload(pid, b"\x00" + section, payload_unit_start=True)
+
+    def _pes_packets(self, pid: int, pes: bytes) -> bytes:
+        return self._packetize_payload(pid, pes, payload_unit_start=True)
+
+    def _packetize_payload(
+        self,
+        pid: int,
+        payload: bytes,
+        *,
+        payload_unit_start: bool,
+    ) -> bytes:
+        packets: list[bytes] = []
+        first = True
+        offset = 0
+        while offset < len(payload):
+            remaining = len(payload) - offset
+            if remaining >= _MAX_TS_PAYLOAD_SIZE:
+                chunk = payload[offset : offset + _MAX_TS_PAYLOAD_SIZE]
+                offset += len(chunk)
+                packets.append(
+                    self._ts_packet(
+                        pid=pid,
+                        payload=chunk,
+                        payload_unit_start=payload_unit_start and first,
+                    )
+                )
+            else:
+                chunk = payload[offset:]
+                offset = len(payload)
+                packets.append(
+                    self._ts_packet(
+                        pid=pid,
+                        payload=chunk,
+                        payload_unit_start=payload_unit_start and first,
+                        pad=True,
+                    )
+                )
+            first = False
+        return b"".join(packets)
+
+    def _ts_packet(
+        self,
+        *,
+        pid: int,
+        payload: bytes,
+        payload_unit_start: bool,
+        pad: bool = False,
+    ) -> bytes:
+        if len(payload) > _MAX_TS_PAYLOAD_SIZE:
+            raise TapoMPEGTSError("TS payload exceeds one packet")
+        continuity = self._continuity.get(pid, 0) & 0x0F
+        self._continuity[pid] = (continuity + 1) & 0x0F
+
+        second = ((0x40 if payload_unit_start else 0x00) | ((pid >> 8) & 0x1F)) & 0xFF
+        if not pad and len(payload) == _MAX_TS_PAYLOAD_SIZE:
+            header = bytes([TS_SYNC_BYTE, second, pid & 0xFF, 0x10 | continuity])
+            packet = header + payload
+        else:
+            adaptation_length = _MAX_TS_PAYLOAD_SIZE - 1 - len(payload)
+            if adaptation_length < 0:
+                raise TapoMPEGTSError("TS payload cannot be padded")
+            header = bytes([TS_SYNC_BYTE, second, pid & 0xFF, 0x30 | continuity])
+            if adaptation_length == 0:
+                adaptation = b"\x00"
+            else:
+                adaptation = bytes([adaptation_length, 0x00]) + (b"\xff" * (adaptation_length - 1))
+            packet = header + adaptation + payload
+        if len(packet) != TS_PACKET_SIZE:
+            raise TapoMPEGTSError("Internal TS packet sizing error")
+        return packet
+
+
+def _pat_section() -> bytes:
+    body = (
+        _TRANSPORT_STREAM_ID.to_bytes(2, "big")
+        + b"\xc1\x00\x00"
+        + _PROGRAM_NUMBER.to_bytes(2, "big")
+        + bytes([0xE0 | ((PMT_PID >> 8) & 0x1F), PMT_PID & 0xFF])
+    )
+    section = _section_header(table_id=0x00, body=body)
+    return section + _mpeg2_crc32(section).to_bytes(4, "big")
+
+
+def _pmt_section(*, stream_type: int) -> bytes:
+    body = (
+        _PROGRAM_NUMBER.to_bytes(2, "big")
+        + b"\xc1\x00\x00"
+        + bytes([0xE0 | ((AUDIO_PID >> 8) & 0x1F), AUDIO_PID & 0xFF])
+        + b"\xf0\x00"
+        + bytes([stream_type, 0xE0 | ((AUDIO_PID >> 8) & 0x1F), AUDIO_PID & 0xFF])
+        + b"\xf0\x00"
+    )
+    section = _section_header(table_id=0x02, body=body)
+    return section + _mpeg2_crc32(section).to_bytes(4, "big")
+
+
+def _section_header(*, table_id: int, body: bytes) -> bytes:
+    section_length = len(body) + 4
+    return bytes([table_id, 0xB0 | ((section_length >> 8) & 0x0F), section_length & 0xFF]) + body
+
+
+def _pes_packet(payload: bytes, *, pts: int) -> bytes:
+    header_data = _encode_pts(pts)
+    pes_header = bytes([0x80, 0x80, len(header_data)]) + header_data
+    packet_length = len(pes_header) + len(payload)
+    if packet_length > 0xFFFF:
+        packet_length = 0
+    return (
+        b"\x00\x00\x01"
+        + bytes([AUDIO_STREAM_ID])
+        + packet_length.to_bytes(2, "big")
+        + pes_header
+        + payload
+    )
+
+
+def _encode_pts(pts: int) -> bytes:
+    pts &= (1 << 33) - 1
+    return bytes(
+        [
+            (0x2 << 4) | (((pts >> 30) & 0x07) << 1) | 0x01,
+            (pts >> 22) & 0xFF,
+            (((pts >> 15) & 0x7F) << 1) | 0x01,
+            (pts >> 7) & 0xFF,
+            ((pts & 0x7F) << 1) | 0x01,
+        ]
+    )
+
+
+def _mpeg2_crc32(data: bytes) -> int:
+    crc = 0xFFFFFFFF
+    for byte in data:
+        crc ^= byte << 24
+        for _ in range(8):
+            if crc & 0x80000000:
+                crc = ((crc << 1) ^ 0x04C11DB7) & 0xFFFFFFFF
+            else:
+                crc = (crc << 1) & 0xFFFFFFFF
+    return crc

--- a/src/homesec/talk/tapo/multipart.py
+++ b/src/homesec/talk/tapo/multipart.py
@@ -12,6 +12,9 @@ DEVICE_BOUNDARY = "--device-stream-boundary--"
 DEVICE_PART_PREFIX = "--" + DEVICE_BOUNDARY
 
 _CRLF = b"\r\n"
+_MAX_PREAMBLE_BYTES = 8 * 1024
+_MAX_HEADER_BYTES = 16 * 1024
+_MAX_HEADER_LINE_BYTES = 4 * 1024
 
 
 class TapoMultipartError(RuntimeError):
@@ -54,11 +57,34 @@ async def read_multipart_part(
     """Read one Content-Length bounded multipart part."""
     if max_payload_bytes < 0:
         raise ValueError("max_payload_bytes must be non-negative")
+    try:
+        async with asyncio.timeout(timeout_s):
+            return await _read_multipart_part(
+                reader,
+                boundary=boundary,
+                max_payload_bytes=max_payload_bytes,
+            )
+    except TimeoutError as exc:
+        raise TapoMultipartError("Tapo multipart read timed out") from exc
+
+
+async def _read_multipart_part(
+    reader: asyncio.StreamReader,
+    *,
+    boundary: str,
+    max_payload_bytes: int,
+) -> TapoMultipartPart:
+    """Read one multipart part under the caller's total timeout."""
     delimiter = ("--" + boundary).encode("ascii")
     closing_delimiter = delimiter + b"--"
 
+    preamble_bytes = 0
     while True:
-        line = await _readline(reader, timeout_s=timeout_s)
+        line = await _readline(reader)
+        _validate_line_size(line)
+        preamble_bytes += len(line)
+        if preamble_bytes > _MAX_PREAMBLE_BYTES:
+            raise TapoMultipartError("Tapo multipart preamble exceeds configured limit")
         stripped = line.rstrip(b"\r\n")
         if stripped == delimiter:
             break
@@ -68,8 +94,13 @@ async def read_multipart_part(
             continue
 
     headers: dict[str, str] = {}
+    header_bytes = 0
     while True:
-        line = await _readline(reader, timeout_s=timeout_s)
+        line = await _readline(reader)
+        _validate_line_size(line)
+        header_bytes += len(line)
+        if header_bytes > _MAX_HEADER_BYTES:
+            raise TapoMultipartError("Tapo multipart headers exceed configured limit")
         if line in {b"\r\n", b"\n", b""}:
             break
         name, separator, value = line.decode("iso-8859-1").partition(":")
@@ -89,15 +120,23 @@ async def read_multipart_part(
     if content_length > max_payload_bytes:
         raise TapoMultipartError("Tapo multipart payload exceeds configured limit")
 
-    body = await asyncio.wait_for(reader.readexactly(content_length), timeout=timeout_s)
+    try:
+        body = await reader.readexactly(content_length)
+    except asyncio.IncompleteReadError as exc:
+        raise TapoMultipartError("Tapo multipart stream ended unexpectedly") from exc
     return TapoMultipartPart(headers=headers, body=body)
 
 
-async def _readline(reader: asyncio.StreamReader, *, timeout_s: float) -> bytes:
+async def _readline(reader: asyncio.StreamReader) -> bytes:
     try:
-        line = await asyncio.wait_for(reader.readline(), timeout=timeout_s)
-    except asyncio.IncompleteReadError as exc:
+        line = await reader.readline()
+    except (asyncio.IncompleteReadError, asyncio.LimitOverrunError) as exc:
         raise TapoMultipartError("Tapo multipart stream ended unexpectedly") from exc
     if line == b"":
         raise TapoMultipartError("Tapo multipart stream ended unexpectedly")
     return line
+
+
+def _validate_line_size(line: bytes) -> None:
+    if len(line) > _MAX_HEADER_LINE_BYTES:
+        raise TapoMultipartError("Tapo multipart line exceeds configured limit")

--- a/src/homesec/talk/tapo/multipart.py
+++ b/src/homesec/talk/tapo/multipart.py
@@ -1,0 +1,103 @@
+"""Small multipart helpers for the Tapo local stream endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+CLIENT_BOUNDARY = "--client-stream-boundary--"
+CLIENT_PART_PREFIX = "--" + CLIENT_BOUNDARY
+DEVICE_BOUNDARY = "--device-stream-boundary--"
+DEVICE_PART_PREFIX = "--" + DEVICE_BOUNDARY
+
+_CRLF = b"\r\n"
+
+
+class TapoMultipartError(RuntimeError):
+    """Raised for malformed Tapo multipart data."""
+
+
+@dataclass(frozen=True, slots=True)
+class TapoMultipartPart:
+    """One parsed multipart part."""
+
+    headers: dict[str, str] = field(default_factory=dict)
+    body: bytes = b""
+
+    def header(self, name: str) -> str | None:
+        """Return a case-insensitive header."""
+        return self.headers.get(name.lower())
+
+
+def multipart_part(
+    boundary_prefix: str,
+    headers: Mapping[str, str],
+    body: bytes,
+) -> bytes:
+    """Render one multipart part with CRLF line endings."""
+    rendered_headers = dict(headers)
+    rendered_headers.setdefault("Content-Length", str(len(body)))
+    lines = [boundary_prefix]
+    lines.extend(f"{name}: {value}" for name, value in rendered_headers.items())
+    head = "\r\n".join(lines).encode("iso-8859-1") + _CRLF * 2
+    return head + body + _CRLF
+
+
+async def read_multipart_part(
+    reader: asyncio.StreamReader,
+    *,
+    boundary: str,
+    max_payload_bytes: int,
+    timeout_s: float,
+) -> TapoMultipartPart:
+    """Read one Content-Length bounded multipart part."""
+    if max_payload_bytes < 0:
+        raise ValueError("max_payload_bytes must be non-negative")
+    delimiter = ("--" + boundary).encode("ascii")
+    closing_delimiter = delimiter + b"--"
+
+    while True:
+        line = await _readline(reader, timeout_s=timeout_s)
+        stripped = line.rstrip(b"\r\n")
+        if stripped == delimiter:
+            break
+        if stripped == closing_delimiter:
+            raise TapoMultipartError("Tapo multipart stream ended before next part")
+        if stripped:
+            continue
+
+    headers: dict[str, str] = {}
+    while True:
+        line = await _readline(reader, timeout_s=timeout_s)
+        if line in {b"\r\n", b"\n", b""}:
+            break
+        name, separator, value = line.decode("iso-8859-1").partition(":")
+        if not separator:
+            raise TapoMultipartError("Invalid Tapo multipart header")
+        headers[name.strip().lower()] = value.strip()
+
+    raw_content_length = headers.get("content-length")
+    if raw_content_length is None:
+        raise TapoMultipartError("Tapo multipart part missing Content-Length")
+    try:
+        content_length = int(raw_content_length)
+    except ValueError as exc:
+        raise TapoMultipartError("Invalid Tapo multipart Content-Length") from exc
+    if content_length < 0:
+        raise TapoMultipartError("Invalid Tapo multipart Content-Length")
+    if content_length > max_payload_bytes:
+        raise TapoMultipartError("Tapo multipart payload exceeds configured limit")
+
+    body = await asyncio.wait_for(reader.readexactly(content_length), timeout=timeout_s)
+    return TapoMultipartPart(headers=headers, body=body)
+
+
+async def _readline(reader: asyncio.StreamReader, *, timeout_s: float) -> bytes:
+    try:
+        line = await asyncio.wait_for(reader.readline(), timeout=timeout_s)
+    except asyncio.IncompleteReadError as exc:
+        raise TapoMultipartError("Tapo multipart stream ended unexpectedly") from exc
+    if line == b"":
+        raise TapoMultipartError("Tapo multipart stream ended unexpectedly")
+    return line

--- a/tests/homesec/talk/tapo/__init__.py
+++ b/tests/homesec/talk/tapo/__init__.py
@@ -1,0 +1,1 @@
+"""Tapo talk backend tests."""

--- a/tests/homesec/talk/tapo/fake_server.py
+++ b/tests/homesec/talk/tapo/fake_server.py
@@ -1,0 +1,223 @@
+"""Fake Tapo local stream endpoint for protocol tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Literal
+
+from homesec.talk.tapo.digest import (
+    TapoDigestChallenge,
+    digest_authorization_matches,
+    parse_www_authenticate,
+)
+from homesec.talk.tapo.multipart import (
+    CLIENT_BOUNDARY,
+    DEVICE_BOUNDARY,
+    DEVICE_PART_PREFIX,
+    TapoMultipartPart,
+    multipart_part,
+    read_multipart_part,
+)
+
+_HEADER_SEPARATOR = b"\r\n\r\n"
+
+
+@dataclass(frozen=True, slots=True)
+class FakeTapoHTTPRequest:
+    """HTTP request captured by the fake Tapo endpoint."""
+
+    method: str
+    uri: str
+    headers: dict[str, str]
+
+
+@dataclass(slots=True)
+class FakeTapoServer:
+    """Minimal local Tapo endpoint with Digest auth and multipart talk setup."""
+
+    hash_kind: Literal["sha256", "md5"] = "sha256"
+    username: str = "admin"
+    credential_hash: str = "A" * 64
+    session_id: str = "tapo-session-1"
+    reject_auth: bool = False
+    omit_session_id: bool = False
+    malformed_setup_json: bool = False
+    setup_content_type: str = "application/json"
+    challenge_qop: str | None = "auth"
+    requests: list[FakeTapoHTTPRequest] = field(default_factory=list)
+    setup_parts: list[TapoMultipartPart] = field(default_factory=list)
+    audio_parts: list[TapoMultipartPart] = field(default_factory=list)
+    closed_connections: int = 0
+    _server: asyncio.AbstractServer | None = field(default=None, init=False, repr=False)
+    _port: int | None = field(default=None, init=False, repr=False)
+    _tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
+
+    @property
+    def host(self) -> str:
+        """Return the bound host."""
+        return "127.0.0.1"
+
+    @property
+    def port(self) -> int:
+        """Return the bound port."""
+        if self._port is None:
+            raise RuntimeError("fake Tapo server is not started")
+        return self._port
+
+    async def start(self) -> None:
+        """Start the fake endpoint."""
+        self._server = await asyncio.start_server(self._handle_client, self.host, 0)
+        sockets = self._server.sockets or ()
+        if not sockets:
+            raise RuntimeError("fake Tapo server did not bind a socket")
+        self._port = int(sockets[0].getsockname()[1])
+
+    async def stop(self) -> None:
+        """Stop the fake endpoint and wait for client handlers."""
+        server = self._server
+        self._server = None
+        self._port = None
+        if server is not None:
+            server.close()
+            await server.wait_closed()
+        tasks = list(self._tasks)
+        if tasks:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._tasks.add(task)
+        try:
+            request = await self._read_request(reader)
+            if not self._authorization_matches(request):
+                writer.write(
+                    _http_response(
+                        status=401,
+                        reason="Unauthorized",
+                        headers={"WWW-Authenticate": self._challenge_header()},
+                    )
+                )
+                await writer.drain()
+
+            request = await self._read_request(reader)
+            if not self._authorization_matches(request) or self.reject_auth:
+                writer.write(
+                    _http_response(
+                        status=401,
+                        reason="Unauthorized",
+                        headers={"WWW-Authenticate": self._challenge_header()},
+                    )
+                )
+                await writer.drain()
+                return
+
+            writer.write(
+                _http_response(
+                    status=200,
+                    headers={"Content-Type": f"multipart/mixed; boundary={DEVICE_BOUNDARY}"},
+                )
+            )
+            await writer.drain()
+
+            setup = await read_multipart_part(
+                reader,
+                boundary=CLIENT_BOUNDARY,
+                max_payload_bytes=64 * 1024,
+                timeout_s=2.0,
+            )
+            self.setup_parts.append(setup)
+            writer.write(self._setup_response_part())
+            await writer.drain()
+
+            while True:
+                try:
+                    part = await read_multipart_part(
+                        reader,
+                        boundary=CLIENT_BOUNDARY,
+                        max_payload_bytes=1024 * 1024,
+                        timeout_s=0.5,
+                    )
+                except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+                    break
+                except Exception:
+                    break
+                if part.header("content-type") == "audio/mp2t":
+                    self.audio_parts.append(part)
+        except (asyncio.IncompleteReadError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            self.closed_connections += 1
+            if task is not None:
+                self._tasks.discard(task)
+
+    async def _read_request(self, reader: asyncio.StreamReader) -> FakeTapoHTTPRequest:
+        head = await reader.readuntil(_HEADER_SEPARATOR)
+        lines = head.decode("iso-8859-1").split("\r\n")
+        method, uri, _version = lines[0].split(" ", maxsplit=2)
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            name, separator, value = line.partition(":")
+            if separator:
+                headers[name.strip().lower()] = value.strip()
+        request = FakeTapoHTTPRequest(method=method, uri=uri, headers=headers)
+        self.requests.append(request)
+        return request
+
+    def _authorization_matches(self, request: FakeTapoHTTPRequest) -> bool:
+        return digest_authorization_matches(
+            authorization_header=request.headers.get("authorization"),
+            challenge=self._challenge(),
+            method=request.method,
+            uri=request.uri,
+            username=self.username,
+            password_material=self.credential_hash,
+        )
+
+    def _challenge_header(self) -> str:
+        parts = ['Digest realm="tapo"', 'nonce="fake-nonce"']
+        if self.challenge_qop is not None:
+            parts.append(f'qop="{self.challenge_qop}"')
+        if self.hash_kind == "sha256":
+            parts.append('encrypt_type="3"')
+        return ", ".join(parts)
+
+    def _challenge(self) -> TapoDigestChallenge:
+        return parse_www_authenticate(self._challenge_header())
+
+    def _setup_response_part(self) -> bytes:
+        if self.malformed_setup_json:
+            body = b"{"
+        elif self.omit_session_id:
+            body = b'{"params":{}}'
+        else:
+            body = f'{{"params":{{"session_id":"{self.session_id}"}}}}'.encode()
+        return multipart_part(
+            DEVICE_PART_PREFIX,
+            {"Content-Type": self.setup_content_type},
+            body,
+        )
+
+
+def _http_response(
+    *,
+    status: int,
+    reason: str = "OK",
+    headers: dict[str, str] | None = None,
+    body: bytes = b"",
+) -> bytes:
+    merged = {"Content-Length": str(len(body))}
+    if headers:
+        merged.update(headers)
+    lines = [f"HTTP/1.1 {status} {reason}"]
+    lines.extend(f"{name}: {value}" for name, value in merged.items())
+    return ("\r\n".join(lines) + "\r\n\r\n").encode("iso-8859-1") + body

--- a/tests/homesec/talk/tapo/fake_server.py
+++ b/tests/homesec/talk/tapo/fake_server.py
@@ -11,16 +11,13 @@ from homesec.talk.tapo.digest import (
     digest_authorization_matches,
     parse_www_authenticate,
 )
-from homesec.talk.tapo.multipart import (
-    CLIENT_BOUNDARY,
-    DEVICE_BOUNDARY,
-    DEVICE_PART_PREFIX,
-    TapoMultipartPart,
-    multipart_part,
-    read_multipart_part,
-)
+from homesec.talk.tapo.multipart import TapoMultipartPart
 
 _HEADER_SEPARATOR = b"\r\n\r\n"
+_CLIENT_BOUNDARY = "--client-stream-boundary--"
+_CLIENT_DELIMITER = b"----client-stream-boundary--"
+_DEVICE_BOUNDARY = "--device-stream-boundary--"
+_DEVICE_DELIMITER = "----device-stream-boundary--"
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,28 +119,21 @@ class FakeTapoServer:
             writer.write(
                 _http_response(
                     status=200,
-                    headers={"Content-Type": f"multipart/mixed; boundary={DEVICE_BOUNDARY}"},
+                    headers={"Content-Type": f"multipart/mixed; boundary={_DEVICE_BOUNDARY}"},
                 )
             )
             await writer.drain()
 
-            setup = await read_multipart_part(
-                reader,
-                boundary=CLIENT_BOUNDARY,
-                max_payload_bytes=64 * 1024,
-                timeout_s=2.0,
-            )
+            setup = await _read_client_part(reader, max_payload_bytes=64 * 1024)
             self.setup_parts.append(setup)
             writer.write(self._setup_response_part())
             await writer.drain()
 
             while True:
                 try:
-                    part = await read_multipart_part(
-                        reader,
-                        boundary=CLIENT_BOUNDARY,
-                        max_payload_bytes=1024 * 1024,
-                        timeout_s=0.5,
+                    part = await asyncio.wait_for(
+                        _read_client_part(reader, max_payload_bytes=1024 * 1024),
+                        timeout=0.5,
                     )
                 except (asyncio.TimeoutError, asyncio.IncompleteReadError):
                     break
@@ -202,10 +192,53 @@ class FakeTapoServer:
         else:
             body = f'{{"params":{{"session_id":"{self.session_id}"}}}}'.encode()
         return multipart_part(
-            DEVICE_PART_PREFIX,
+            _DEVICE_DELIMITER,
             {"Content-Type": self.setup_content_type},
             body,
         )
+
+
+async def _read_client_part(
+    reader: asyncio.StreamReader,
+    *,
+    max_payload_bytes: int,
+) -> TapoMultipartPart:
+    while True:
+        line = await reader.readline()
+        if line == b"":
+            raise asyncio.IncompleteReadError(line, None)
+        if line.rstrip(b"\r\n") == _CLIENT_DELIMITER:
+            break
+
+    headers: dict[str, str] = {}
+    while True:
+        line = await reader.readline()
+        if line in {b"\r\n", b"\n", b""}:
+            break
+        name, separator, value = line.decode("iso-8859-1").partition(":")
+        if separator:
+            headers[name.strip().lower()] = value.strip()
+
+    content_length = int(headers["content-length"])
+    if content_length > max_payload_bytes:
+        raise ValueError("fake Tapo client part exceeds limit")
+    body = await reader.readexactly(content_length)
+    trailer = await reader.readexactly(2)
+    if trailer != b"\r\n":
+        raise ValueError("fake Tapo client part missing trailing CRLF")
+    return TapoMultipartPart(headers=headers, body=body)
+
+
+def multipart_part(
+    boundary_prefix: str,
+    headers: dict[str, str],
+    body: bytes,
+) -> bytes:
+    rendered_headers = dict(headers)
+    rendered_headers.setdefault("Content-Length", str(len(body)))
+    lines = [boundary_prefix]
+    lines.extend(f"{name}: {value}" for name, value in rendered_headers.items())
+    return ("\r\n".join(lines) + "\r\n\r\n").encode("iso-8859-1") + body + b"\r\n"
 
 
 def _http_response(

--- a/tests/homesec/talk/tapo/test_client.py
+++ b/tests/homesec/talk/tapo/test_client.py
@@ -1,0 +1,270 @@
+"""Tests for the Tapo local protocol client."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from homesec.models.config import CameraTalkConfig, TalkConfig
+from homesec.talk.backends import TalkBackendConfigError, TalkBackendContext
+from homesec.talk.tapo.client import (
+    TapoAuthError,
+    TapoProtocolError,
+    _read_http_response,
+    open_tapo_local_client,
+)
+from homesec.talk.tapo.config import TapoLocalTalkConfig
+from homesec.talk.tapo.multipart import (
+    CLIENT_PART_PREFIX,
+    TapoMultipartError,
+    multipart_part,
+    read_multipart_part,
+)
+
+from .fake_server import FakeTapoServer
+
+_SHA256 = "A" * 64
+_MD5 = "B" * 32
+
+
+def _context(env: dict[str, str]) -> TalkBackendContext:
+    return TalkBackendContext(
+        camera_name="office",
+        source_backend="rtsp",
+        runtime_talk=TalkConfig(),
+        camera_talk=CameraTalkConfig(backend="tapo_local"),
+        resolve_env=lambda name: env.get(name),
+    )
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_authenticates_sha256_mode_and_parses_session_id() -> None:
+    """Tapo client should authenticate SHA256 Digest mode and parse talk setup."""
+    # Given: A fake Tapo endpoint requiring SHA256 password material
+    server = FakeTapoServer(hash_kind="sha256", credential_hash=_SHA256)
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        )
+
+        # When: Opening the local Tapo client
+        client = await open_tapo_local_client(
+            config,
+            _context({"OFFICE_TAPO_SHA256": _SHA256.lower()}),
+        )
+        await client.close()
+
+        # Then: The client authenticated, sent setup JSON, and captured session_id
+        assert client.tapo_session_id == server.session_id
+        assert len(server.requests) == 2
+        assert server.requests[1].headers["authorization"].startswith("Digest ")
+        setup = json.loads(server.setup_parts[0].body.decode("utf-8"))
+        assert setup == {
+            "params": {"talk": {"mode": "aec"}, "method": "get"},
+            "seq": 3,
+            "type": "request",
+        }
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_accepts_json_setup_response_with_charset() -> None:
+    """Tapo client should accept JSON setup parts with content-type parameters."""
+    # Given: A fake Tapo endpoint that includes a charset on setup JSON
+    server = FakeTapoServer(
+        hash_kind="sha256",
+        credential_hash=_SHA256,
+        setup_content_type="application/json; charset=utf-8",
+    )
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        )
+
+        # When: Opening the local Tapo client
+        client = await open_tapo_local_client(config, _context({"OFFICE_TAPO_SHA256": _SHA256}))
+        await client.close()
+
+        # Then: The setup response is parsed as JSON and returns the Tapo session id
+        assert client.tapo_session_id == server.session_id
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_authenticates_md5_mode() -> None:
+    """Tapo client should authenticate legacy MD5 Digest mode when hinted."""
+    # Given: A fake Tapo endpoint without encrypt_type=3
+    server = FakeTapoServer(hash_kind="md5", credential_hash=_MD5)
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_md5_env="OFFICE_TAPO_MD5",
+        )
+
+        # When: Opening the local Tapo client
+        client = await open_tapo_local_client(config, _context({"OFFICE_TAPO_MD5": _MD5}))
+        await client.close()
+
+        # Then: The session setup succeeds through MD5 credential material
+        assert client.tapo_session_id == server.session_id
+        assert len(server.setup_parts) == 1
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_missing_hash_env_maps_to_config_error() -> None:
+    """Missing Tapo credential env vars should fail as structured config errors."""
+    # Given: A fake Tapo endpoint and config pointing at an unset env var
+    server = FakeTapoServer(hash_kind="sha256", credential_hash=_SHA256)
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="TAPO_PASSWORD_SHA256",
+        )
+
+        # When: Opening the local Tapo client
+        # Then: The error names the missing env var without exposing secret material
+        with pytest.raises(TalkBackendConfigError) as exc_info:
+            await open_tapo_local_client(config, _context({}))
+        assert exc_info.value.public_message == (
+            "Required Tapo local environment variable is not set: TAPO_PASSWORD_SHA256"
+        )
+        assert _SHA256 not in exc_info.value.public_message
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_wrong_hash_maps_to_auth_error_without_hash_value() -> None:
+    """Rejected Digest credentials should map to a generic auth error."""
+    # Given: A fake Tapo endpoint and a wrong configured hash
+    server = FakeTapoServer(hash_kind="sha256", credential_hash=_SHA256)
+    await server.start()
+    try:
+        wrong_hash = "C" * 64
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        )
+
+        # When: Opening the local Tapo client
+        # Then: Authentication fails without exposing the hash value
+        with pytest.raises(TapoAuthError) as exc_info:
+            await open_tapo_local_client(config, _context({"OFFICE_TAPO_SHA256": wrong_hash}))
+        assert str(exc_info.value) == "Tapo local authentication failed"
+        assert wrong_hash not in str(exc_info.value)
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_rejects_missing_setup_session_id() -> None:
+    """Tapo talk setup should require a non-empty session id."""
+    # Given: A fake Tapo endpoint whose setup response omits session_id
+    server = FakeTapoServer(
+        hash_kind="sha256",
+        credential_hash=_SHA256,
+        omit_session_id=True,
+    )
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        )
+
+        # When: Opening the local Tapo client
+        # Then: The malformed setup response is rejected safely
+        with pytest.raises(TapoProtocolError, match="session id"):
+            await open_tapo_local_client(config, _context({"OFFICE_TAPO_SHA256": _SHA256}))
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_writes_audio_mp2t_multipart_chunk() -> None:
+    """Tapo client should write audio/mp2t chunks with the negotiated session id."""
+    # Given: An authenticated Tapo client and fake endpoint
+    server = FakeTapoServer(hash_kind="sha256", credential_hash=_SHA256)
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        )
+        client = await open_tapo_local_client(config, _context({"OFFICE_TAPO_SHA256": _SHA256}))
+
+        # When: Writing one MPEG-TS audio payload
+        await client.write_audio_mp2t(b"G" * 188)
+        await _wait_for_audio_part(server)
+        await client.close()
+
+        # Then: The fake endpoint receives the expected Tapo audio multipart headers
+        part = server.audio_parts[0]
+        assert part.header("content-type") == "audio/mp2t"
+        assert part.header("x-if-encrypt") == "0"
+        assert part.header("x-session-id") == server.session_id
+        assert part.body == b"G" * 188
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_multipart_parser_rejects_oversized_payload() -> None:
+    """Multipart parser should reject parts over the configured payload limit."""
+    # Given: A multipart part whose content length exceeds the caller limit
+    reader = asyncio.StreamReader()
+    reader.feed_data(
+        multipart_part(
+            CLIENT_PART_PREFIX,
+            {"Content-Type": "application/json"},
+            b"{}",
+        )
+    )
+
+    # When/Then: Reading with a smaller limit fails before accepting the payload
+    with pytest.raises(TapoMultipartError, match="exceeds"):
+        await read_multipart_part(
+            reader,
+            boundary="--client-stream-boundary--",
+            max_payload_bytes=1,
+            timeout_s=1.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_http_response_parser_rejects_malformed_response() -> None:
+    """HTTP response parser should reject malformed status lines safely."""
+    # Given: A stream containing invalid HTTP response bytes
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"not-http\r\n\r\n")
+
+    # When/Then: Parsing the response fails with a safe protocol error
+    with pytest.raises(TapoProtocolError, match="Malformed"):
+        await _read_http_response(reader, io_timeout_s=1.0, read_body=True)
+
+
+async def _wait_for_audio_part(server: FakeTapoServer) -> None:
+    for _ in range(20):
+        if server.audio_parts:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("fake Tapo server did not receive an audio part")

--- a/tests/homesec/talk/tapo/test_client.py
+++ b/tests/homesec/talk/tapo/test_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import cast
 
 import pytest
 
@@ -11,6 +12,7 @@ from homesec.models.config import CameraTalkConfig, TalkConfig
 from homesec.talk.backends import TalkBackendConfigError, TalkBackendContext
 from homesec.talk.tapo.client import (
     TapoAuthError,
+    TapoLocalClient,
     TapoProtocolError,
     _read_http_response,
     open_tapo_local_client,
@@ -61,6 +63,7 @@ async def test_tapo_client_authenticates_sha256_mode_and_parses_session_id() -> 
 
         # Then: The client authenticated, sent setup JSON, and captured session_id
         assert client.tapo_session_id == server.session_id
+        assert server.session_id not in repr(client)
         assert len(server.requests) == 2
         assert server.requests[1].headers["authorization"].startswith("Digest ")
         setup = json.loads(server.setup_parts[0].body.decode("utf-8"))
@@ -69,6 +72,31 @@ async def test_tapo_client_authenticates_sha256_mode_and_parses_session_id() -> 
             "seq": 3,
             "type": "request",
         }
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_tapo_client_rejects_unsupported_digest_qop() -> None:
+    """Tapo client should fail closed when Digest qop=auth is unavailable."""
+    # Given: A fake endpoint that only advertises an unsupported qop
+    server = FakeTapoServer(
+        hash_kind="sha256",
+        credential_hash=_SHA256,
+        challenge_qop="auth-int",
+    )
+    await server.start()
+    try:
+        config = TapoLocalTalkConfig(
+            host=server.host,
+            port=server.port,
+            password_sha256_env="OFFICE_TAPO_SHA256",
+        )
+
+        # When/Then: Opening fails without sending a legacy no-qop Digest response
+        with pytest.raises(TapoProtocolError, match="Digest challenge"):
+            await open_tapo_local_client(config, _context({"OFFICE_TAPO_SHA256": _SHA256}))
+        assert len(server.requests) == 1
     finally:
         await server.stop()
 
@@ -228,6 +256,30 @@ async def test_tapo_client_writes_audio_mp2t_multipart_chunk() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tapo_client_closes_after_audio_write_failure() -> None:
+    """Audio write failures should close the client stream before surfacing."""
+    # Given: A connected client whose writer fails during drain
+    writer = _FailingDrainWriter()
+    client = TapoLocalClient(
+        host="127.0.0.1",
+        port=8800,
+        io_timeout_s=1.0,
+        reader=asyncio.StreamReader(),
+        writer=cast(asyncio.StreamWriter, writer),
+        tapo_session_id="session-token",
+    )
+
+    # When: Writing an audio chunk fails
+    # Then: The stream is closed and future writes fail as closed-client errors
+    with pytest.raises(ConnectionResetError):
+        await client.write_audio_mp2t(b"G" * 188)
+    assert writer.closed is True
+    assert writer.wait_closed_called is True
+    with pytest.raises(TapoProtocolError, match="closed"):
+        await client.write_audio_mp2t(b"G" * 188)
+
+
+@pytest.mark.asyncio
 async def test_multipart_parser_rejects_oversized_payload() -> None:
     """Multipart parser should reject parts over the configured payload limit."""
     # Given: A multipart part whose content length exceeds the caller limit
@@ -251,6 +303,23 @@ async def test_multipart_parser_rejects_oversized_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_multipart_parser_rejects_oversized_preamble() -> None:
+    """Multipart parser should bound preamble/header scanning before payload reads."""
+    # Given: A stream that keeps sending non-boundary preamble lines
+    reader = asyncio.StreamReader()
+    reader.feed_data((b"x" * 1024 + b"\r\n") * 9)
+
+    # When/Then: Reading a part fails once the preamble exceeds the configured limit
+    with pytest.raises(TapoMultipartError, match="preamble"):
+        await read_multipart_part(
+            reader,
+            boundary="--client-stream-boundary--",
+            max_payload_bytes=64 * 1024,
+            timeout_s=1.0,
+        )
+
+
+@pytest.mark.asyncio
 async def test_http_response_parser_rejects_malformed_response() -> None:
     """HTTP response parser should reject malformed status lines safely."""
     # Given: A stream containing invalid HTTP response bytes
@@ -262,9 +331,40 @@ async def test_http_response_parser_rejects_malformed_response() -> None:
         await _read_http_response(reader, io_timeout_s=1.0, read_body=True)
 
 
+@pytest.mark.asyncio
+async def test_http_response_parser_rejects_oversized_body_before_read() -> None:
+    """HTTP response parser should cap optional response body reads."""
+    # Given: A response that advertises a body larger than the client limit
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 65537\r\n\r\n")
+
+    # When/Then: Parsing fails without attempting an unbounded read
+    with pytest.raises(TapoProtocolError, match="body exceeds"):
+        await _read_http_response(reader, io_timeout_s=1.0, read_body=True)
+
+
 async def _wait_for_audio_part(server: FakeTapoServer) -> None:
     for _ in range(20):
         if server.audio_parts:
             return
         await asyncio.sleep(0.01)
     raise AssertionError("fake Tapo server did not receive an audio part")
+
+
+class _FailingDrainWriter:
+    def __init__(self) -> None:
+        self.closed = False
+        self.wait_closed_called = False
+        self.writes: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        raise ConnectionResetError("simulated drain failure")
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.wait_closed_called = True

--- a/tests/homesec/talk/tapo/test_digest.py
+++ b/tests/homesec/talk/tapo/test_digest.py
@@ -117,6 +117,22 @@ def test_build_digest_authorization_rejects_non_digest_challenge() -> None:
         )
 
 
+def test_build_digest_authorization_rejects_unsupported_qop() -> None:
+    """Digest authorization should fail closed for unsupported qop challenges."""
+    # Given: A Digest challenge that does not offer qop=auth
+    challenge = parse_www_authenticate('Digest realm="tapo", nonce="abc", qop="auth-int"')
+
+    # When/Then: Building a Tapo authorization header fails safely
+    with pytest.raises(TapoDigestError, match="qop"):
+        build_digest_authorization_header(
+            challenge=challenge,
+            method="POST",
+            uri="/stream",
+            username="admin",
+            password_material="A" * 64,
+        )
+
+
 def test_digest_mismatch_does_not_validate() -> None:
     """Digest validation should reject wrong credential material."""
     # Given: A header generated with one credential hash

--- a/tests/homesec/talk/tapo/test_digest.py
+++ b/tests/homesec/talk/tapo/test_digest.py
@@ -1,0 +1,171 @@
+"""Tests for Tapo local Digest authentication helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from homesec.talk.tapo.digest import (
+    TapoDigestError,
+    build_digest_authorization_header,
+    digest_authorization_matches,
+    parse_digest_authorization,
+    parse_www_authenticate,
+)
+
+
+def test_parse_www_authenticate_reads_encrypt_type_hint() -> None:
+    """Digest challenge parsing should preserve Tapo SHA256 hint metadata."""
+    # Given: A Tapo Digest challenge with encrypt_type=3
+    header = 'Digest realm="tapo", nonce="abc", qop="auth", encrypt_type="3"'
+
+    # When: Parsing the challenge
+    challenge = parse_www_authenticate(header)
+
+    # Then: The challenge prefers SHA256 credential material
+    assert challenge.scheme == "digest"
+    assert challenge.realm == "tapo"
+    assert challenge.nonce == "abc"
+    assert challenge.encrypt_type == "3"
+    assert challenge.preferred_hash_kind == "sha256"
+
+
+def test_parse_www_authenticate_defaults_to_md5_without_encrypt_hint() -> None:
+    """Digest challenge parsing should default old Tapo challenges to MD5 hashes."""
+    # Given: A Digest challenge without the newer encrypt_type hint
+    header = 'Digest realm="tapo", nonce="abc", qop="auth"'
+
+    # When: Parsing the challenge
+    challenge = parse_www_authenticate(header)
+
+    # Then: MD5 credential material is preferred
+    assert challenge.preferred_hash_kind == "md5"
+
+
+def test_build_digest_authorization_header_matches_expected_response() -> None:
+    """Digest authorization should be deterministic for a fixed cnonce and nonce count."""
+    # Given: A fixed Tapo Digest challenge and credential hash material
+    challenge = parse_www_authenticate('Digest realm="tapo", nonce="abc", qop="auth"')
+
+    # When: Building the Authorization header
+    header = build_digest_authorization_header(
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="A" * 64,
+        nonce_count=1,
+        cnonce="client-nonce",
+    )
+
+    # Then: The header is parseable and validates against the same challenge
+    values = parse_digest_authorization(header)
+    assert values["username"] == "admin"
+    assert values["uri"] == "/stream"
+    assert values["qop"] == "auth"
+    assert values["nc"] == "00000001"
+    assert values["cnonce"] == "client-nonce"
+    assert digest_authorization_matches(
+        authorization_header=header,
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="A" * 64,
+    )
+
+
+def test_build_digest_authorization_supports_legacy_no_qop_challenge() -> None:
+    """Digest authorization should support old challenges without qop."""
+    # Given: A Digest challenge without qop
+    challenge = parse_www_authenticate('Digest realm="tapo", nonce="abc"')
+
+    # When: Building the Authorization header
+    header = build_digest_authorization_header(
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="B" * 32,
+    )
+
+    # Then: The response validates without nc/cnonce fields
+    values = parse_digest_authorization(header)
+    assert "qop" not in values
+    assert digest_authorization_matches(
+        authorization_header=header,
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="B" * 32,
+    )
+
+
+def test_build_digest_authorization_rejects_non_digest_challenge() -> None:
+    """Tapo Digest helpers should reject unsupported auth schemes."""
+    # Given: A Basic challenge
+    challenge = parse_www_authenticate('Basic realm="tapo"')
+
+    # When/Then: Building a Tapo authorization header fails safely
+    with pytest.raises(TapoDigestError, match="Digest"):
+        build_digest_authorization_header(
+            challenge=challenge,
+            method="POST",
+            uri="/stream",
+            username="admin",
+            password_material="A" * 64,
+        )
+
+
+def test_digest_mismatch_does_not_validate() -> None:
+    """Digest validation should reject wrong credential material."""
+    # Given: A header generated with one credential hash
+    challenge = parse_www_authenticate('Digest realm="tapo", nonce="abc", qop="auth"')
+    header = build_digest_authorization_header(
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="A" * 64,
+        cnonce="client-nonce",
+    )
+
+    # When: Validating with a different credential hash
+    valid = digest_authorization_matches(
+        authorization_header=header,
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="B" * 64,
+    )
+
+    # Then: The header does not match
+    assert valid is False
+
+
+def test_digest_validation_rejects_invalid_nonce_count() -> None:
+    """Digest validation should fail closed for malformed qop counters."""
+    # Given: A valid Digest header whose nc value is corrupted
+    challenge = parse_www_authenticate('Digest realm="tapo", nonce="abc", qop="auth"')
+    header = build_digest_authorization_header(
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="A" * 64,
+        cnonce="client-nonce",
+    ).replace("nc=00000001", "nc=nothex")
+
+    # When: Validating the corrupted header
+    valid = digest_authorization_matches(
+        authorization_header=header,
+        challenge=challenge,
+        method="POST",
+        uri="/stream",
+        username="admin",
+        password_material="A" * 64,
+    )
+
+    # Then: The helper rejects it instead of raising
+    assert valid is False

--- a/tests/homesec/talk/tapo/test_mpegts.py
+++ b/tests/homesec/talk/tapo/test_mpegts.py
@@ -4,62 +4,51 @@ from __future__ import annotations
 
 import pytest
 
-from homesec.talk.tapo.mpegts import (
-    AUDIO_PID,
-    PAT_PID,
-    PMT_PID,
-    STREAM_TYPE_PCMA_TAPO,
-    TS_PACKET_SIZE,
-    TS_SYNC_BYTE,
-    TapoMPEGTSError,
-    TapoPCMATransportStreamMuxer,
-)
+from homesec.talk.tapo.mpegts import TapoMPEGTSError, TapoPCMATransportStreamMuxer
+
+_TS_PACKET_SIZE = 188
+_TS_SYNC_BYTE = 0x47
+_PAT_PID = 0x0000
+_PMT_PID = 0x1000
+_AUDIO_PID = 0x0100
+_PROGRAM_NUMBER = 1
+_STREAM_TYPE_PCMA_TAPO = 0x90
+_AUDIO_STREAM_ID = 0xC0
+_AUDIO_CLOCK_INCREMENT_20MS = 1800
 
 
-def test_mpegts_header_contains_pat_and_pmt_packets() -> None:
-    """Muxer header should contain deterministic PAT and PMT packets."""
+def test_mpegts_header_contains_valid_pat_and_pmt_packets() -> None:
+    """Muxer header should contain independently parseable PAT and PMT packets."""
     # Given: A fresh Tapo PCMA transport-stream muxer
     muxer = TapoPCMATransportStreamMuxer()
 
     # When: Rendering the stream header
     header = muxer.header()
 
-    # Then: It contains two valid TS packets for PAT and PMT
+    # Then: It contains a PAT mapping the program to the PMT and a PMT for audio
     packets = _packets(header)
     assert len(packets) == 2
-    assert all(packet[0] == TS_SYNC_BYTE for packet in packets)
-    assert _pid(packets[0]) == PAT_PID
-    assert _pid(packets[1]) == PMT_PID
-    assert _continuity_counter(packets[0]) == 0
-    assert _continuity_counter(packets[1]) == 0
+    pat_packet, pmt_packet = packets
+    assert _pid(pat_packet) == _PAT_PID
+    assert _pid(pmt_packet) == _PMT_PID
+    assert _payload_unit_start(pat_packet) is True
+    assert _payload_unit_start(pmt_packet) is True
+    assert _continuity_counter(pat_packet) == 0
+    assert _continuity_counter(pmt_packet) == 0
+
+    pat = _parse_pat(pat_packet)
+    pmt = _parse_pmt(pmt_packet)
+    assert pat == {"program_number": _PROGRAM_NUMBER, "pmt_pid": _PMT_PID}
+    assert pmt == {
+        "program_number": _PROGRAM_NUMBER,
+        "pcr_pid": _AUDIO_PID,
+        "stream_type": _STREAM_TYPE_PCMA_TAPO,
+        "elementary_pid": _AUDIO_PID,
+    }
 
 
-def test_mpegts_pmt_contains_tapo_pcma_stream_type_and_audio_pid() -> None:
-    """PMT should advertise Tapo's private PCMA stream type and audio PID."""
-    # Given: A rendered header
-    muxer = TapoPCMATransportStreamMuxer()
-    _pat, pmt = _packets(muxer.header())
-
-    # When: Extracting PMT payload bytes
-    payload = _payload(pmt)
-
-    # Then: The PMT advertises stream type 0x90 on PID 0x0100
-    assert (
-        bytes(
-            [
-                STREAM_TYPE_PCMA_TAPO,
-                0xE0 | ((AUDIO_PID >> 8) & 0x1F),
-                AUDIO_PID & 0xFF,
-                0xF0,
-                0x00,
-            ]
-        )
-        in payload
-    )
-
-
-def test_mpegts_audio_payload_packets_are_188_byte_ts_packets() -> None:
-    """Audio payload output should be packetized as MPEG-TS packets."""
+def test_mpegts_audio_payload_packets_have_pes_pts_and_pcr() -> None:
+    """Audio payload output should be packetized as timed MPEG-TS packets."""
     # Given: One 20 ms PCMA frame
     muxer = TapoPCMATransportStreamMuxer()
     pcma = bytes(range(160))
@@ -67,31 +56,43 @@ def test_mpegts_audio_payload_packets_are_188_byte_ts_packets() -> None:
     # When: Packetizing audio
     payload = muxer.audio_payload(pcma)
 
-    # Then: Every packet has the TS size, sync byte, and audio PID
+    # Then: The first audio packet has PES, PTS, and PCR for the advertised PCR PID
     packets = _packets(payload)
-    assert packets
-    assert all(len(packet) == TS_PACKET_SIZE for packet in packets)
-    assert all(packet[0] == TS_SYNC_BYTE for packet in packets)
-    assert all(_pid(packet) == AUDIO_PID for packet in packets)
-    assert _payload_unit_start(packets[0]) is True
+    assert len(packets) == 1
+    packet = packets[0]
+    assert _pid(packet) == _AUDIO_PID
+    assert _payload_unit_start(packet) is True
+    assert _continuity_counter(packet) == 0
+    assert _pcr_base(packet) == 0
+
+    pes = _payload(packet)
+    assert pes[:4] == b"\x00\x00\x01" + bytes([_AUDIO_STREAM_ID])
+    assert int.from_bytes(pes[4:6], "big") == len(pes) - 6
+    assert pes[6:9] == b"\x80\x80\x05"
+    assert _pts_from_pes(pes) == 0
+    assert pes[14:] == pcma
 
 
-def test_mpegts_audio_continuity_counter_advances() -> None:
-    """Audio continuity counters should advance across payload calls."""
-    # Given: A muxer that has already emitted one audio payload
+def test_mpegts_audio_continuity_counter_advances_across_multiple_packets() -> None:
+    """Audio continuity counters should advance for multi-packet payloads."""
+    # Given: A PCMA payload large enough to span multiple TS packets
     muxer = TapoPCMATransportStreamMuxer()
-    first = _packets(muxer.audio_payload(b"\xaa" * 160))
+    pcma = bytes([0xAA]) * 400
 
-    # When: Emitting a second payload
-    second = _packets(muxer.audio_payload(b"\xbb" * 160))
+    # When: Packetizing audio
+    packets = _packets(muxer.audio_payload(pcma))
 
-    # Then: The continuity counter continues on the audio PID
-    assert _continuity_counter(first[-1]) == 0
-    assert _continuity_counter(second[0]) == 1
+    # Then: Counters advance and only the first packet starts the PES/PCR sequence
+    assert len(packets) == 3
+    assert [_continuity_counter(packet) for packet in packets] == [0, 1, 2]
+    assert [_payload_unit_start(packet) for packet in packets] == [True, False, False]
+    assert _pcr_base(packets[0]) == 0
+    assert _pcr_base(packets[1]) is None
+    assert _pcr_base(packets[2]) is None
 
 
-def test_mpegts_audio_pts_increments_by_pcma_sample_count() -> None:
-    """Audio PTS should advance by the number of PCMA samples sent."""
+def test_mpegts_audio_pts_uses_90khz_clock() -> None:
+    """Audio PTS should advance on the MPEG-TS 90 kHz clock."""
     # Given: A muxer with deterministic initial timestamp
     muxer = TapoPCMATransportStreamMuxer()
 
@@ -99,9 +100,10 @@ def test_mpegts_audio_pts_increments_by_pcma_sample_count() -> None:
     first = _packets(muxer.audio_payload(b"\xaa" * 160))[0]
     second = _packets(muxer.audio_payload(b"\xbb" * 160))[0]
 
-    # Then: The second PES timestamp advances by the first payload sample count
-    assert _pts_from_first_packet(first) == 0
-    assert _pts_from_first_packet(second) == 160
+    # Then: The second PES timestamp advances by 20 ms at 90 kHz
+    assert _pts_from_pes(_payload(first)) == 0
+    assert _pts_from_pes(_payload(second)) == _AUDIO_CLOCK_INCREMENT_20MS
+    assert _pcr_base(second) == _AUDIO_CLOCK_INCREMENT_20MS
 
 
 def test_mpegts_output_is_deterministic_for_fixed_input() -> None:
@@ -130,8 +132,13 @@ def test_mpegts_rejects_empty_audio_payload() -> None:
 
 
 def _packets(data: bytes) -> list[bytes]:
-    assert len(data) % TS_PACKET_SIZE == 0
-    return [data[index : index + TS_PACKET_SIZE] for index in range(0, len(data), TS_PACKET_SIZE)]
+    assert len(data) % _TS_PACKET_SIZE == 0
+    packets = [
+        data[index : index + _TS_PACKET_SIZE] for index in range(0, len(data), _TS_PACKET_SIZE)
+    ]
+    assert all(len(packet) == _TS_PACKET_SIZE for packet in packets)
+    assert all(packet[0] == _TS_SYNC_BYTE for packet in packets)
+    return packets
 
 
 def _pid(packet: bytes) -> int:
@@ -149,19 +156,59 @@ def _continuity_counter(packet: bytes) -> int:
 def _payload(packet: bytes) -> bytes:
     adaptation_control = (packet[3] >> 4) & 0x03
     offset = 4
-    if adaptation_control == 0x03:
+    if adaptation_control & 0x02:
         offset += 1 + packet[offset]
+    assert adaptation_control & 0x01
     payload = packet[offset:]
-    if _payload_unit_start(packet) and _pid(packet) in {PAT_PID, PMT_PID}:
+    if _payload_unit_start(packet) and _pid(packet) in {_PAT_PID, _PMT_PID}:
         pointer = payload[0]
         payload = payload[1 + pointer :]
     return payload
 
 
-def _pts_from_first_packet(packet: bytes) -> int:
+def _section(packet: bytes, *, table_id: int) -> bytes:
     payload = _payload(packet)
-    assert payload[:4] == b"\x00\x00\x01\xc0"
-    pts = payload[9:14]
+    assert payload[0] == table_id
+    section_length = ((payload[1] & 0x0F) << 8) | payload[2]
+    section = payload[: 3 + section_length]
+    assert len(section) == 3 + section_length
+    assert _mpeg2_crc32(section[:-4]) == int.from_bytes(section[-4:], "big")
+    return section
+
+
+def _parse_pat(packet: bytes) -> dict[str, int]:
+    section = _section(packet, table_id=0x00)
+    program_number = int.from_bytes(section[8:10], "big")
+    pmt_pid = ((section[10] & 0x1F) << 8) | section[11]
+    return {"program_number": program_number, "pmt_pid": pmt_pid}
+
+
+def _parse_pmt(packet: bytes) -> dict[str, int]:
+    section = _section(packet, table_id=0x02)
+    program_number = int.from_bytes(section[3:5], "big")
+    pcr_pid = ((section[8] & 0x1F) << 8) | section[9]
+    program_info_length = ((section[10] & 0x0F) << 8) | section[11]
+    offset = 12 + program_info_length
+    stream_type = section[offset]
+    elementary_pid = ((section[offset + 1] & 0x1F) << 8) | section[offset + 2]
+    es_info_length = ((section[offset + 3] & 0x0F) << 8) | section[offset + 4]
+    assert es_info_length == 0
+    assert offset + 5 == len(section) - 4
+    return {
+        "program_number": program_number,
+        "pcr_pid": pcr_pid,
+        "stream_type": stream_type,
+        "elementary_pid": elementary_pid,
+    }
+
+
+def _pts_from_pes(pes: bytes) -> int:
+    pts = pes[9:14]
+    assert len(pts) == 5
+    assert (pts[0] & 0xF0) == 0x20
+    assert pts[0] & 0x01
+    assert pts[2] & 0x01
+    assert pts[4] & 0x01
     return (
         ((pts[0] >> 1) & 0x07) << 30
         | pts[1] << 22
@@ -169,3 +216,32 @@ def _pts_from_first_packet(packet: bytes) -> int:
         | pts[3] << 7
         | ((pts[4] >> 1) & 0x7F)
     )
+
+
+def _pcr_base(packet: bytes) -> int | None:
+    adaptation_control = (packet[3] >> 4) & 0x03
+    if not adaptation_control & 0x02:
+        return None
+    adaptation_length = packet[4]
+    if adaptation_length == 0:
+        return None
+    adaptation = packet[5 : 5 + adaptation_length]
+    flags = adaptation[0]
+    if not flags & 0x10:
+        return None
+    raw = int.from_bytes(adaptation[1:7], "big")
+    assert ((raw >> 9) & 0x3F) == 0x3F
+    assert (raw & 0x1FF) == 0
+    return raw >> 15
+
+
+def _mpeg2_crc32(data: bytes) -> int:
+    crc = 0xFFFFFFFF
+    for byte in data:
+        crc ^= byte << 24
+        for _ in range(8):
+            if crc & 0x80000000:
+                crc = ((crc << 1) ^ 0x04C11DB7) & 0xFFFFFFFF
+            else:
+                crc = (crc << 1) & 0xFFFFFFFF
+    return crc

--- a/tests/homesec/talk/tapo/test_mpegts.py
+++ b/tests/homesec/talk/tapo/test_mpegts.py
@@ -1,0 +1,171 @@
+"""Tests for the Tapo MPEG-TS PCMA muxer."""
+
+from __future__ import annotations
+
+import pytest
+
+from homesec.talk.tapo.mpegts import (
+    AUDIO_PID,
+    PAT_PID,
+    PMT_PID,
+    STREAM_TYPE_PCMA_TAPO,
+    TS_PACKET_SIZE,
+    TS_SYNC_BYTE,
+    TapoMPEGTSError,
+    TapoPCMATransportStreamMuxer,
+)
+
+
+def test_mpegts_header_contains_pat_and_pmt_packets() -> None:
+    """Muxer header should contain deterministic PAT and PMT packets."""
+    # Given: A fresh Tapo PCMA transport-stream muxer
+    muxer = TapoPCMATransportStreamMuxer()
+
+    # When: Rendering the stream header
+    header = muxer.header()
+
+    # Then: It contains two valid TS packets for PAT and PMT
+    packets = _packets(header)
+    assert len(packets) == 2
+    assert all(packet[0] == TS_SYNC_BYTE for packet in packets)
+    assert _pid(packets[0]) == PAT_PID
+    assert _pid(packets[1]) == PMT_PID
+    assert _continuity_counter(packets[0]) == 0
+    assert _continuity_counter(packets[1]) == 0
+
+
+def test_mpegts_pmt_contains_tapo_pcma_stream_type_and_audio_pid() -> None:
+    """PMT should advertise Tapo's private PCMA stream type and audio PID."""
+    # Given: A rendered header
+    muxer = TapoPCMATransportStreamMuxer()
+    _pat, pmt = _packets(muxer.header())
+
+    # When: Extracting PMT payload bytes
+    payload = _payload(pmt)
+
+    # Then: The PMT advertises stream type 0x90 on PID 0x0100
+    assert (
+        bytes(
+            [
+                STREAM_TYPE_PCMA_TAPO,
+                0xE0 | ((AUDIO_PID >> 8) & 0x1F),
+                AUDIO_PID & 0xFF,
+                0xF0,
+                0x00,
+            ]
+        )
+        in payload
+    )
+
+
+def test_mpegts_audio_payload_packets_are_188_byte_ts_packets() -> None:
+    """Audio payload output should be packetized as MPEG-TS packets."""
+    # Given: One 20 ms PCMA frame
+    muxer = TapoPCMATransportStreamMuxer()
+    pcma = bytes(range(160))
+
+    # When: Packetizing audio
+    payload = muxer.audio_payload(pcma)
+
+    # Then: Every packet has the TS size, sync byte, and audio PID
+    packets = _packets(payload)
+    assert packets
+    assert all(len(packet) == TS_PACKET_SIZE for packet in packets)
+    assert all(packet[0] == TS_SYNC_BYTE for packet in packets)
+    assert all(_pid(packet) == AUDIO_PID for packet in packets)
+    assert _payload_unit_start(packets[0]) is True
+
+
+def test_mpegts_audio_continuity_counter_advances() -> None:
+    """Audio continuity counters should advance across payload calls."""
+    # Given: A muxer that has already emitted one audio payload
+    muxer = TapoPCMATransportStreamMuxer()
+    first = _packets(muxer.audio_payload(b"\xaa" * 160))
+
+    # When: Emitting a second payload
+    second = _packets(muxer.audio_payload(b"\xbb" * 160))
+
+    # Then: The continuity counter continues on the audio PID
+    assert _continuity_counter(first[-1]) == 0
+    assert _continuity_counter(second[0]) == 1
+
+
+def test_mpegts_audio_pts_increments_by_pcma_sample_count() -> None:
+    """Audio PTS should advance by the number of PCMA samples sent."""
+    # Given: A muxer with deterministic initial timestamp
+    muxer = TapoPCMATransportStreamMuxer()
+
+    # When: Emitting two 160-sample PCMA frames
+    first = _packets(muxer.audio_payload(b"\xaa" * 160))[0]
+    second = _packets(muxer.audio_payload(b"\xbb" * 160))[0]
+
+    # Then: The second PES timestamp advances by the first payload sample count
+    assert _pts_from_first_packet(first) == 0
+    assert _pts_from_first_packet(second) == 160
+
+
+def test_mpegts_output_is_deterministic_for_fixed_input() -> None:
+    """Fresh muxers should produce identical output for identical PCMA input."""
+    # Given: Two fresh muxers and fixed PCMA data
+    pcma = b"\xd5" * 160
+
+    # When: Rendering headers and one audio payload from each muxer
+    first_muxer = TapoPCMATransportStreamMuxer()
+    first = first_muxer.header() + first_muxer.audio_payload(pcma)
+    muxer = TapoPCMATransportStreamMuxer()
+    second = muxer.header() + muxer.audio_payload(pcma)
+
+    # Then: The output is deterministic
+    assert first == second
+
+
+def test_mpegts_rejects_empty_audio_payload() -> None:
+    """Muxer should reject empty audio payloads."""
+    # Given: A fresh muxer
+    muxer = TapoPCMATransportStreamMuxer()
+
+    # When/Then: Packetizing an empty payload fails
+    with pytest.raises(TapoMPEGTSError, match="must not be empty"):
+        muxer.audio_payload(b"")
+
+
+def _packets(data: bytes) -> list[bytes]:
+    assert len(data) % TS_PACKET_SIZE == 0
+    return [data[index : index + TS_PACKET_SIZE] for index in range(0, len(data), TS_PACKET_SIZE)]
+
+
+def _pid(packet: bytes) -> int:
+    return ((packet[1] & 0x1F) << 8) | packet[2]
+
+
+def _payload_unit_start(packet: bytes) -> bool:
+    return bool(packet[1] & 0x40)
+
+
+def _continuity_counter(packet: bytes) -> int:
+    return packet[3] & 0x0F
+
+
+def _payload(packet: bytes) -> bytes:
+    adaptation_control = (packet[3] >> 4) & 0x03
+    offset = 4
+    if adaptation_control == 0x03:
+        offset += 1 + packet[offset]
+    payload = packet[offset:]
+    if _payload_unit_start(packet) and _pid(packet) in {PAT_PID, PMT_PID}:
+        pointer = payload[0]
+        payload = payload[1 + pointer :]
+    return payload
+
+
+def _pts_from_first_packet(packet: bytes) -> int:
+    payload = _payload(packet)
+    assert payload[:4] == b"\x00\x00\x01\xc0"
+    pts = payload[9:14]
+    return (
+        ((pts[0] >> 1) & 0x07) << 30
+        | pts[1] << 22
+        | ((pts[2] >> 1) & 0x7F) << 15
+        | pts[3] << 7
+        | ((pts[4] >> 1) & 0x7F)
+    )


### PR DESCRIPTION
## Summary

Implements Phase 10.2 for the HomeSec push-to-talk stack: local Tapo protocol primitives without wiring the backend into `TalkManager` yet.

This PR adds:
- Tapo Digest challenge parsing and Authorization generation for MD5-style Digest over either MD5 or SHA256 password-hash material.
- An async local HTTP `POST /stream` client that performs the unauthenticated challenge, authenticated stream open, multipart JSON talk setup, and audio/mp2t multipart writes.
- Multipart part writer/parser helpers with bounded payload, preamble, header, and total-read limits.
- A minimal Tapo MPEG-TS muxer for PCMA/8000 talk audio, including PAT/PMT, private stream type `0x90`, PES packets, 90 kHz PTS, PCR, and continuity counters.
- Fake local Tapo endpoint tests for auth/setup/audio write behavior and MPEG-TS packetization tests.

## Design notes

- This is intentionally protocol-only. It does not create `TapoLocalTalkSession`, does not connect PCM browser frames to the Tapo stream, and does not change API/UI/runtime/TalkManager behavior.
- Credential handling stays hash-only through the Phase 10.1 config model. No raw Tapo password env support is added.
- Errors exposed from these primitives are safe/generic and avoid logging credential hash material.
- The fake endpoint validates raw multipart framing independently instead of mirroring the production parser/renderer.
- Tapo session IDs are treated like media/session tokens and excluded from dataclass repr output.

## Notion

- Phase 10 parent: https://www.notion.so/levneiman/Phase-10-implement-Tapo-C120-local-talkback-backend-358d8336c59f81c0b03afeb3c4708b5e
- Phase 10.2 ticket: https://www.notion.so/levneiman/35ad8336c59f81599a60eec05529cacc

## Stack

- Stacked on Phase 10.1: https://github.com/lan17/homesec/pull/92

## Review loop

- xhigh review round found protocol, multipart lifecycle, and MPEG-TS timing/PCR issues.
- Fixes were pushed in `de81fda`.
- Fresh xhigh re-review round returned no findings.

## Validation

- `uv run pytest tests/homesec/talk/tapo -q` -> 54 passed
- `uv run --locked ruff check src/homesec/talk/tapo tests/homesec/talk/tapo` -> passed
- `uv run --locked ruff format --check src/homesec/talk/tapo tests/homesec/talk/tapo` -> passed
- `uv run mypy src/homesec/talk/tapo tests/homesec/talk/tapo` -> passed
- `uv run pytest tests/homesec/talk/tapo tests/homesec/talk/test_backend_registry.py tests/homesec/talk/test_selector.py tests/homesec/talk/test_proprietary_backend_readiness.py tests/homesec/rtsp/test_talk_backend.py tests/homesec/rtsp/test_runtime.py::test_unknown_explicit_talk_backend_reports_config_error_without_onvif_probe -q` -> 95 passed
- `make typecheck` -> passed
- `make check` -> static checks passed; pytest reached 1286 passed, then 38 local Postgres-auth fixture errors against the local `homesec` test DB (`asyncpg.exceptions.InvalidPasswordError`)
- GitHub CI for https://github.com/lan17/homesec/pull/93 -> passing
