### PR TITLE
feat: add event card list

### DIFF
--- a/ui/src/features/clips/ClipsPage.test.tsx
+++ b/ui/src/features/clips/ClipsPage.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import type { ClipListSnapshot } from '../../api/client'
+import type { CameraResponse } from '../../api/generated/types'
+import type { useCamerasQuery } from '../../api/hooks/useCamerasQuery'
+import type { useClipsQuery } from '../../api/hooks/useClipsQuery'
+import { ClipsPage } from './ClipsPage'
+
+const useClipsQueryMock = vi.fn()
+const useCamerasQueryMock = vi.fn()
+
+vi.mock('../../api/hooks/useClipsQuery', () => ({
+  useClipsQuery: (...args: unknown[]) => useClipsQueryMock(...args),
+}))
+
+vi.mock('../../api/hooks/useCamerasQuery', () => ({
+  useCamerasQuery: () => useCamerasQueryMock(),
+}))
+
+function makeCamera(name: string): CameraResponse {
+  return {
+    name,
+    enabled: true,
+    healthy: true,
+    last_heartbeat: 1_739_590_400,
+    source_backend: 'rtsp',
+    source_config: { rtsp_url: 'rtsp://***redacted***@camera.local/stream' },
+  }
+}
+
+function renderEventsPage({
+  clipList,
+  cameras = [makeCamera('front_door')],
+  route = '/events?detected=any',
+}: {
+  clipList: ClipListSnapshot
+  cameras?: CameraResponse[]
+  route?: string
+}) {
+  useClipsQueryMock.mockReturnValue({
+    data: clipList,
+    isPending: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ReturnType<typeof useClipsQuery>)
+
+  useCamerasQueryMock.mockReturnValue({
+    data: cameras,
+    isPending: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ReturnType<typeof useCamerasQuery>)
+
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <ClipsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ClipsPage event list', () => {
+  afterEach(() => {
+    cleanup()
+    useClipsQueryMock.mockReset()
+    useCamerasQueryMock.mockReset()
+  })
+
+  it('renders grouped media-first event cards without the technical table default', () => {
+    // Given: Existing clip list API data with event-facing metadata
+    renderEventsPage({
+      clipList: {
+        httpStatus: 200,
+        limit: 25,
+        next_cursor: null,
+        has_more: false,
+        clips: [
+          {
+            id: 'clip-1',
+            camera: 'front_door',
+            status: 'done',
+            created_at: '2026-02-14T18:30:00.000Z',
+            activity_type: 'package_drop',
+            risk_level: 'high',
+            summary: 'Package left near the front door.',
+            detected_objects: ['person', 'package'],
+            alerted: true,
+            storage_uri: 'dropbox:/clips/clip-1.mp4',
+            view_url: null,
+          },
+          {
+            id: 'clip-2',
+            camera: 'driveway',
+            status: 'uploaded',
+            created_at: '2026-02-14T18:10:00.000Z',
+            activity_type: 'vehicle',
+            risk_level: 'low',
+            summary: null,
+            detected_objects: ['car'],
+            alerted: false,
+            storage_uri: null,
+            view_url: null,
+          },
+        ],
+      },
+      cameras: [makeCamera('front_door'), makeCamera('driveway')],
+    })
+
+    // When: Reading the refreshed event list
+    const cards = screen.getAllByRole('article')
+    const firstCard = cards[0]
+    const links = screen.getAllByRole('link', { name: 'View event' })
+
+    // Then: The default list should prioritize what happened over raw clip fields
+    expect(screen.queryByRole('columnheader', { name: 'ID' })).toBeNull()
+    expect(screen.queryByText('clip-1')).toBeNull()
+    expect(screen.queryByText('dropbox:/clips/clip-1.mp4')).toBeNull()
+    expect(firstCard ? within(firstCard).getByText('Package Drop') : null).toBeTruthy()
+    expect(firstCard ? within(firstCard).getByText('Package left near the front door.') : null).toBeTruthy()
+    expect(firstCard ? within(firstCard).getByText('front_door') : null).toBeTruthy()
+    expect(firstCard ? within(firstCard).getByText('person, package') : null).toBeTruthy()
+    expect(firstCard ? within(firstCard).getByText('Alert sent') : null).toBeTruthy()
+    expect(links[0]?.getAttribute('href')).toBe('/events/clip-1?detected=any')
+  })
+
+  it('shows a no-results state without a table shell', () => {
+    // Given: The existing clip query returns no matches
+    renderEventsPage({
+      clipList: {
+        httpStatus: 200,
+        limit: 25,
+        next_cursor: null,
+        has_more: false,
+        clips: [],
+      },
+    })
+
+    // When: The Events page renders
+    const emptyState = screen.getByRole('heading', { name: 'No events found' })
+
+    // Then: Empty results should be homeowner-readable and avoid the old table shell
+    expect(emptyState).toBeTruthy()
+    expect(screen.queryByRole('table')).toBeNull()
+  })
+})

--- a/ui/src/features/clips/ClipsPage.tsx
+++ b/ui/src/features/clips/ClipsPage.tsx
@@ -7,6 +7,11 @@ import { useClipsQuery } from '../../api/hooks/useClipsQuery'
 import { ApiKeyGate } from '../../components/ui/ApiKeyGate'
 import { Button } from '../../components/ui/Button'
 import { Card } from '../../components/ui/Card'
+import { EmptyState } from '../../components/ui/EmptyState'
+import { EventCard } from '../../components/ui/EventCard'
+import { MediaPanel } from '../../components/ui/MediaPanel'
+import { RiskBadge } from '../../components/ui/RiskBadge'
+import { StatusBadge } from '../../components/ui/StatusBadge'
 import {
   CLIP_LIMIT_OPTIONS,
   CLIP_STATUS_OPTIONS,
@@ -27,7 +32,13 @@ import {
   resetCursorHistory,
   type CursorHistoryState,
 } from './cursorState'
-import { describeClipError, formatTimestamp, renderDetectedObjects } from './presentation'
+import {
+  describeClipError,
+  formatActivityType,
+  formatDetectedObjects,
+  formatEventTime,
+  groupClipsByDate,
+} from './presentation'
 
 interface ClipsFilterPanelProps {
   cameraOptions: string[]
@@ -186,8 +197,14 @@ function ClipsFilterPanel({
   )
 }
 
+function eventDetailPath(clipId: string, routeSearch: string): string {
+  const suffix = routeSearch ? `?${routeSearch}` : ''
+  return `/events/${encodeURIComponent(clipId)}${suffix}`
+}
+
 export function ClipsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
+  const routeSearch = searchParams.toString()
   const query = useMemo(() => parseClipsQuery(searchParams), [searchParams])
   const filterQuery = useMemo(() => queryWithoutCursor(query), [query])
   const filterSignature = useMemo(
@@ -205,6 +222,7 @@ export function ClipsPage() {
 
   const unauthorized = isUnauthorizedAPIError(clipsQuery.error)
   const clipItems = useMemo(() => clipsQuery.data?.clips ?? [], [clipsQuery.data])
+  const eventGroups = useMemo(() => groupClipsByDate(clipItems), [clipItems])
   const cameraOptions = useMemo(() => {
     const uniqueNames = new Set<string>()
     for (const camera of camerasQuery.data ?? []) {
@@ -300,10 +318,15 @@ export function ClipsPage() {
         onReset={resetFilters}
       />
 
-      <Card title="Results" subtitle={clipItems.length > 0 ? `${clipItems.length} event(s)` : undefined}>
-        {clipsQuery.isPending ? (
-          <p className="muted">Loading events...</p>
-        ) : null}
+      <section className="events-results" aria-labelledby="events-results-title">
+        <header className="events-results__header">
+          <div>
+            <h2 id="events-results-title" className="section-title">Results</h2>
+            {clipItems.length > 0 ? (
+              <p className="muted">{clipItems.length} event(s)</p>
+            ) : null}
+          </div>
+        </header>
 
         {unauthorized ? (
           <ApiKeyGate
@@ -313,68 +336,79 @@ export function ClipsPage() {
           />
         ) : null}
 
+        {clipsQuery.isPending ? (
+          <EmptyState
+            title="Loading events"
+            description="Fetching recorded security events with the current filters."
+            tone="loading"
+          />
+        ) : null}
+
         {clipsQuery.error && !unauthorized ? (
-          <p className="error-text">{describeClipError(clipsQuery.error)}</p>
+          <EmptyState
+            title="Events could not load"
+            description={describeClipError(clipsQuery.error)}
+            tone="error"
+          />
         ) : null}
 
         {!clipsQuery.isPending && !clipsQuery.error && clipItems.length === 0 ? (
-          <p className="muted">No events match the current filters.</p>
+          <EmptyState
+            title="No events found"
+            description="No recorded security events match the current filters."
+          />
         ) : null}
 
         {clipItems.length > 0 ? (
           <>
-            <div className="clips-table-wrap">
-              <table className="clips-table">
-                <thead>
-                  <tr>
-                    <th>ID</th>
-                    <th>Camera</th>
-                    <th>Status</th>
-                    <th>Created</th>
-                    <th>Activity</th>
-                    <th>Risk</th>
-                    <th>Alerted</th>
-                    <th>Detected</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {clipItems.map((clip) => (
-                    <tr key={clip.id}>
-                      <td>
-                        <Link to={`/events/${encodeURIComponent(clip.id)}`}>{clip.id}</Link>
-                      </td>
-                      <td>{clip.camera}</td>
-                      <td>
-                        <span className="clips-chip">{clip.status}</span>
-                      </td>
-                      <td>{formatTimestamp(clip.created_at)}</td>
-                      <td>{clip.activity_type ?? '-'}</td>
-                      <td>{clip.risk_level ?? '-'}</td>
-                      <td>{clip.alerted ? 'true' : 'false'}</td>
-                      <td>{renderDetectedObjects(clip)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <ul className="clips-mobile-list">
-              {clipItems.map((clip) => (
-                <li key={clip.id} className="clips-mobile-item">
-                  <Link to={`/events/${encodeURIComponent(clip.id)}`} className="clips-mobile-id">
-                    {clip.id}
-                  </Link>
-                  <p className="muted">{clip.camera}</p>
-                  <p className="muted">{formatTimestamp(clip.created_at)}</p>
-                  <div className="clips-mobile-meta">
-                    <span className="clips-chip">{clip.status}</span>
-                    <span className="clips-chip">{clip.activity_type ?? 'n/a'}</span>
-                    <span className="clips-chip">{clip.risk_level ?? 'n/a'}</span>
-                    <span className="clips-chip">{clip.alerted ? 'alerted' : 'no alert'}</span>
+            <div className="event-groups">
+              {eventGroups.map((group) => (
+                <section
+                  key={group.key}
+                  className="event-group"
+                  aria-labelledby={`events-${group.key}`}
+                >
+                  <h3 id={`events-${group.key}`} className="event-group__title">
+                    {group.label}
+                  </h3>
+                  <div className="event-list">
+                    {group.clips.map((clip) => (
+                      <EventCard
+                        key={clip.id}
+                        camera={clip.camera}
+                        time={formatEventTime(clip.created_at)}
+                        title={formatActivityType(clip.activity_type)}
+                        summary={clip.summary?.trim() || 'No summary available yet.'}
+                        media={(
+                          <MediaPanel
+                            aspect="video"
+                            className="event-card__media-panel"
+                            placeholder="Open event to view video"
+                          />
+                        )}
+                        risk={<RiskBadge level={clip.risk_level} />}
+                        status={(
+                          <StatusBadge tone={clip.alerted ? 'unhealthy' : 'unknown'}>
+                            {clip.alerted ? 'Alert sent' : 'No alert'}
+                          </StatusBadge>
+                        )}
+                        meta={[
+                          { label: 'Objects', value: formatDetectedObjects(clip) },
+                        ]}
+                        actions={(
+                          <Link
+                            to={eventDetailPath(clip.id, routeSearch)}
+                            className="button button--primary"
+                          >
+                            View event
+                          </Link>
+                        )}
+                      />
+                    ))}
                   </div>
-                </li>
+                </section>
               ))}
-            </ul>
+            </div>
 
             <div className="clips-pagination">
               <Button
@@ -397,7 +431,7 @@ export function ClipsPage() {
             </div>
           </>
         ) : null}
-      </Card>
+      </section>
     </section>
   )
 }

--- a/ui/src/features/clips/presentation.test.ts
+++ b/ui/src/features/clips/presentation.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { APIError } from '../../api/client'
 import {
   describeClipError,
+  formatActivityType,
+  formatDetectedObjects,
+  formatEventDateGroup,
+  formatEventTime,
+  groupClipsByDate,
   renderDetectedObjects,
   resolveClipExternalLink,
   resolveClipViewLink,
@@ -37,6 +42,61 @@ describe('renderDetectedObjects', () => {
 
     // Then: UI should show explicit empty-state text
     expect(value).toBe('None')
+  })
+})
+
+describe('event presentation helpers', () => {
+  it('formats event time, grouping, activity, and object labels for cards', () => {
+    // Given: Event metadata from the existing clips API
+    const clip = {
+      id: 'clip-1',
+      camera: 'front_door',
+      status: 'done',
+      created_at: '2026-02-14T18:30:00',
+      activity_type: 'package_drop',
+      detected_objects: ['person', 'package'],
+      alerted: true,
+    }
+
+    // When: Formatting event metadata for the refreshed list
+    const time = formatEventTime(clip.created_at)
+    const group = formatEventDateGroup(clip.created_at, new Date('2026-02-15T20:00:00'))
+    const activity = formatActivityType(clip.activity_type)
+    const objects = formatDetectedObjects(clip)
+
+    // Then: Labels should be scan-friendly and avoid raw API casing
+    expect(time).toMatch(/6:30|18:30/)
+    expect(group).toBe('Yesterday')
+    expect(activity).toBe('Package Drop')
+    expect(objects).toBe('person, package')
+  })
+
+  it('groups clips by local event date without changing list order', () => {
+    // Given: A list of clips already ordered by the API
+    const clips = [
+      {
+        id: 'clip-1',
+        camera: 'front_door',
+        status: 'done',
+        created_at: '2026-02-14T18:30:00.000Z',
+        alerted: true,
+      },
+      {
+        id: 'clip-2',
+        camera: 'garage',
+        status: 'done',
+        created_at: '2026-02-13T18:30:00.000Z',
+        alerted: false,
+      },
+    ]
+
+    // When: Grouping clips for the event list
+    const groups = groupClipsByDate(clips)
+
+    // Then: Date grouping should preserve the API result order within each group
+    expect(groups).toHaveLength(2)
+    expect(groups[0]?.clips.map((clip) => clip.id)).toEqual(['clip-1'])
+    expect(groups[1]?.clips.map((clip) => clip.id)).toEqual(['clip-2'])
   })
 })
 

--- a/ui/src/features/clips/presentation.ts
+++ b/ui/src/features/clips/presentation.ts
@@ -9,6 +9,75 @@ export function formatTimestamp(value: string): string {
   return date.toLocaleString()
 }
 
+function clipDate(value: string): Date | null {
+  const date = new Date(value)
+  return Number.isNaN(date.valueOf()) ? null : date
+}
+
+function localDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+export function formatEventTime(value: string): string {
+  const date = clipDate(value)
+  if (!date) {
+    return value
+  }
+  return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+}
+
+export function formatEventDateGroup(value: string, now: Date = new Date()): string {
+  const date = clipDate(value)
+  if (!date) {
+    return 'Unknown date'
+  }
+
+  const dayDiff = Math.round(
+    (startOfLocalDay(now).getTime() - startOfLocalDay(date).getTime()) / 86_400_000,
+  )
+  if (dayDiff === 0) {
+    return 'Today'
+  }
+  if (dayDiff === 1) {
+    return 'Yesterday'
+  }
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    year: now.getFullYear() === date.getFullYear() ? undefined : 'numeric',
+  })
+}
+
+export function groupClipsByDate(clips: readonly ClipResponse[]): Array<{
+  key: string
+  label: string
+  clips: ClipResponse[]
+}> {
+  const groups = new Map<string, { key: string; label: string; clips: ClipResponse[] }>()
+
+  for (const clip of clips) {
+    const date = clipDate(clip.created_at)
+    const key = date ? localDateKey(date) : 'unknown-date'
+    const label = formatEventDateGroup(clip.created_at)
+    const group = groups.get(key)
+    if (group) {
+      group.clips.push(clip)
+    } else {
+      groups.set(key, { key, label, clips: [clip] })
+    }
+  }
+
+  return [...groups.values()]
+}
+
 export function describeClipError(error: unknown): string {
   return describeUnknownError(error)
 }
@@ -19,6 +88,26 @@ export function renderDetectedObjects(clip: ClipResponse): string {
     return 'None'
   }
   return detectedObjects.join(', ')
+}
+
+export function formatDetectedObjects(clip: ClipResponse): string {
+  const detectedObjects = clip.detected_objects ?? []
+  if (detectedObjects.length === 0) {
+    return 'No objects detected'
+  }
+  return detectedObjects.join(', ')
+}
+
+export function formatActivityType(activityType: string | null | undefined): string {
+  const normalized = activityType?.trim()
+  if (!normalized) {
+    return 'Activity unavailable'
+  }
+  return normalized
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
 }
 
 function isHttpUrl(value: string | null | undefined): value is string {

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -351,6 +351,11 @@ a:hover {
   color: var(--text-secondary);
 }
 
+.section-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
 .camera-chip {
   display: inline-flex;
   align-items: center;
@@ -633,6 +638,35 @@ a:hover {
 .event-card__camera {
   margin: 0;
   font-weight: 600;
+}
+
+.events-results,
+.event-groups,
+.event-group,
+.event-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.events-results__header {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.event-group__title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.event-card__media-panel {
+  height: 100%;
+}
+
+.event-card__media-panel .media-panel__viewport {
+  height: 100%;
 }
 
 .clips-mobile-list {


### PR DESCRIPTION
## Ticket

- https://www.notion.so/35ad8336c59f81ddb0b1e0c5d6e705b9

## Scope

- Replaces the Events page's default table/mobile split with grouped, media-first event cards.
- Uses only existing clip list API fields: camera, created_at, summary, risk_level, activity_type, detected_objects, alerted, and status internally.
- Groups events by local date and keeps existing URL-synced filters plus cursor pagination.
- Hides raw clip IDs, storage handles, and raw processing status from the default list; IDs remain only in route hrefs for navigation.
- Uses a media placeholder because the existing list API does not provide thumbnails or media tokens.

## Stack

- Depends on https://github.com/lan17/homesec/pull/98.
- Base branch: `codex/m1-push-to-talk-primary`.

## UI Notes

- Desktop and mobile now render event cards as the normal review surface.
- Built-app smoke verified no default table rendered and storage URI text did not appear in the default event list.

## Checks

- `pnpm --dir ui exec vitest run src/features/clips/ClipsPage.test.tsx src/features/clips/presentation.test.ts src/features/clips/queryParams.test.ts src/features/clips/cursorState.test.ts`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui lint`
- `make ui-check`
- Built-app Playwright smoke against `ui/dist` for Events desktop/mobile

## Backend

- No backend routes, schemas, persistence, notification behavior, review state, thumbnail endpoints, event aggregation endpoints, or new event model fields were added.
