### PR TITLE
feat: split settings system health

### DIFF
--- a/ui/src/app/layout/AppShell.test.tsx
+++ b/ui/src/app/layout/AppShell.test.tsx
@@ -4,18 +4,35 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, screen, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 
+import type { CameraResponse } from '../../api/generated/types'
 import { ThemeProvider } from '../providers/ThemeProvider'
 import { AppShell } from './AppShell'
 
 const useHealthQueryMock = vi.fn()
+const useCamerasQueryMock = vi.fn()
 
 vi.mock('../../api/hooks/useHealthQuery', () => ({
   useHealthQuery: () => useHealthQueryMock(),
 }))
 
-function renderShell(path = '/live') {
+vi.mock('../../api/hooks/useCamerasQuery', () => ({
+  useCamerasQuery: () => useCamerasQueryMock(),
+}))
+
+function renderShell(
+  path = '/live',
+  {
+    cameras = [],
+  }: {
+    cameras?: CameraResponse[]
+  } = {},
+) {
   useHealthQueryMock.mockReturnValue({
     data: { status: 'healthy' },
+    isError: false,
+  })
+  useCamerasQueryMock.mockReturnValue({
+    data: cameras,
     isError: false,
   })
 
@@ -40,6 +57,7 @@ describe('AppShell navigation', () => {
   afterEach(() => {
     cleanup()
     useHealthQueryMock.mockReset()
+    useCamerasQueryMock.mockReset()
   })
 
   it('renders homeowner-first desktop navigation with System available', () => {
@@ -73,5 +91,28 @@ describe('AppShell navigation', () => {
     expect(within(mobileNav).getByRole('link', { name: 'Cameras' })).toBeTruthy()
     expect(within(mobileNav).getByRole('link', { name: 'Settings' })).toBeTruthy()
     expect(within(mobileNav).queryByRole('link', { name: 'System' })).toBeNull()
+  })
+
+  it('surfaces offline camera issues in the compact system status', () => {
+    // Given: The shell has one enabled unhealthy camera from the existing camera list API
+    renderShell('/live', {
+      cameras: [
+        {
+          name: 'front',
+          enabled: true,
+          healthy: false,
+          last_heartbeat: 1_739_590_400,
+          source_backend: 'rtsp',
+          source_config: {},
+        },
+      ],
+    })
+
+    // When: The shell status is rendered
+    const systemStatus = screen.getByRole('link', { name: '1 camera offline' })
+
+    // Then: The non-nominal camera state stays visible instead of being hidden as System OK
+    expect(systemStatus.getAttribute('href')).toBe('/system')
+    expect(systemStatus.className).not.toContain('app-shell__header-status--nominal')
   })
 })

--- a/ui/src/app/layout/AppShell.tsx
+++ b/ui/src/app/layout/AppShell.tsx
@@ -1,7 +1,9 @@
 import { NavLink, Outlet } from 'react-router-dom'
 
+import { useCamerasQuery } from '../../api/hooks/useCamerasQuery'
 import { useHealthQuery } from '../../api/hooks/useHealthQuery'
 import { MobileBottomNav, type MobileBottomNavLink } from '../../components/ui/MobileBottomNav'
+import { cameraIssueSummary } from '../../features/cameras/cameraHealth'
 import { useTheme } from '../providers/theme-context'
 
 const DESKTOP_NAV_LINKS = [
@@ -39,7 +41,10 @@ function systemStatusText(status: string | undefined, isError: boolean): string 
 export function AppShell() {
   const { theme, toggleTheme } = useTheme()
   const healthQuery = useHealthQuery()
-  const systemStatusClassName = !healthQuery.isError && healthQuery.data?.status === 'healthy'
+  const camerasQuery = useCamerasQuery()
+  const cameraIssue = cameraIssueSummary(camerasQuery.data)
+  const systemStatus = cameraIssue ?? systemStatusText(healthQuery.data?.status, healthQuery.isError)
+  const systemStatusClassName = !cameraIssue && !healthQuery.isError && healthQuery.data?.status === 'healthy'
     ? 'app-shell__header-status app-shell__header-status--nominal'
     : 'app-shell__header-status'
 
@@ -61,7 +66,7 @@ export function AppShell() {
       <div className="app-shell__main">
         <header className="app-shell__header">
           <NavLink className={systemStatusClassName} to="/system">
-            {systemStatusText(healthQuery.data?.status, healthQuery.isError)}
+            {systemStatus}
           </NavLink>
           <button type="button" className="button button--ghost" onClick={toggleTheme}>
             Theme: {theme === 'dark' ? 'Dark' : 'Light'}

--- a/ui/src/features/cameras/CamerasPage.test.tsx
+++ b/ui/src/features/cameras/CamerasPage.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 
 import type { RuntimeStatusSnapshot } from '../../api/client'
 import type { CameraResponse } from '../../api/generated/types'
@@ -124,7 +125,11 @@ function setupPage({
     errors: { create: null, update: null, delete: null, reload: null },
   } as unknown as ReturnType<typeof useCameraActions>)
 
-  render(<CamerasPage />)
+  render(
+    <MemoryRouter initialEntries={['/cameras']}>
+      <CamerasPage />
+    </MemoryRouter>,
+  )
 
   return {
     createCamera,

--- a/ui/src/features/cameras/cameraHealth.test.ts
+++ b/ui/src/features/cameras/cameraHealth.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CameraResponse } from '../../api/generated/types'
+import {
+  cameraHealthLabel,
+  cameraHealthTone,
+  cameraIssueSummary,
+  countOfflineCameras,
+  formatLastSeen,
+} from './cameraHealth'
+
+function makeCamera(overrides: Partial<CameraResponse> = {}): CameraResponse {
+  return {
+    name: 'front_door',
+    enabled: true,
+    healthy: true,
+    last_heartbeat: 1_770_000_000,
+    source_backend: 'rtsp',
+    source_config: {},
+    ...overrides,
+  }
+}
+
+describe('cameraHealth presentation helpers', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('derives simple homeowner labels from existing camera fields only', () => {
+    // Given: Cameras with the existing enabled and healthy fields
+    const online = makeCamera()
+    const disabled = makeCamera({ enabled: false, healthy: false })
+    const offline = makeCamera({ enabled: true, healthy: false })
+
+    // When: Labels and badge tones are derived
+    const labels = [
+      cameraHealthLabel(online),
+      cameraHealthLabel(disabled),
+      cameraHealthLabel(offline),
+    ]
+
+    // Then: The UI uses only simple M1 health states
+    expect(labels).toEqual(['Online', 'Disabled', 'Offline'])
+    expect(cameraHealthTone(online)).toBe('healthy')
+    expect(cameraHealthTone(disabled)).toBe('unknown')
+    expect(cameraHealthTone(offline)).toBe('unhealthy')
+  })
+
+  it('counts only enabled unhealthy cameras as offline issues', () => {
+    // Given: A mixed camera list with disabled and offline cameras
+    const cameras = [
+      makeCamera({ name: 'front' }),
+      makeCamera({ name: 'garage', enabled: false, healthy: false }),
+      makeCamera({ name: 'driveway', enabled: true, healthy: false }),
+    ]
+
+    // When: The compact shell issue summary is computed
+    const offlineCount = countOfflineCameras(cameras)
+    const summary = cameraIssueSummary(cameras)
+
+    // Then: Disabled cameras are not treated as active offline problems
+    expect(offlineCount).toBe(1)
+    expect(summary).toBe('1 camera offline')
+  })
+
+  it('formats last-seen text without adding backend reason codes', () => {
+    // Given: A stable current time and existing last_heartbeat values
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-14T12:10:00.000Z'))
+    const heartbeat = Date.parse('2026-02-14T12:05:00.000Z') / 1000
+
+    // When: Last-seen display text is formatted
+    const seen = formatLastSeen(heartbeat)
+    const unavailable = formatLastSeen(null)
+
+    // Then: The UI shows conservative time/status text only
+    expect(seen).toBe('5 minutes ago')
+    expect(unavailable).toBe('Status unavailable')
+
+  })
+})

--- a/ui/src/features/cameras/cameraHealth.ts
+++ b/ui/src/features/cameras/cameraHealth.ts
@@ -1,0 +1,52 @@
+import type { CameraResponse } from '../../api/generated/types'
+import type { StatusBadgeTone } from '../../components/ui/StatusBadge'
+
+export function cameraHealthLabel(camera: CameraResponse): 'Online' | 'Disabled' | 'Offline' {
+  if (!camera.enabled) {
+    return 'Disabled'
+  }
+  return camera.healthy ? 'Online' : 'Offline'
+}
+
+export function cameraHealthTone(camera: CameraResponse): StatusBadgeTone {
+  if (!camera.enabled) {
+    return 'unknown'
+  }
+  return camera.healthy ? 'healthy' : 'unhealthy'
+}
+
+export function countOfflineCameras(cameras: readonly CameraResponse[] | undefined): number {
+  return cameras?.filter((camera) => camera.enabled && !camera.healthy).length ?? 0
+}
+
+export function cameraIssueSummary(cameras: readonly CameraResponse[] | undefined): string | null {
+  const offlineCount = countOfflineCameras(cameras)
+  if (offlineCount === 0) {
+    return null
+  }
+  return offlineCount === 1 ? '1 camera offline' : `${offlineCount} cameras offline`
+}
+
+export function formatLastSeen(value: number | null, nowMs = Date.now()): string {
+  if (!value) {
+    return 'Status unavailable'
+  }
+
+  const heartbeatMs = value * 1000
+  const elapsedMs = Math.max(0, nowMs - heartbeatMs)
+  const elapsedMinutes = Math.floor(elapsedMs / 60_000)
+
+  if (elapsedMinutes < 1) {
+    return 'just now'
+  }
+  if (elapsedMinutes < 60) {
+    return elapsedMinutes === 1 ? '1 minute ago' : `${elapsedMinutes} minutes ago`
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60)
+  if (elapsedHours < 24) {
+    return elapsedHours === 1 ? '1 hour ago' : `${elapsedHours} hours ago`
+  }
+
+  return new Date(heartbeatMs).toLocaleString()
+}

--- a/ui/src/features/cameras/components/CameraList.tsx
+++ b/ui/src/features/cameras/components/CameraList.tsx
@@ -1,7 +1,11 @@
+import { createSearchParams, Link } from 'react-router-dom'
+
 import type { CameraCreate, CameraResponse } from '../../../api/generated/types'
 import { Button } from '../../../components/ui/Button'
 import { Card } from '../../../components/ui/Card'
 import { StatusBadge } from '../../../components/ui/StatusBadge'
+import { TechnicalDetailsDisclosure } from '../../../components/ui/TechnicalDetailsDisclosure'
+import { cameraHealthLabel, cameraHealthTone, formatLastSeen } from '../cameraHealth'
 import { CameraPreviewPanel } from './CameraPreviewPanel'
 import { CameraSourceConfigEditor } from './CameraSourceConfigEditor'
 
@@ -19,18 +23,8 @@ interface CameraListProps {
   onDelete: (camera: CameraResponse) => void
 }
 
-function cameraHealthTone(camera: CameraResponse): 'healthy' | 'unknown' | 'unhealthy' {
-  if (!camera.enabled) {
-    return 'unknown'
-  }
-  return camera.healthy ? 'healthy' : 'unhealthy'
-}
-
-function formatLastHeartbeat(value: number | null): string {
-  if (!value) {
-    return 'n/a'
-  }
-  return new Date(value * 1000).toLocaleString()
+function cameraEventsSearch(cameraName: string): string {
+  return createSearchParams({ camera: cameraName }).toString()
 }
 
 export function CameraList({
@@ -59,7 +53,7 @@ export function CameraList({
                 <p className="camera-item__name">{camera.name}</p>
                 <div className="camera-item__badges">
                   <StatusBadge tone={cameraHealthTone(camera)}>
-                    {camera.healthy && camera.enabled ? 'HEALTHY' : camera.enabled ? 'UNHEALTHY' : 'DISABLED'}
+                    {cameraHealthLabel(camera)}
                   </StatusBadge>
                   <span className="camera-chip">{camera.source_backend}</span>
                 </div>
@@ -67,12 +61,12 @@ export function CameraList({
 
               <dl className="camera-item__meta">
                 <div className="camera-item__meta-row">
-                  <dt>Enabled</dt>
-                  <dd>{camera.enabled ? 'true' : 'false'}</dd>
+                  <dt>Status</dt>
+                  <dd>{cameraHealthLabel(camera)}</dd>
                 </div>
                 <div className="camera-item__meta-row">
-                  <dt>Last heartbeat</dt>
-                  <dd>{formatLastHeartbeat(camera.last_heartbeat)}</dd>
+                  <dt>Last seen</dt>
+                  <dd>{formatLastSeen(camera.last_heartbeat)}</dd>
                 </div>
               </dl>
 
@@ -80,9 +74,14 @@ export function CameraList({
                 <CameraPreviewPanel cameraName={camera.name} />
               ) : null}
 
-              <pre className="camera-item__config">{JSON.stringify(camera.source_config, null, 2)}</pre>
+              <TechnicalDetailsDisclosure summary="Technical source details">
+                <pre className="camera-item__config">{JSON.stringify(camera.source_config, null, 2)}</pre>
+              </TechnicalDetailsDisclosure>
 
               <div className="inline-form__actions">
+                <Link className="button button--primary" to={`/events?${cameraEventsSearch(camera.name)}`}>
+                  View Events
+                </Link>
                 <CameraSourceConfigEditor
                   camera={camera}
                   isMutating={isMutating}
@@ -91,6 +90,7 @@ export function CameraList({
                   onSubmitPatch={onPatchSourceConfig}
                 />
                 <Button
+                  variant="ghost"
                   onClick={() => {
                     onToggleEnabled(camera)
                   }}
@@ -107,6 +107,9 @@ export function CameraList({
                 >
                   Delete
                 </Button>
+                <Link className="button button--ghost" to="/system">
+                  Open System
+                </Link>
               </div>
             </article>
           ))}

--- a/ui/src/features/cameras/components/CameraPreviewPanel.test.tsx
+++ b/ui/src/features/cameras/components/CameraPreviewPanel.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
+import { APIError } from '../../../api/client'
 import { CameraPreviewPanel } from './CameraPreviewPanel'
 
 const DEFAULT_PLAYLIST_URL =
@@ -692,6 +693,26 @@ describe('CameraPreviewPanel', () => {
       'Microphone blocked. Allow microphone access in your browser and try again.',
     )).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Microphone blocked' }).hasAttribute('disabled')).toBe(true)
+  })
+
+  it('keeps talk API failure details out of the default message', () => {
+    // Given: The existing talk status API reports a backend error
+    const apiError = new APIError(
+      'Unhandled GET /api/v1/talk/cameras/front',
+      404,
+      { detail: 'Unhandled GET /api/v1/talk/cameras/front' },
+      null,
+    )
+    mockReadyPreviewSession()
+    mockIdlePushToTalk({ canStart: false, error: apiError })
+
+    // When: Rendering the preview controls
+    render(<CameraPreviewPanel cameraName="front" />)
+
+    // Then: The default copy stays homeowner-readable and raw details stay technical
+    expect(screen.getByText('Talk status could not load.')).toBeTruthy()
+    expect(screen.queryByText('Unhandled GET /api/v1/talk/cameras/front')).toBeNull()
+    expect(screen.getByText('Technical talk details')).toBeTruthy()
   })
 
 })

--- a/ui/src/features/cameras/components/PushToTalkControl.tsx
+++ b/ui/src/features/cameras/components/PushToTalkControl.tsx
@@ -173,6 +173,9 @@ function userMessage({
     if (isAPIError(error) && error.errorCode === 'TALK_SESSION_ALREADY_ACTIVE') {
       return 'Another talk session is already active.'
     }
+    if (isAPIError(error)) {
+      return 'Talk status could not load.'
+    }
     return describeUnknownError(error)
   }
   if (isPending) {

--- a/ui/src/features/live/LiveCameraCard.tsx
+++ b/ui/src/features/live/LiveCameraCard.tsx
@@ -4,36 +4,16 @@ import type { CameraResponse } from '../../api/generated/types'
 import { Button } from '../../components/ui/Button'
 import { CameraCard } from '../../components/ui/CameraCard'
 import { MediaPanel } from '../../components/ui/MediaPanel'
-import { StatusBadge, type StatusBadgeTone } from '../../components/ui/StatusBadge'
+import { StatusBadge } from '../../components/ui/StatusBadge'
 import { TechnicalDetailsDisclosure } from '../../components/ui/TechnicalDetailsDisclosure'
 import { CameraPreviewPanel } from '../cameras/components/CameraPreviewPanel'
+import { cameraHealthLabel, cameraHealthTone, formatLastSeen } from '../cameras/cameraHealth'
 
 interface LiveCameraCardProps {
   camera: CameraResponse
   isCompactViewport?: boolean
   isFocused?: boolean
   onFocusCamera?: (cameraName: string) => void
-}
-
-function cameraStatusTone(camera: CameraResponse): StatusBadgeTone {
-  if (!camera.enabled) {
-    return 'unknown'
-  }
-  return camera.healthy ? 'healthy' : 'unhealthy'
-}
-
-function cameraStatusLabel(camera: CameraResponse): string {
-  if (!camera.enabled) {
-    return 'Disabled'
-  }
-  return camera.healthy ? 'Online' : 'Offline'
-}
-
-function formatLastSeen(value: number | null): string {
-  if (!value) {
-    return 'Status unavailable'
-  }
-  return new Date(value * 1000).toLocaleString()
 }
 
 function eventsSearch(cameraName: string): string {
@@ -99,8 +79,8 @@ export function LiveCameraCard(props: LiveCameraCardProps) {
     <CameraCard
       title={camera.name}
       status={
-        <StatusBadge tone={cameraStatusTone(camera)}>
-          {cameraStatusLabel(camera)}
+        <StatusBadge tone={cameraHealthTone(camera)}>
+          {cameraHealthLabel(camera)}
         </StatusBadge>
       }
       media={renderPreview(props)}

--- a/ui/src/features/settings/SettingsPage.test.tsx
+++ b/ui/src/features/settings/SettingsPage.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { SettingsPage } from './SettingsPage'
+
+function renderSettingsPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/settings']}>
+      <SettingsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SettingsPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('separates homeowner settings from advanced system diagnostics', () => {
+    // Given: The homeowner opens Settings from the mobile or desktop nav
+    renderSettingsPage()
+
+    // When: The settings cards render
+    const settings = screen.getByRole('heading', { name: 'Settings' })
+    const advancedCard = screen.getByRole('heading', { name: 'Advanced' }).closest('.card')
+
+    // Then: User-facing configuration is visible and System is nested under Advanced
+    expect(settings).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Cameras' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Notifications' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Detection' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Storage' })).toBeTruthy()
+    expect(
+      advancedCard
+        ? within(advancedCard as HTMLElement).getByRole('link', { name: 'Open System' }).getAttribute('href')
+        : null,
+    ).toBe('/system')
+  })
+})

--- a/ui/src/features/settings/SettingsPage.tsx
+++ b/ui/src/features/settings/SettingsPage.tsx
@@ -2,48 +2,75 @@ import { Link } from 'react-router-dom'
 
 import { Card } from '../../components/ui/Card'
 
+const SETTINGS_SECTIONS = [
+  {
+    title: 'Cameras',
+    subtitle: 'Camera setup and controls',
+    description: 'Add cameras, enable or disable existing cameras, and open camera controls.',
+    to: '/cameras',
+    action: 'Manage cameras',
+    primary: true,
+  },
+  {
+    title: 'Notifications',
+    subtitle: 'Alert destinations',
+    description: 'Update where HomeSec sends alerts using the existing guided setup flow.',
+    to: '/setup',
+    action: 'Update notifications',
+    primary: false,
+  },
+  {
+    title: 'Detection',
+    subtitle: 'What HomeSec watches for',
+    description: 'Adjust object detection, AI summaries, and alert sensitivity in guided setup.',
+    to: '/setup',
+    action: 'Update detection',
+    primary: false,
+  },
+  {
+    title: 'Storage',
+    subtitle: 'Where event video is saved',
+    description: 'Choose or revise clip storage settings without entering system diagnostics.',
+    to: '/setup',
+    action: 'Update storage',
+    primary: false,
+  },
+  {
+    title: 'Advanced',
+    subtitle: 'System status and diagnostics',
+    description: 'Runtime health, database backups, reload controls, and diagnostics live in System.',
+    to: '/system',
+    action: 'Open System',
+    primary: false,
+  },
+] as const
+
 export function SettingsPage() {
   return (
     <section className="page fade-in-up">
       <header className="page__header">
         <div>
           <h1 className="page__title">Settings</h1>
-          <p className="page__lead">Configure cameras, storage, detection, and notifications.</p>
+          <p className="page__lead">
+            Manage homeowner-facing configuration first. System details stay under Advanced.
+          </p>
         </div>
       </header>
 
       <div className="settings-grid">
-        <Card title="Setup wizard" subtitle="Homeowner configuration">
-          <p className="muted">
-            Update camera setup, storage, detection, and notification choices with the existing
-            guided flow.
-          </p>
-          <div className="inline-form__actions">
-            <Link className="button button--primary" to="/setup">
-              Open setup wizard
-            </Link>
-          </div>
-        </Card>
-
-        <Card title="Cameras" subtitle="Camera definitions">
-          <p className="muted">Manage existing cameras and preview controls.</p>
-          <div className="inline-form__actions">
-            <Link className="button button--ghost" to="/cameras">
-              Open Cameras
-            </Link>
-          </div>
-        </Card>
-
-        <Card title="Advanced" subtitle="System status and diagnostics">
-          <p className="muted">
-            Runtime health, database backups, and diagnostic details are available in System.
-          </p>
-          <div className="inline-form__actions">
-            <Link className="button button--ghost" to="/system">
-              Open System
-            </Link>
-          </div>
-        </Card>
+        {SETTINGS_SECTIONS.map((section) => (
+          <Card key={section.title} title={section.title} subtitle={section.subtitle}>
+            <p className="muted">{section.description}</p>
+            <div className="inline-form__actions">
+              <Link
+                className={section.primary ? 'button button--primary' : 'button button--ghost'}
+                to={section.to}
+              >
+                {section.action}
+              </Link>
+            </div>
+          </Card>
+        ))}
       </div>
     </section>
   )

--- a/ui/src/routes/AppRouter.test.tsx
+++ b/ui/src/routes/AppRouter.test.tsx
@@ -8,9 +8,14 @@ import { ThemeProvider } from '../app/providers/ThemeProvider'
 import { AppRouter } from './AppRouter'
 
 const useHealthQueryMock = vi.fn()
+const useCamerasQueryMock = vi.fn()
 
 vi.mock('../api/hooks/useHealthQuery', () => ({
   useHealthQuery: () => useHealthQueryMock(),
+}))
+
+vi.mock('../api/hooks/useCamerasQuery', () => ({
+  useCamerasQuery: () => useCamerasQueryMock(),
 }))
 
 vi.mock('../features/live/LivePage', () => ({
@@ -51,6 +56,10 @@ function renderRouter(initialPath: string) {
     data: { status: 'healthy' },
     isError: false,
   })
+  useCamerasQueryMock.mockReturnValue({
+    data: [],
+    isError: false,
+  })
 
   render(
     <ThemeProvider>
@@ -66,6 +75,7 @@ describe('AppRouter route cleanup', () => {
   afterEach(() => {
     cleanup()
     useHealthQueryMock.mockReset()
+    useCamerasQueryMock.mockReset()
   })
 
   it('redirects the root route to Live', async () => {


### PR DESCRIPTION
## Tickets
- Settings/System split: https://www.notion.so/35ad8336c59f81199ba0f8bb28d0f955
- Basic camera health: https://www.notion.so/35ad8336c59f81d3aa1ef147f741bb94

## Scope
- Splits Settings into homeowner-facing configuration categories: Cameras, Notifications, Detection, Storage, and Advanced.
- Keeps System reachable from Settings / Advanced and keeps desktop System nav unchanged from the stack.
- Adds shared camera health presentation helpers using existing `enabled`, `healthy`, and `last_heartbeat` fields only.
- Updates Live and Cameras cards to use Online, Disabled, Offline, Last seen, and Status unavailable labels.
- Adds a compact app-shell camera issue indicator such as `1 camera offline` using the existing camera list API.
- Adds simple camera-card actions before diagnostics: View Events, edit camera/source config, enable/disable, delete, and Open System.
- Keeps raw source config under technical details by default.
- Keeps talk API failure text homeowner-readable by default while retaining technical details under disclosure.

## Stack
- Stacked on https://github.com/lan17/homesec/pull/102.
- Depends on the mobile shell behavior and mobile bottom-nav treatment from the previous PR.

## UI Notes
- Mobile Settings keeps System nested under Advanced unless a non-nominal app-shell status is visible.
- Disabled cameras are not counted as offline problems; enabled unhealthy cameras are shown as offline.
- No enriched health reasons are invented when existing data is insufficient.

## Self-Review Notes
- Rechecked that camera health only derives from existing camera fields and does not introduce backend health reason codes.
- Kept System as the diagnostics destination and Settings focused on homeowner-facing configuration.
- Verified raw source config and talk backend details remain behind technical disclosure/default-safe copy.

## Checks
- `pnpm --dir ui exec vitest run src/features/cameras/components/CameraPreviewPanel.test.tsx src/features/cameras/cameraHealth.test.ts src/features/cameras/CamerasPage.test.tsx src/app/layout/AppShell.test.tsx src/features/settings/SettingsPage.test.tsx src/routes/AppRouter.test.tsx`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui lint`
- `make ui-check`
- GitHub CI passed.
- Built app mobile smoke with mocked existing APIs for offline camera shell indicator, Settings -> Advanced -> System, Cameras health labels, last-seen/status-unavailable text, hidden raw source config, and no raw talk API text.

## Backend Scope
- No backend routes, schema changes, persistence changes, new camera health fields, new reason codes, notification behavior, review state, or new media APIs were added.