### PR TITLE
feat: refresh event detail view

### DIFF
--- a/ui/src/features/clips/ClipDetailPage.test.tsx
+++ b/ui/src/features/clips/ClipDetailPage.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import type { ClipListSnapshot } from '../../api/client'
+import type { ClipResponse } from '../../api/generated/types'
+import { QUERY_KEYS } from '../../api/hooks/queryKeys'
+import type { useClipMediaUrl } from '../../api/hooks/useClipMediaUrl'
+import type { useClipQuery } from '../../api/hooks/useClipQuery'
+import { ClipDetailPage } from './ClipDetailPage'
+import { parseClipsQuery } from './queryParams'
+
+const useClipQueryMock = vi.fn()
+const useClipMediaUrlMock = vi.fn()
+
+vi.mock('../../api/hooks/useClipQuery', () => ({
+  useClipQuery: (...args: unknown[]) => useClipQueryMock(...args),
+}))
+
+vi.mock('../../api/hooks/useClipMediaUrl', () => ({
+  useClipMediaUrl: (...args: unknown[]) => useClipMediaUrlMock(...args),
+}))
+
+function makeClip(id: string, overrides: Partial<ClipResponse> = {}): ClipResponse {
+  return {
+    id,
+    camera: 'front_door',
+    status: 'done',
+    created_at: '2026-02-14T18:30:00.000Z',
+    activity_type: 'package_drop',
+    risk_level: 'high',
+    summary: 'Package left near the front door.',
+    detected_objects: ['person', 'package'],
+    alerted: true,
+    storage_uri: `dropbox:/clips/${id}.mp4`,
+    view_url: `https://storage.example/${id}`,
+    ...overrides,
+  }
+}
+
+function renderDetail({
+  route = '/events/clip-2?detected=any',
+  clip = makeClip('clip-2'),
+  cachedClips,
+}: {
+  route?: string
+  clip?: ClipResponse
+  cachedClips?: ClipResponse[]
+} = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  if (cachedClips) {
+    const query = parseClipsQuery(new URLSearchParams('detected=any'))
+    queryClient.setQueryData<ClipListSnapshot>(QUERY_KEYS.clips(query), {
+      httpStatus: 200,
+      clips: cachedClips,
+      limit: 25,
+      next_cursor: null,
+      has_more: false,
+    })
+  }
+
+  useClipQueryMock.mockReturnValue({
+    data: clip,
+    isPending: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ReturnType<typeof useClipQuery>)
+
+  useClipMediaUrlMock.mockReturnValue({
+    mediaUrl: '/api/v1/clips/clip-2/media',
+    expiresAt: null,
+    usesToken: false,
+    isPending: false,
+    error: null,
+    refresh: vi.fn().mockResolvedValue('/api/v1/clips/clip-2/media'),
+  } as unknown as ReturnType<typeof useClipMediaUrl>)
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[route]}>
+        <Routes>
+          <Route path="/events/:clipId" element={<ClipDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ClipDetailPage', () => {
+  afterEach(() => {
+    cleanup()
+    useClipQueryMock.mockReset()
+    useClipMediaUrlMock.mockReset()
+  })
+
+  it('puts video, summary, and navigation ahead of technical metadata', () => {
+    // Given: A detail page opened from a loaded filtered event list
+    renderDetail({
+      cachedClips: [
+        makeClip('clip-1', { summary: 'Earlier package event.' }),
+        makeClip('clip-2'),
+        makeClip('clip-3', { summary: 'Next package event.' }),
+      ],
+    })
+
+    // When: Reading the refreshed detail page
+    const technicalSummary = screen.getByText('Technical event details')
+    const technicalDetails = technicalSummary.closest('details')
+
+    // Then: Core review information is prominent and list context is preserved
+    expect(screen.getByRole('heading', { name: 'Package Drop' })).toBeTruthy()
+    expect(screen.getByText('Package left near the front door.')).toBeTruthy()
+    expect(screen.getByText('person, package')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Back to events' }).getAttribute('href')).toBe(
+      '/events?detected=any',
+    )
+    expect(screen.getByRole('link', { name: 'Previous event' }).getAttribute('href')).toBe(
+      '/events/clip-1?detected=any',
+    )
+    expect(screen.getByRole('link', { name: 'Next event' }).getAttribute('href')).toBe(
+      '/events/clip-3?detected=any',
+    )
+    expect(technicalDetails?.hasAttribute('open')).toBe(false)
+    expect(technicalDetails ? within(technicalDetails).getByText('clip-2') : null).toBeTruthy()
+    expect(technicalDetails ? within(technicalDetails).getByText('dropbox:/clips/clip-2.mp4') : null).toBeTruthy()
+  })
+
+  it('disables previous and next controls when no client result window is loaded', () => {
+    // Given: A user opens an event detail URL directly
+    renderDetail()
+
+    // When: There is no clips query cache containing the current event
+    const previous = screen.getByText('Previous event')
+    const next = screen.getByText('Next event')
+
+    // Then: The page does not call a backend neighbor endpoint or invent navigation
+    expect(previous.getAttribute('aria-disabled')).toBe('true')
+    expect(next.getAttribute('aria-disabled')).toBe('true')
+  })
+})

