### PR TITLE
feat: harden mobile home security flows

### DIFF
--- a/ui/src/app/layout/AppShell.test.tsx
+++ b/ui/src/app/layout/AppShell.test.tsx
@@ -55,7 +55,9 @@ describe('AppShell navigation', () => {
     expect(within(primaryNav).getByRole('link', { name: 'Cameras' })).toBeTruthy()
     expect(within(primaryNav).getByRole('link', { name: 'Settings' })).toBeTruthy()
     expect(within(primaryNav).getByRole('link', { name: 'System' })).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'System OK' }).getAttribute('href')).toBe('/system')
+    const systemStatus = screen.getByRole('link', { name: 'System OK' })
+    expect(systemStatus.getAttribute('href')).toBe('/system')
+    expect(systemStatus.className).toContain('app-shell__header-status--nominal')
   })
 
   it('keeps System out of mobile bottom navigation', () => {

--- a/ui/src/app/layout/AppShell.tsx
+++ b/ui/src/app/layout/AppShell.tsx
@@ -39,6 +39,9 @@ function systemStatusText(status: string | undefined, isError: boolean): string 
 export function AppShell() {
   const { theme, toggleTheme } = useTheme()
   const healthQuery = useHealthQuery()
+  const systemStatusClassName = !healthQuery.isError && healthQuery.data?.status === 'healthy'
+    ? 'app-shell__header-status app-shell__header-status--nominal'
+    : 'app-shell__header-status'
 
   return (
     <div className="app-shell">
@@ -57,7 +60,7 @@ export function AppShell() {
 
       <div className="app-shell__main">
         <header className="app-shell__header">
-          <NavLink className="app-shell__header-status" to="/system">
+          <NavLink className={systemStatusClassName} to="/system">
             {systemStatusText(healthQuery.data?.status, healthQuery.isError)}
           </NavLink>
           <button type="button" className="button button--ghost" onClick={toggleTheme}>

--- a/ui/src/features/cameras/components/CameraPreviewPanel.tsx
+++ b/ui/src/features/cameras/components/CameraPreviewPanel.tsx
@@ -435,6 +435,9 @@ export function CameraPreviewPanel({
               }}
             >
               <span className="camera-preview__fullscreen-icon" aria-hidden="true" />
+              <span className="camera-preview__fullscreen-label">
+                {isPreviewFullscreen ? 'Exit' : 'Fullscreen'}
+              </span>
             </button>
           </>
         ) : (

--- a/ui/src/features/live/LiveCameraCard.tsx
+++ b/ui/src/features/live/LiveCameraCard.tsx
@@ -1,6 +1,7 @@
 import { createSearchParams, Link } from 'react-router-dom'
 
 import type { CameraResponse } from '../../api/generated/types'
+import { Button } from '../../components/ui/Button'
 import { CameraCard } from '../../components/ui/CameraCard'
 import { MediaPanel } from '../../components/ui/MediaPanel'
 import { StatusBadge, type StatusBadgeTone } from '../../components/ui/StatusBadge'
@@ -9,6 +10,9 @@ import { CameraPreviewPanel } from '../cameras/components/CameraPreviewPanel'
 
 interface LiveCameraCardProps {
   camera: CameraResponse
+  isCompactViewport?: boolean
+  isFocused?: boolean
+  onFocusCamera?: (cameraName: string) => void
 }
 
 function cameraStatusTone(camera: CameraResponse): StatusBadgeTone {
@@ -40,8 +44,33 @@ function canShowPreview(camera: CameraResponse): boolean {
   return camera.enabled && camera.source_backend === 'rtsp'
 }
 
-function renderPreview(camera: CameraResponse) {
+function renderPreview({
+  camera,
+  isCompactViewport = false,
+  isFocused = false,
+  onFocusCamera,
+}: LiveCameraCardProps) {
   if (canShowPreview(camera)) {
+    if (isCompactViewport && !isFocused) {
+      return (
+        <MediaPanel
+          title="Preview"
+          subtitle="Open one camera at a time on mobile."
+          actions={
+            <Button
+              variant="ghost"
+              onClick={() => {
+                onFocusCamera?.(camera.name)
+              }}
+            >
+              Open live view
+            </Button>
+          }
+          placeholder="Open live view to start preview controls."
+        />
+      )
+    }
+
     return (
       <CameraPreviewPanel
         cameraName={camera.name}
@@ -64,7 +93,8 @@ function renderPreview(camera: CameraResponse) {
   )
 }
 
-export function LiveCameraCard({ camera }: LiveCameraCardProps) {
+export function LiveCameraCard(props: LiveCameraCardProps) {
+  const { camera } = props
   return (
     <CameraCard
       title={camera.name}
@@ -73,7 +103,7 @@ export function LiveCameraCard({ camera }: LiveCameraCardProps) {
           {cameraStatusLabel(camera)}
         </StatusBadge>
       }
-      media={renderPreview(camera)}
+      media={renderPreview(props)}
       meta={[
         { label: 'Last seen', value: formatLastSeen(camera.last_heartbeat) },
       ]}

--- a/ui/src/features/live/LivePage.test.tsx
+++ b/ui/src/features/live/LivePage.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 
 import type { CameraResponse } from '../../api/generated/types'
@@ -63,8 +64,26 @@ function renderLivePage(cameras: CameraResponse[]) {
   )
 }
 
+function setCompactViewport(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
 describe('LivePage camera cards', () => {
   beforeEach(() => {
+    setCompactViewport(false)
     useCamerasQueryMock.mockReset()
     useSetupRedirectMock.mockReset()
   })
@@ -114,5 +133,25 @@ describe('LivePage camera cards', () => {
         : null,
     ).toBeTruthy()
     expect(screen.queryByTestId('preview-dropbox_uploads')).toBeNull()
+  })
+
+  it('keeps only one live preview panel focused on compact viewports', async () => {
+    // Given: A mobile viewport with multiple RTSP cameras
+    const user = userEvent.setup()
+    setCompactViewport(true)
+    renderLivePage([
+      makeCamera({ name: 'front_door' }),
+      makeCamera({ name: 'driveway' }),
+    ])
+
+    // When: The compact Live view renders and the homeowner switches cameras
+    expect(await screen.findByTestId('preview-front_door')).toBeTruthy()
+    expect(screen.queryByTestId('preview-driveway')).toBeNull()
+    await user.click(screen.getByRole('button', { name: 'Open live view' }))
+
+    // Then: Only the selected camera exposes preview controls
+    expect(await screen.findByTestId('preview-driveway')).toBeTruthy()
+    expect(screen.queryByTestId('preview-front_door')).toBeNull()
+    expect(screen.getByText('Open live view to start preview controls.')).toBeTruthy()
   })
 })

--- a/ui/src/features/live/LivePage.tsx
+++ b/ui/src/features/live/LivePage.tsx
@@ -1,5 +1,7 @@
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import type { CameraResponse } from '../../api/generated/types'
 import { clearApiKey, isUnauthorizedAPIError, saveApiKey } from '../../api/client'
 import { useCamerasQuery } from '../../api/hooks/useCamerasQuery'
 import { ApiKeyGate } from '../../components/ui/ApiKeyGate'
@@ -10,12 +12,22 @@ import { ResponsivePageShell } from '../../components/ui/ResponsivePageShell'
 import { describeCameraError } from '../cameras/presentation'
 import { useSetupRedirect } from '../setup/useSetupRedirect'
 import { LiveCameraCard } from './LiveCameraCard'
+import { useCompactViewport } from './useCompactViewport'
+
+const EMPTY_CAMERAS: CameraResponse[] = []
 
 export function LivePage() {
   const { shouldRedirect, isChecking } = useSetupRedirect()
   const camerasQuery = useCamerasQuery()
-  const cameras = camerasQuery.data ?? []
+  const cameras = camerasQuery.data ?? EMPTY_CAMERAS
   const unauthorized = isUnauthorizedAPIError(camerasQuery.error)
+  const isCompactViewport = useCompactViewport()
+  const cameraNames = useMemo(() => cameras.map((camera) => camera.name), [cameras])
+  const [selectedCameraName, setSelectedCameraName] = useState<string | null>(null)
+  const focusedCameraName =
+    selectedCameraName && cameraNames.includes(selectedCameraName)
+      ? selectedCameraName
+      : cameraNames[0] ?? null
 
   if (isChecking || shouldRedirect) {
     return null
@@ -84,7 +96,13 @@ export function LivePage() {
       {cameras.length > 0 ? (
         <div className="live-camera-list">
           {cameras.map((camera) => (
-            <LiveCameraCard key={camera.name} camera={camera} />
+            <LiveCameraCard
+              key={camera.name}
+              camera={camera}
+              isCompactViewport={isCompactViewport}
+              isFocused={focusedCameraName === camera.name}
+              onFocusCamera={setSelectedCameraName}
+            />
           ))}
         </div>
       ) : null}

--- a/ui/src/features/live/useCompactViewport.ts
+++ b/ui/src/features/live/useCompactViewport.ts
@@ -1,0 +1,40 @@
+import { useCallback, useSyncExternalStore } from 'react'
+
+export const COMPACT_VIEWPORT_QUERY = '(max-width: 620px)'
+
+function matchesQuery(query: string): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return false
+  }
+  return window.matchMedia(query).matches
+}
+
+export function useCompactViewport(query = COMPACT_VIEWPORT_QUERY): boolean {
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return () => {}
+    }
+
+    const mediaQuery = window.matchMedia(query)
+    const handleChange = (): void => {
+      onStoreChange()
+    }
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange)
+      return () => {
+        mediaQuery.removeEventListener('change', handleChange)
+      }
+    }
+
+    mediaQuery.addListener(handleChange)
+    return () => {
+      mediaQuery.removeListener(handleChange)
+    }
+  }, [query])
+
+  const getSnapshot = useCallback(() => matchesQuery(query), [query])
+  const getServerSnapshot = useCallback(() => false, [])
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/ui/src/styles/global.css
+++ b/ui/src/styles/global.css
@@ -412,7 +412,7 @@ a:hover {
 }
 
 .filter-chip {
-  min-height: 2.35rem;
+  min-height: 2.75rem;
   border: 1px solid var(--line);
   border-radius: 999px;
   background: color-mix(in srgb, var(--surface-1) 76%, transparent);
@@ -501,6 +501,9 @@ a:hover {
 
 .technical-details__summary {
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  min-height: 2.75rem;
   padding: 0.65rem 0.75rem;
   color: var(--text-secondary);
   font-family: var(--font-mono);
@@ -1047,15 +1050,17 @@ a:hover {
   right: 0.65rem;
   bottom: 0.65rem;
   z-index: 1;
-  display: grid;
-  place-items: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
   border: 1px solid rgb(255 255 255 / 48%);
   border-radius: var(--radius-sm);
   background: rgb(0 0 0 / 58%);
   color: #fff;
   cursor: pointer;
+  padding: 0.52rem 0.7rem;
 }
 
 .camera-preview__fullscreen-button:hover {
@@ -1069,6 +1074,7 @@ a:hover {
 
 .camera-preview__fullscreen-icon {
   display: block;
+  flex: 0 0 auto;
   width: 1rem;
   height: 1rem;
   background:
@@ -1080,6 +1086,11 @@ a:hover {
     linear-gradient(currentColor, currentColor) left bottom / 0.12rem 0.45rem no-repeat,
     linear-gradient(currentColor, currentColor) right bottom / 0.45rem 0.12rem no-repeat,
     linear-gradient(currentColor, currentColor) right bottom / 0.12rem 0.45rem no-repeat;
+}
+
+.camera-preview__fullscreen-label {
+  font-size: 0.78rem;
+  font-weight: 700;
 }
 
 .camera-preview__placeholder {
@@ -1332,6 +1343,10 @@ a:hover {
 }
 
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
   border-radius: var(--radius-sm);
   border: 1px solid transparent;
   font-family: inherit;
@@ -1344,6 +1359,7 @@ a:hover {
     background-color var(--duration-fast) ease,
     color var(--duration-fast) ease;
   padding: 0.54rem 0.9rem;
+  text-align: center;
 }
 
 .button:disabled {
@@ -1471,6 +1487,14 @@ a:hover {
     margin-bottom: 0;
   }
 
+  .app-shell__header {
+    align-items: stretch;
+  }
+
+  .app-shell__header-status--nominal {
+    display: none;
+  }
+
   .app-shell__content {
     padding-bottom: calc(var(--space-7) + 4.5rem);
   }
@@ -1495,7 +1519,7 @@ a:hover {
   .mobile-nav-link {
     display: grid;
     place-items: center;
-    min-height: 2.8rem;
+    min-height: 3rem;
     border: 1px solid transparent;
     border-radius: var(--radius-sm);
     color: var(--text-secondary);
@@ -1537,6 +1561,23 @@ a:hover {
 
   .camera-form-grid {
     grid-template-columns: 1fr;
+  }
+
+  .inline-form__actions,
+  .camera-card__actions,
+  .event-card__actions,
+  .clip-detail-actions,
+  .push-to-talk__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .inline-form__actions .button,
+  .camera-card__actions .button,
+  .event-card__actions .button,
+  .clip-detail-actions .button,
+  .push-to-talk__actions .button {
+    width: 100%;
   }
 
   .clips-table-wrap {


### PR DESCRIPTION
## Ticket
- https://www.notion.so/35ad8336c59f811cb1b4e22a3fd0bb59

## Scope
- Keeps mobile Live focused on one preview-control surface at a time while preserving desktop multi-card behavior.
- Adds a compact viewport hook for frontend-only responsive behavior.
- Hides the nominal `System OK` shortcut on mobile while keeping non-nominal system states available as a compact entry point.
- Makes core mobile touch targets larger across buttons, filter chips, technical disclosures, bottom nav, push-to-talk actions, event actions, and camera actions.
- Makes the live preview fullscreen control visibly labeled and mobile-sized instead of relying on the icon alone.

## Stack
- Stacked on https://github.com/lan17/homesec/pull/101.
- Depends on the Live cards, Events cards, event detail, and quick-filter sheet work from the earlier M1 PRs.

## UI Notes
- Mobile Live defaults to the first camera card and asks the homeowner to open another live view before rendering that camera's preview controls.
- Events keeps the quick filters, bottom-sheet advanced filters, and list-to-detail flow from the previous stack.
- System remains out of the mobile bottom nav; healthy status is nested away by default, while degraded/unavailable/checking states can still surface in the shell header.

## Checks
- `pnpm --dir ui exec vitest run src/features/live/LivePage.test.tsx src/app/layout/AppShell.test.tsx src/features/cameras/components/CameraPreviewPanel.test.tsx`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui lint`
- `make ui-check`
- Built app mobile smoke with mocked existing APIs for Live focus switching, Events quick-filter sheet open/close, and Events list -> detail -> back flow.
- GitHub CI passed.
- Codecov patch passed and reports all modified coverable lines covered; Codecov project remains red on a repo-wide `87.18% -> 87.16%` delta with unchanged Python line count.

## Backend Scope
- No backend routes, schema changes, persistence changes, review state, notification behavior, new health fields, or new media APIs were added.