--- a/ui/src/features/clips/ClipDetailPage.tsx
+++ b/ui/src/features/clips/ClipDetailPage.tsx
@@ -1,16 +1,30 @@
-import { useEffect, useRef } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useEffect, useMemo, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Link, useLocation, useParams } from 'react-router-dom'
 
-import { clearApiKey, isUnauthorizedAPIError, saveApiKey } from '../../api/client'
+import {
+  clearApiKey,
+  isUnauthorizedAPIError,
+  saveApiKey,
+  type ClipListSnapshot,
+} from '../../api/client'
+import type { ClipResponse, ListClipsQuery } from '../../api/generated/types'
 import { useClipMediaUrl } from '../../api/hooks/useClipMediaUrl'
 import { useClipQuery } from '../../api/hooks/useClipQuery'
+import { QUERY_KEYS } from '../../api/hooks/queryKeys'
 import { ApiKeyGate } from '../../components/ui/ApiKeyGate'
 import { Button } from '../../components/ui/Button'
-import { Card } from '../../components/ui/Card'
+import { EmptyState } from '../../components/ui/EmptyState'
+import { MediaPanel } from '../../components/ui/MediaPanel'
+import { RiskBadge } from '../../components/ui/RiskBadge'
+import { StatusBadge } from '../../components/ui/StatusBadge'
+import { TechnicalDetailsDisclosure } from '../../components/ui/TechnicalDetailsDisclosure'
 import {
   describeClipError,
+  formatActivityType,
+  formatDetectedObjects,
+  formatEventTime,
   formatTimestamp,
-  renderDetectedObjects,
   resolveClipExternalLink,
   resolveClipViewLink,
 } from './presentation'
@@ -18,15 +32,82 @@ import {
   nextAttemptsAfterMediaSourceChange,
   shouldRefreshPlaybackSource,
 } from './playbackRetry'
+import { parseClipsQuery } from './queryParams'
+
+interface NeighborEvents {
+  previous: ClipResponse | null
+  next: ClipResponse | null
+}
+
+function eventDetailPath(clipId: string, routeSearch: string): string {
+  return `/events/${encodeURIComponent(clipId)}${routeSearch}`
+}
+
+function eventListPath(routeSearch: string): string {
+  return `/events${routeSearch}`
+}
+
+function findClipWindow(
+  queryClient: ReturnType<typeof useQueryClient>,
+  currentClipId: string | undefined,
+  query: ListClipsQuery,
+): ClipResponse[] {
+  if (!currentClipId) {
+    return []
+  }
+
+  const preferredWindow = queryClient.getQueryData<ClipListSnapshot>(
+    QUERY_KEYS.clips(query),
+  )?.clips
+  if (preferredWindow?.some((clip) => clip.id === currentClipId)) {
+    return preferredWindow
+  }
+
+  const cachedWindows = queryClient.getQueriesData<ClipListSnapshot>({ queryKey: ['clips'] })
+  for (const [, data] of cachedWindows) {
+    if (data?.clips.some((clip) => clip.id === currentClipId)) {
+      return data.clips
+    }
+  }
+
+  return []
+}
+
+function findNeighbors(clips: readonly ClipResponse[], currentClipId: string | undefined): NeighborEvents {
+  const currentIndex = clips.findIndex((clip) => clip.id === currentClipId)
+  if (currentIndex < 0) {
+    return { previous: null, next: null }
+  }
+
+  return {
+    previous: clips[currentIndex - 1] ?? null,
+    next: clips[currentIndex + 1] ?? null,
+  }
+}
 
 export function ClipDetailPage() {
   const { clipId } = useParams<{ clipId: string }>()
+  const location = useLocation()
+  const queryClient = useQueryClient()
   const clipQuery = useClipQuery(clipId)
   const mediaQuery = useClipMediaUrl(clipId)
   const unauthorized = isUnauthorizedAPIError(clipQuery.error)
   const clip = clipQuery.data
   const externalLink = clip ? resolveClipExternalLink(clip) : null
   const viewUrlLink = clip ? resolveClipViewLink(clip) : null
+  const externalStorageLink = externalLink && externalLink !== viewUrlLink ? externalLink : null
+  const listQuery = useMemo(
+    () => parseClipsQuery(new URLSearchParams(location.search)),
+    [location.search],
+  )
+  const clipWindow = useMemo(
+    () => findClipWindow(queryClient, clipId, listQuery),
+    [clipId, listQuery, queryClient],
+  )
+  const neighbors = useMemo(
+    () => findNeighbors(clipWindow, clipId),
+    [clipId, clipWindow],
+  )
   const playbackRefreshAttempts = useRef(0)
   const previousMediaUrl = useRef<string | null>(null)
 
@@ -72,7 +153,9 @@ export function ClipDetailPage() {
       <header className="page__header">
         <div>
           <h1 className="page__title">Event Detail</h1>
-          <p className="page__lead">Event ID: {clipId ?? 'unknown'}</p>
+          <p className="page__lead">
+            {clip ? `${clip.camera} - ${formatTimestamp(clip.created_at)}` : 'Recorded security event'}
+          </p>
         </div>
         <Button variant="ghost" onClick={refreshClip} disabled={clipQuery.isFetching || !clipId}>
           {clipQuery.isFetching ? 'Refreshing...' : 'Refresh'}
@@ -80,39 +163,52 @@ export function ClipDetailPage() {
       </header>
 
       {!clipId ? (
-        <Card title="Invalid event request">
-          <p className="error-text">Missing event ID in route.</p>
-          <p className="muted">
-            Return to <Link to="/events">events list</Link>.
-          </p>
-        </Card>
+        <EmptyState
+          title="Invalid event request"
+          description={(
+            <>
+              Missing event ID. Return to <Link to={eventListPath(location.search)}>events</Link>.
+            </>
+          )}
+          tone="error"
+        />
       ) : null}
 
       {clipQuery.isPending ? (
-        <Card title="Loading event">
-          <p className="muted">Fetching event metadata...</p>
-        </Card>
+        <EmptyState
+          title="Loading event"
+          description="Fetching event video and metadata."
+          tone="loading"
+        />
       ) : null}
 
       {unauthorized ? (
-        <Card title="Authentication required">
+        <section className="auth-panel" aria-label="Authentication required">
           <ApiKeyGate
             busy={clipQuery.isFetching}
             onSubmit={submitApiKey}
             onClear={clearStoredApiKey}
           />
-        </Card>
+        </section>
       ) : null}
 
       {clipQuery.error && !unauthorized ? (
-        <Card title="Event query failed">
-          <p className="error-text">{describeClipError(clipQuery.error)}</p>
-        </Card>
+        <EmptyState
+          title="Event could not load"
+          description={describeClipError(clipQuery.error)}
+          tone="error"
+        />
       ) : null}
 
       {clip ? (
-        <>
-          <Card title="Event video" subtitle="Primary playback is served by HomeSec /media">
+        <div className="clip-detail-layout">
+          <MediaPanel
+            title="Event video"
+            subtitle={`${clip.camera} at ${formatEventTime(clip.created_at)}`}
+            status={<RiskBadge level={clip.risk_level} />}
+            aspect="video"
+            className="clip-detail-media"
+          >
             <div className="clip-detail-video-shell">
               {mediaQuery.isPending ? (
                 <p className="muted">Preparing secure playback URL...</p>
@@ -132,91 +228,125 @@ export function ClipDetailPage() {
                 <p className="muted">Event media is not available for playback.</p>
               )}
             </div>
+          </MediaPanel>
 
+          <section className="clip-detail-summary" aria-label="Event summary">
             {mediaQuery.error ? (
               <p className="error-text">{describeClipError(mediaQuery.error)}</p>
             ) : null}
+            <div className="clip-detail-summary__header">
+              <div>
+                <p className="clip-detail-eyebrow">{clip.camera}</p>
+                <h2 className="clip-detail-heading">
+                  {formatActivityType(clip.activity_type)}
+                </h2>
+              </div>
+              <StatusBadge tone={clip.alerted ? 'unhealthy' : 'unknown'}>
+                {clip.alerted ? 'Alert sent' : 'No alert'}
+              </StatusBadge>
+            </div>
+            <p className="clip-detail-summary__text">
+              {clip.summary?.trim() || 'No summary available yet.'}
+            </p>
 
             <div className="clip-detail-actions">
-              {externalLink ? (
-                <a
-                  className="button button--primary"
-                  href={externalLink}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  Open in storage
-                </a>
-              ) : null}
-              <Link className="button button--ghost" to="/events">
+              <Link className="button button--ghost" to={eventListPath(location.search)}>
                 Back to events
               </Link>
+              {neighbors.previous ? (
+                <Link
+                  className="button button--ghost"
+                  to={eventDetailPath(neighbors.previous.id, location.search)}
+                >
+                  Previous event
+                </Link>
+              ) : (
+                <span className="button button--ghost button--disabled" aria-disabled="true">
+                  Previous event
+                </span>
+              )}
+              {neighbors.next ? (
+                <Link
+                  className="button button--primary"
+                  to={eventDetailPath(neighbors.next.id, location.search)}
+                >
+                  Next event
+                </Link>
+              ) : (
+                <span className="button button--primary button--disabled" aria-disabled="true">
+                  Next event
+                </span>
+              )}
             </div>
-            <div className="clip-detail-link-list">
-              <p className="muted">
-                <strong>view_url:</strong>{' '}
-                {viewUrlLink ? (
-                  <a href={viewUrlLink} target="_blank" rel="noreferrer noopener">
-                    {viewUrlLink}
-                  </a>
-                ) : (
-                  'not available'
-                )}
-              </p>
-              <p className="muted clip-detail-mono">
-                <strong>storage_uri:</strong> {clip.storage_uri ?? 'not available'}
-              </p>
-            </div>
-          </Card>
 
-          <div className="clip-detail-grid">
-            <Card title="Analysis" subtitle="VLM + detection fields from API">
+            <section className="clip-detail-section" aria-labelledby="event-ai-metadata">
+              <h3 id="event-ai-metadata" className="section-title">AI metadata</h3>
               <dl className="clip-detail-kv">
                 <div className="clip-detail-kv-row">
-                  <dt>Summary</dt>
-                  <dd>{clip.summary ?? 'not available'}</dd>
+                  <dt>Activity</dt>
+                  <dd>{formatActivityType(clip.activity_type)}</dd>
                 </div>
                 <div className="clip-detail-kv-row">
-                  <dt>Activity Type</dt>
-                  <dd>{clip.activity_type ?? 'not available'}</dd>
-                </div>
-                <div className="clip-detail-kv-row">
-                  <dt>Risk Level</dt>
+                  <dt>Risk</dt>
                   <dd>{clip.risk_level ?? 'not available'}</dd>
                 </div>
                 <div className="clip-detail-kv-row">
                   <dt>Detected Objects</dt>
-                  <dd>{renderDetectedObjects(clip)}</dd>
+                  <dd>{formatDetectedObjects(clip)}</dd>
                 </div>
                 <div className="clip-detail-kv-row">
-                  <dt>Alerted</dt>
-                  <dd>{clip.alerted ? 'true' : 'false'}</dd>
-                </div>
-              </dl>
-            </Card>
-
-            <Card title="Metadata">
-              <dl className="clip-detail-kv">
-                <div className="clip-detail-kv-row">
-                  <dt>ID</dt>
-                  <dd className="clip-detail-mono">{clip.id}</dd>
-                </div>
-                <div className="clip-detail-kv-row">
-                  <dt>Camera</dt>
-                  <dd>{clip.camera}</dd>
-                </div>
-                <div className="clip-detail-kv-row">
-                  <dt>Status</dt>
-                  <dd>{clip.status}</dd>
-                </div>
-                <div className="clip-detail-kv-row">
-                  <dt>Created At</dt>
+                  <dt>Time</dt>
                   <dd>{formatTimestamp(clip.created_at)}</dd>
                 </div>
               </dl>
-            </Card>
-          </div>
-        </>
+            </section>
+
+            <TechnicalDetailsDisclosure summary="Technical event details">
+              <dl className="clip-detail-kv">
+                <div className="clip-detail-kv-row">
+                  <dt>Event ID</dt>
+                  <dd className="clip-detail-mono">{clip.id}</dd>
+                </div>
+                <div className="clip-detail-kv-row">
+                  <dt>Processing Status</dt>
+                  <dd>{clip.status}</dd>
+                </div>
+                <div className="clip-detail-kv-row">
+                  <dt>Storage URI</dt>
+                  <dd className="clip-detail-mono">{clip.storage_uri ?? 'not available'}</dd>
+                </div>
+                <div className="clip-detail-kv-row">
+                  <dt>View URL</dt>
+                  <dd>
+                    {viewUrlLink ? (
+                      <a href={viewUrlLink} target="_blank" rel="noreferrer noopener">
+                        Open external view
+                      </a>
+                    ) : (
+                      'not available'
+                    )}
+                  </dd>
+                </div>
+                <div className="clip-detail-kv-row">
+                  <dt>Playback Source</dt>
+                  <dd>{mediaQuery.usesToken ? 'Tokenized media URL' : 'Direct media endpoint'}</dd>
+                </div>
+                <div className="clip-detail-kv-row">
+                  <dt>External Storage Link</dt>
+                  <dd>
+                    {externalStorageLink ? (
+                      <a href={externalStorageLink} target="_blank" rel="noreferrer noopener">
+                        Open external link
+                      </a>
+                    ) : (
+                      'not available'
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </TechnicalDetailsDisclosure>
+          </section>
+        </div>
       ) : null}
     </section>
   )

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -711,6 +711,57 @@ a:hover {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
+.clip-detail-layout,
+.clip-detail-summary,
+.clip-detail-section {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.clip-detail-media .media-panel__viewport {
+  background: #000;
+}
+
+.clip-detail-summary {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-elevated);
+  padding: var(--space-4);
+}
+
+.clip-detail-summary__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.clip-detail-eyebrow {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+.clip-detail-heading {
+  margin: 0.2rem 0 0;
+  font-size: 1.25rem;
+}
+
+.clip-detail-summary__text {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.auth-panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-elevated);
+  padding: var(--space-4);
+}
+
 .form-checkbox-field {
   display: flex;
   align-items: center;
@@ -1203,10 +1254,10 @@ a:hover {
 }
 
 .clip-detail-video-shell {
-  margin-bottom: var(--space-3);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--surface-1) 72%, transparent);
+  display: grid;
+  min-height: 100%;
+  place-items: center;
+  background: #000;
   overflow: hidden;
 }
 
@@ -1296,6 +1347,12 @@ a:hover {
 
 .button--ghost:hover:not(:disabled) {
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.button--disabled,
+.button--disabled:hover {
+  opacity: 0.56;
+  pointer-events: none;
 }
 
 .status-badge {


### PR DESCRIPTION
## Ticket

- https://www.notion.so/35ad8336c59f81b0b931c47c77cc489f

## Scope

- Reorders event detail around video first, then camera/time, summary, risk, alert status, and AI metadata.
- Adds previous/next navigation from already-loaded client clip list results in React Query cache.
- Preserves filtered list context in Back/Previous/Next links where it exists.
- Moves raw event ID, processing status, storage URI, view URL, and playback source notes into a collapsed technical details disclosure.
- Keeps media playback on the existing clip media URL/token hook.

## Stack

- Depends on https://github.com/lan17/homesec/pull/99.
- Base branch: `codex/m1-events-card-list`.

## UI Notes

- Direct detail URLs render disabled previous/next controls when no client result window is loaded.
- Built-app smoke verified list-to-detail navigation on desktop and mobile with cached previous/next links.

## Checks

- `pnpm --dir ui exec vitest run src/features/clips/ClipDetailPage.test.tsx src/features/clips/playbackRetry.test.ts src/features/clips/presentation.test.ts`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui lint`
- `make ui-check`
- Built-app Playwright smoke against `ui/dist` for Events list to Event detail on desktop/mobile

## Backend

- No backend routes, event-neighbor endpoint, review/dismiss state, alert triage workflow, schema changes, or media API changes were added.
